### PR TITLE
Get seeding from projection instead of as input to fnct

### DIFF
--- a/TestBenches/MatchCalculator_test.cpp
+++ b/TestBenches/MatchCalculator_test.cpp
@@ -22,19 +22,37 @@ int main()
 	HLSCandidateMatch inPHI4[nevents][MAX_nCM];   // input CM
     HLSAllStubs       inStub[nevents][MAX_nSTUB]; // input stubs
     HLSProjection     inProj[nevents][MAX_nPROJ]; // input projections
-    HLSFullMatch      outMatch[nevents][MAX_nFM]; // output FMs
-    ap_uint<7>        nMatches[nevents];          // output num of FMs (7b allow for up to 64)
+    HLSFullMatch      outMatch0[nevents][MAX_nFM]; // output FMs
+    HLSFullMatch      outMatch1[nevents][MAX_nFM]; // output FMs
+    HLSFullMatch      outMatch2[nevents][MAX_nFM]; // output FMs
+    HLSFullMatch      outMatch3[nevents][MAX_nFM]; // output FMs
+    HLSFullMatch      outMatch4[nevents][MAX_nFM]; // output FMs
+    HLSFullMatch      outMatch5[nevents][MAX_nFM]; // output FMs
+    HLSFullMatch      outMatch6[nevents][MAX_nFM]; // output FMs
+    ap_uint<7>        nMatches0[nevents];          // output num of FMs (7b allow for up to 64)
+    ap_uint<7>        nMatches1[nevents];          // output num of FMs (7b allow for up to 64)
+    ap_uint<7>        nMatches2[nevents];          // output num of FMs (7b allow for up to 64)
+    ap_uint<7>        nMatches3[nevents];          // output num of FMs (7b allow for up to 64)
+    ap_uint<7>        nMatches4[nevents];          // output num of FMs (7b allow for up to 64)
+    ap_uint<7>        nMatches5[nevents];          // output num of FMs (7b allow for up to 64)
+    ap_uint<7>        nMatches6[nevents];          // output num of FMs (7b allow for up to 64)
 
 
     // initialize
 	for (int i = 0; i < nevents; i++){
-		for (int j = 0; j < MAX_nCM;   j++) inPHI1[i][j]   = HLSCandidateMatch();
-		for (int j = 0; j < MAX_nCM;   j++) inPHI2[i][j]   = HLSCandidateMatch();
-		for (int j = 0; j < MAX_nCM;   j++) inPHI3[i][j]   = HLSCandidateMatch();
-		for (int j = 0; j < MAX_nCM;   j++) inPHI4[i][j]   = HLSCandidateMatch();
-		for (int j = 0; j < MAX_nSTUB; j++) inStub[i][j]   = HLSAllStubs();
-		for (int j = 0; j < MAX_nPROJ; j++) inProj[i][j]   = HLSProjection();
-		for (int j = 0; j < MAX_nFM;   j++) outMatch[i][j] = HLSFullMatch();
+		for (int j = 0; j < MAX_nCM;   j++) inPHI1[i][j]    = HLSCandidateMatch();
+		for (int j = 0; j < MAX_nCM;   j++) inPHI2[i][j]    = HLSCandidateMatch();
+		for (int j = 0; j < MAX_nCM;   j++) inPHI3[i][j]    = HLSCandidateMatch();
+		for (int j = 0; j < MAX_nCM;   j++) inPHI4[i][j]    = HLSCandidateMatch();
+		for (int j = 0; j < MAX_nSTUB; j++) inStub[i][j]    = HLSAllStubs();
+		for (int j = 0; j < MAX_nPROJ; j++) inProj[i][j]    = HLSProjection();
+		for (int j = 0; j < MAX_nFM;   j++) outMatch0[i][j] = HLSFullMatch();
+		for (int j = 0; j < MAX_nFM;   j++) outMatch1[i][j] = HLSFullMatch();
+		for (int j = 0; j < MAX_nFM;   j++) outMatch2[i][j] = HLSFullMatch();
+		for (int j = 0; j < MAX_nFM;   j++) outMatch3[i][j] = HLSFullMatch();
+		for (int j = 0; j < MAX_nFM;   j++) outMatch4[i][j] = HLSFullMatch();
+		for (int j = 0; j < MAX_nFM;   j++) outMatch5[i][j] = HLSFullMatch();
+		for (int j = 0; j < MAX_nFM;   j++) outMatch6[i][j] = HLSFullMatch();
 	}
 
 	CM_proj_index in_p_index;
@@ -42,7 +60,11 @@ int main()
 
 
 	// counter for which CM in the event is being read in
-	ap_uint<7> cur_CM = 0;
+	ap_uint<7> cur_CM[10];
+    for (int i = 0; i < 10; i++)
+    {
+    	cur_CM[i] = 0;
+    }
 
 	// read in files
 	ifstream fin_CM;
@@ -56,7 +78,7 @@ int main()
     }
     while (getline(fin_CM,token)){
 
-        if (cur_CM < MAX_nCM){
+        if (cur_CM[0] < MAX_nCM){
             // read in lines
 			std::cout << "Reading in file" << std::endl;
 
@@ -70,7 +92,7 @@ int main()
 			in_s_index = CM_stub_index(str_s_index.c_str(),2);
 
 			// make the CM
-			inPHI1[0][cur_CM].AddCM(in_p_index,in_s_index);
+			inPHI1[0][cur_CM[0]].AddCM(in_p_index,in_s_index);
 
         }
         else{ // cur_CM >= MAX_nCM
@@ -79,20 +101,22 @@ int main()
         }
 
         //increment counter of CMs
-        cur_CM++;
+        cur_CM[0]++;
     }
     fin_CM.close();
 
     // hack to get a stub and projection in more quickly
     ap_uint<nBITS_STUB> stub  = 0xA81E3ACE0UL;
-    ap_uint<nBITS_PROJ> proj1 = 0xA06B7E1F807010UL;
-    ap_uint<nBITS_PROJ> proj2 = 0x2A06B781F006C0EUL;
-    ap_uint<nBITS_PROJ> proj3 = 0x2A0EB6E1080701AUL;
-    ap_uint<7> num2 = 1;
-    ap_uint<7> num3 = 0;
-    ap_uint<7> num4 = 0;
+    ap_uint<nBITS_PROJ> proj1 = 0x0A06B7E1F807010UL;  // FIXME: old format of projections
+    ap_uint<nBITS_PROJ> proj2 = 0x2A06B781F006C0EUL;  // FIXME: old format of projections
+    ap_uint<nBITS_PROJ> proj3 = 0x2A0EB6E1080701AUL;  // FIXME: old format of projections
+    ap_uint<7> num2[10];
+    ap_uint<7> num3[10];
+    ap_uint<7> num4[10];
+    num2[0] = 0; // FIXME: switch this to 1 if you want to test merger (dumby inPHI2 = 0 will be read)
+    num3[0] = 0;
+    num4[0] = 0;
 
-    inPHI2[0][0].AddCM(0,0);
     inStub[0][0].AddStub(stub);
 	inProj[0][0].AddProj(proj1);
 	inProj[0][1].AddProj(proj2);
@@ -101,19 +125,22 @@ int main()
 	// loop over events
 	for (int i = 0; i < nevents; i++){
 		// run the MatchCalculator
-		// MatchCalculator (SEED, LAYER, CM1, CM2, CM3, CM4, nCM1, nCM2, nCM3, nCM4, AS, PROJ, FM out, nFM out)
-		MatchCalculator( 0, 2,
+		// MatchCalculator (LAYER, CM1, CM2, CM3, CM4, nCM1, nCM2, nCM3, nCM4, AS, PROJ, FM out, nFM out)
+		MatchCalculator(2,
 				        inPHI1[i], inPHI2[i], inPHI3[i], inPHI4[i],
-				        cur_CM, num2, num3, num4,
-						inStub[i], inProj[i] , outMatch[i], nMatches[i]
+				        cur_CM[i], num2[i], num3[i], num4[i], inStub[i], inProj[i] ,
+						outMatch0[i], outMatch1[i], outMatch2[i], outMatch3[i], outMatch4[i], outMatch5[i], outMatch6[i],
+						nMatches0[i], nMatches1[i], nMatches2[i], nMatches3[i], nMatches4[i], nMatches5[i], nMatches6[i]
 					   );
 	}
+
 
 	// setup hw and sw outputs for comparison
 	ap_uint<nBITS_FM> hw_result[nevents][MAX_nFM];
 	for (int i = 0; i < nevents; i++){
-		for (int j = 0; j < nMatches[i]; j++){
-			hw_result[i][j] = outMatch[i][j].raw();
+		for (int j = 0; j < nMatches0[i]; j++){  // NOTE! : Only comparing L1L2 seeding matches
+			hw_result[i][j] = outMatch0[i][j].raw();
+			std::cout << "HW result : " << hw_result[i][j] << std::endl;
 		}
 	}
 
@@ -121,6 +148,7 @@ int main()
 	ap_uint<nBITS_FM> sw_result[nevents][MAX_nFM];
 	sw_result[0][0] = 16384;
 	sw_result[0][1] = 1073766403;
+	ap_uint<7> nFoundMatches = 2;
 
 	// check output between hw and sw
 	int err_cnt = 0;
@@ -128,13 +156,16 @@ int main()
 	fp = fopen("results.dat","w");
 	printf("Testing DUT results");
 	for (int i = 0; i < nevents; i++){
-		for (int j = 0; j < nMatches[i]; j++){
+		for (int j = 0; j < nFoundMatches; j++){
 			// FIXME: can't print ap_ints directly. is there a better way to do the comparison w/o using to_long?
 			fprintf(fp,"%d %d \n",hw_result[i][j].to_long(),sw_result[i][j].to_long());
 			if (hw_result[i][j] != sw_result[i][j]){
 				err_cnt++; // increase error counter if they don't match
-				printf("\n!!! ERROR at Event %d and FM %d -- expected %d , observed %d !!!\n",
+				printf("\n!!! ERROR at Event %d and FM %d -- expected %d , observed %d !!!",
 						i, j, sw_result[i][j].to_long(), hw_result[i][j].to_long());
+			}
+			else{
+				printf("\nEvent %d and FM %d : Expected %d, Observed %d",i,j,sw_result[i][j].to_long(),hw_result[i][j].to_long());
 			}
 		}
 	}

--- a/TrackletAlgorithm/HLSAllStubs.hh
+++ b/TrackletAlgorithm/HLSAllStubs.hh
@@ -28,11 +28,7 @@ class HLSAllStubs
 {
 private: 
 	AllStub		data_;
-	AS_r		stub_r;
-	AS_z		stub_z;
-	AS_phi		stub_phi;
-	AS_bend		stub_bend;
-	
+
 public:
 	// constructors
 	HLSAllStubs(AllStub newdata):
@@ -42,10 +38,6 @@ public:
 	HLSAllStubs():
 		data_(0)
 	{
-		stub_r    = 0;
-		stub_z    = 0;
-		stub_phi  = 0;
-		stub_bend = 0;
 	}
 	HLSAllStubs(const AS_r   new_stub_r,   const AS_z    new_stub_z,
 			    const AS_phi new_stub_phi, const AS_bend new_stub_bend)
@@ -63,23 +55,23 @@ public:
 	// return values
 	AS_r GetR() const
 	{
-		AS_r r = ((data_ >> (nBITS_Z+nBITS_PHI+nBITS_BEND)) & 0x7FUL);//((1<<nBITS_R-1)-1));
+		AS_r r = data_.range(35,29);
 		return r;
 	}
 	AS_z GetZ() const
 	{
-		AS_z z = ((data_ >> (nBITS_PHI+nBITS_BEND)) & 0xFFFUL); //((1<<nBITS_Z-1)-1));
+		AS_z z = data_.range(28,17);
 		return z;
 
 	}
 	AS_phi GetPhi() const
 	{
-		AS_phi phi = ((data_ >> nBITS_BEND) & 0x3FFFUL);//((1<<nBITS_PHI)-1));
+		AS_phi phi = data_.range(16,3);
 		return phi;
 	}
 	AS_bend GetBend() const
 	{
-		AS_bend bend = (data_ & 0x7UL); //(data_ & ((1 << nBITS_BEND)-1));
+		AS_bend bend = data_.range(2,0);
 		return bend;
 	}
 
@@ -91,18 +83,9 @@ public:
 	void AddStub(const AS_r   new_stub_r,   const AS_z    new_stub_z,
 				 const AS_phi new_stub_phi, const AS_bend new_stub_bend)
 	{
-		stub_r    = new_stub_r;
-		stub_z    = new_stub_z;
-		stub_phi  = new_stub_phi;
-		stub_bend = new_stub_bend;
 		// setup full stub data by concatenating variables above
 		// data_ = {r, z, phi, bend}
-		// need "to_long" for shifts otherwise data will truncate at current size
-		data_     = (((new_stub_r.to_long()  << (nBITS_Z + nBITS_PHI + nBITS_BEND -1)) |
-					 (new_stub_z.to_long()   << (nBITS_PHI + nBITS_BEND -1)) |
-					 (new_stub_phi.to_long() << (nBITS_BEND -1)) |
-					 (new_stub_bend))
-					 & ((1<<nBITS_STUB)-1));  // protect to keep length at nBITS_STUB
+		data_  = (((new_stub_r,new_stub_z),new_stub_phi),new_stub_bend);
 	}
 
 };

--- a/TrackletAlgorithm/HLSFullMatch.hh
+++ b/TrackletAlgorithm/HLSFullMatch.hh
@@ -21,11 +21,6 @@ class HLSFullMatch
 {
 private:
 	FullMatch 		data_;
-	FM_PROJ_INDEX	p_index;
-	FM_STUB_INDEX	s_index;
-	FM_PHI			FM_phi;
-	FM_Z			FM_z;
-
 public:
 	// constructors
 	HLSFullMatch(FullMatch newdata):
@@ -49,20 +44,9 @@ public:
 	void AddFM(const FM_PROJ_INDEX newpindex, const FM_STUB_INDEX newsindex,
 			   const FM_PHI        newphi,    const FM_Z newz)
 	{
-		p_index = newpindex;
-		s_index = newsindex;
-		FM_phi  = newphi;
-		FM_z    = newz;
-		std::cout << " FM : " << newphi << " " << newz <<  " " << std::endl;
-
 		// setup full stub data by concatenating variables above
 		// data_ = {proj index, stub index, phi residual, z residual}
-		// need "to_long" for shifts otherwise data will truncate at current size
-		data_   = (((newpindex.to_long() << (nBITS_FM_SID + nBITS_FM_PHI + nBITS_FM_Z) ) |
-				  (newsindex.to_long()   << (nBITS_FM_PHI + nBITS_FM_Z) ) |
-				  (newphi.to_long()      << (nBITS_FM_Z) ) |
-				  (newz))
-				  & ((1<<nBITS_FM)-1)); // protect to keep length at nBITS_FM
+		data_   = (((newpindex,newsindex),newphi),newz);
 	}
 
 	// other functions
@@ -73,22 +57,22 @@ public:
 
 	FM_PROJ_INDEX GetPIndex() const
 	{
-		FM_PROJ_INDEX pid = ((data_ >> (nBITS_FM_SID+nBITS_FM_PHI+nBITS_FM_Z)) & 0x3FFUL);
+		FM_PROJ_INDEX pid = data_.range(39,30);
 		return pid;
 	}
 	FM_STUB_INDEX GetSIndex() const
 	{
-		FM_STUB_INDEX sid = ((data_ >> (nBITS_FM_PHI+nBITS_FM_Z)) & 0x1FFUL);
+		FM_STUB_INDEX sid = data_.range(29,21);
 		return sid;
 	}
 	FM_PHI GetPhi() const
 	{
-		FM_PHI phi = ((data_ >> (nBITS_FM_Z)) & 0xFFFUL);
+		FM_PHI phi = data_.range(20,9);
 		return phi;
 	}
 	FM_Z GetZ() const
 	{
-		FM_Z z = (data_ & 0x1FFUL);
+		FM_Z z = data_.range(8,0);
 		return z;
 	}
 

--- a/TrackletAlgorithm/HLSProjection.hh
+++ b/TrackletAlgorithm/HLSProjection.hh
@@ -3,15 +3,32 @@
 #pragma once
 #include "ap_int.h"
 
-const int MAX_nPROJ = 5;
-const int nBITS_PROJ = 56;
+const int MAX_nPROJ = 36;
+const int nBITS_PROJ = 60;
 
-const int nBITS_PROJ_TCID = 6;  // bits for tracket ID
-const int nBITS_PROJ_NUM  = 6;  // bits for tracklet number
+// THESE ARE OLD DEFINITIONS OF TRACKLET PROJECTION
+// bit size will change in new version but consistent with the input data at the time
+// (ie. that of the current test bench)
+
+const int nBITS_PROJ_TCID = 6;  // bits for tracket ID           -- think this should be 7 bits in new proj format
+const int nBITS_PROJ_NUM  = 7;  // bits for tracklet number
 const int nBITS_PROJ_PHI  = 14; // bits for phi
 const int nBITS_PROJ_Z    = 12; // bits for z
-const int nBITS_PROJ_PHID = 11; // bits for phi derivative
+const int nBITS_PROJ_PHID = 11; // bits for phi derivative       -- think this should be 10 bits in new proj format
 const int nBITS_PROJ_ZD   = 10; // bits for z derivative
+
+const int kLSB_PROJ_ZD   = 0;
+const int kMSB_PROJ_ZD   = nBITS_PROJ_ZD-1;
+const int kLSB_PROJ_PHID = kMSB_PROJ_ZD+1;
+const int kMSB_PROJ_PHID = kLSB_PROJ_PHID+nBITS_PROJ_PHID-1;
+const int kLSB_PROJ_Z    = kMSB_PROJ_PHID+1;
+const int kMSB_PROJ_Z    = kLSB_PROJ_Z+nBITS_PROJ_Z-1;
+const int kLSB_PROJ_PHI  = kMSB_PROJ_Z+1;
+const int kMSB_PROJ_PHI  = kLSB_PROJ_PHI+nBITS_PROJ_PHI-1;
+const int kLSB_PROJ_NUM  = kMSB_PROJ_PHI+1;
+const int kMSB_PROJ_NUM  = kLSB_PROJ_NUM+nBITS_PROJ_NUM-1;
+const int kLSB_PROJ_TCID = kMSB_PROJ_NUM+1;
+const int kMSB_PROJ_TCID = kLSB_PROJ_TCID+nBITS_PROJ_TCID-1;
 
 // defintion of raw projection
 typedef ap_uint<nBITS_PROJ> Projection;
@@ -28,12 +45,6 @@ class HLSProjection
 {
 private:
 	Projection data_;
-	PROJ_TCID  tcid;
-	PROJ_TCNUM tcnum;
-	PROJ_PHI   proj_phi;
-	PROJ_Z     proj_z;
-	PROJ_PHID  proj_phid;
-	PROJ_ZD    proj_zd;
 
 public:
 	// constructors
@@ -45,40 +56,22 @@ public:
 		data_(0)
 	{
 	}
-	
-	// other functions
-
-	// build up projection
-	void AddProj(const Projection newproj)
+	HLSProjection(PROJ_TCID id, PROJ_TCNUM num, PROJ_PHI phi, PROJ_Z z, PROJ_PHID phid, PROJ_ZD zd)
 	{
-		data_ = newproj;
-	}
-	
-	// return raw values
-	Projection raw() const
-	{
-		return data_;
+		data_ = (((((id,num),phi),z),phid),zd);
 	}
 
-	PROJ_PHI GetPhi() const
-	{
-		PROJ_PHI phi = ((data_ >> (nBITS_PROJ_ZD+nBITS_PROJ_PHID+nBITS_PROJ_Z)) & 0x3FFFUL);
-		return phi;
-	}
-	PROJ_Z GetZ() const
-	{
-		PROJ_Z z = ((data_ >> (nBITS_PROJ_ZD+nBITS_PROJ_PHID)) & 0xFFFUL);
-		return z;
-	}
-	PROJ_PHID GetPhiDeriv() const
-	{
-		PROJ_PHID phid = ((data_ >> (nBITS_PROJ_ZD)) & 0x7FFUL);
-		return phid;
-	}
-	PROJ_ZD GetZDeriv() const
-	{
-		PROJ_ZD zd = (data_ & 0x3FFUL);
-		return zd;
-	}
+	// Getters
+	Projection raw() const { return data_; }
+	PROJ_TCID  GetTCID() const { return data_.range(kMSB_PROJ_TCID,kLSB_PROJ_TCID); }
+	PROJ_TCNUM GetIndex() const { return data_.range(kMSB_PROJ_NUM,kLSB_PROJ_NUM); }
+	PROJ_PHI   GetPhi() const { return data_.range(kMSB_PROJ_PHI,kLSB_PROJ_PHI); }
+	PROJ_Z     GetZ() const { return data_.range(kMSB_PROJ_Z,kLSB_PROJ_Z); }
+	PROJ_PHID  GetPhiDeriv() const { return data_.range(kMSB_PROJ_PHID,kLSB_PROJ_PHID); }
+	PROJ_ZD    GetZDeriv() const { return data_.range(kMSB_PROJ_ZD,kLSB_PROJ_ZD); }
+
+	// Setters
+	Projection AddProj(Projection newdata){ data_ = newdata; }
+
 
 };

--- a/TrackletAlgorithm/MatchCalculator.hh
+++ b/TrackletAlgorithm/MatchCalculator.hh
@@ -36,10 +36,15 @@ const int phi_corr_shift_L456   = phi_corr_shift_L123 - (10-bits_r_L456);
 const int z_corr_shift_L456     = -1-shift_2S_zd + (bits_proj_z_L123 - bits_proj_z_L456 + bits_r_L456 - bits_r_L123);
 
 // doubles needed to make the MC cuts
-const double zlength		   	= 120;
+const double zlength		   	= 120.0;
 const double kphi1            	= 2*3.14/((0.75*27)*(1<<bits_stub_phi_L456));
 const double kz               	= 2*zlength/(1<<bits_z_L123);
 const double rmean[6]         	= {25.1493,37.468,52.5977,68.7737,86.0591,110.844};
+const double kphiproj123        = 0.0000626264;
+const double rmaxdisk           = 120.0;
+const int    nrbitsdisk         = 12;
+const double kr                 = rmaxdisk/(1<<nrbitsdisk);
+const double krprojshiftdisk    = 0.0585938;
 
 // phi cuts for each seeding and layer
 const int cut_p_L3L4_L1 = 0.07/(kphi1*rmean[0]);
@@ -77,31 +82,142 @@ const int cut_z_L3L4_L5 =  8.0/kz;
 const int cut_z_L1L2_L6 =  4.0/kz;
 const int cut_z_L3L4_L6 =  9.5/kz;
 
+// phi cuts for each seeding and disk (also split PS/2S)
+// PS
+const int cut_p_L1L2_D1_PS = 0.20/(kphiproj123*kr);
+const int cut_p_D3D4_D1_PS = 0.10/(kphiproj123*kr);
+const int cut_p_L1L2_D2_PS = 0.20/(kphiproj123*kr);
+const int cut_p_D3D4_D2_PS = 0.10/(kphiproj123*kr);
+const int cut_p_L1D1_D2_PS = 0.10/(kphiproj123*kr);
+const int cut_p_L2D1_D2_PS = 0.10/(kphiproj123*kr);
+const int cut_p_L1L2_D3_PS = 0.25/(kphiproj123*kr);
+const int cut_p_D1D2_D3_PS = 0.15/(kphiproj123*kr);
+const int cut_p_L1D1_D3_PS = 0.20/(kphiproj123*kr);
+const int cut_p_L2D1_D3_PS = 0.15/(kphiproj123*kr);
+const int cut_p_L1L2_D4_PS = 0.50/(kphiproj123*kr);
+const int cut_p_D1D2_D4_PS = 0.20/(kphiproj123*kr);
+const int cut_p_L1D1_D4_PS = 0.30/(kphiproj123*kr);
+const int cut_p_L2D1_D4_PS = 0.50/(kphiproj123*kr);
+const int cut_p_D1D2_D5_PS = 0.25/(kphiproj123*kr);
+const int cut_p_D3D4_D5_PS = 0.10/(kphiproj123*kr);
+const int cut_p_L1D1_D5_PS = 0.50/(kphiproj123*kr);
+
+// 2S
+const int cut_p_L1L2_D1_2S = 0.50/(kphiproj123*kr);
+const int cut_p_L3L4_D1_2S = 0.80/(kphiproj123*kr);
+const int cut_p_L1L2_D2_2S = 0.50/(kphiproj123*kr);
+const int cut_p_L3L4_D2_2S = 0.80/(kphiproj123*kr);
+const int cut_p_L1D1_D2_2S = 0.50/(kphiproj123*kr);
+const int cut_p_L2D1_D2_2S = 0.15/(kphiproj123*kr);
+const int cut_p_L1L2_D3_2S = 0.50/(kphiproj123*kr);
+const int cut_p_D1D2_D3_2S = 0.15/(kphiproj123*kr);
+const int cut_p_L1D1_D3_2S = 0.20/(kphiproj123*kr);
+const int cut_p_L2D1_D3_2S = 0.25/(kphiproj123*kr);
+const int cut_p_L1L2_D4_2S = 0.50/(kphiproj123*kr);
+const int cut_p_D1D2_D4_2S = 0.20/(kphiproj123*kr);
+const int cut_p_L1D1_D4_2S = 0.25/(kphiproj123*kr);
+const int cut_p_L2D1_D4_2S = 0.50/(kphiproj123*kr);
+const int cut_p_D1D2_D5_2S = 0.40/(kphiproj123*kr);
+const int cut_p_D3D4_D5_2S = 0.20/(kphiproj123*kr);
+const int cut_p_L1D1_D5_2S = 0.40/(kphiproj123*kr);
+
+// r cuts for each seeding and disk (also split PS/2S)
+// PS
+const int cut_r_L1L2_D1_PS = 0.5/krprojshiftdisk;
+const int cut_r_D3D4_D1_PS = 0.5/krprojshiftdisk;
+const int cut_r_L1L2_D2_PS = 0.5/krprojshiftdisk;
+const int cut_r_D3D4_D2_PS = 0.5/krprojshiftdisk;
+const int cut_r_L1D1_D2_PS = 0.5/krprojshiftdisk;
+const int cut_r_L2D1_D2_PS = 0.5/krprojshiftdisk;
+const int cut_r_L1L2_D3_PS = 0.5/krprojshiftdisk;
+const int cut_r_D1D2_D3_PS = 0.5/krprojshiftdisk;
+const int cut_r_L1D1_D3_PS = 0.6/krprojshiftdisk;
+const int cut_r_L2D1_D3_PS = 0.8/krprojshiftdisk;
+const int cut_r_L1L2_D4_PS = 0.5/krprojshiftdisk;
+const int cut_r_D1D2_D4_PS = 0.8/krprojshiftdisk;
+const int cut_r_L1D1_D4_PS = 1.0/krprojshiftdisk;
+const int cut_r_L2D1_D4_PS = 1.0/krprojshiftdisk;
+const int cut_r_D1D2_D5_PS = 1.0/krprojshiftdisk;
+const int cut_r_D3D4_D5_PS = 0.5/krprojshiftdisk;
+const int cut_r_L1D1_D5_PS = 2.0/krprojshiftdisk;
+
+// 2S
+const int cut_r_L1L2_D1_2S = 3.8/krprojshiftdisk;
+const int cut_r_L3L4_D1_2S = 3.8/krprojshiftdisk;
+const int cut_r_L1L2_D2_2S = 3.8/krprojshiftdisk;
+const int cut_r_L3L4_D2_2S = 3.8/krprojshiftdisk;
+const int cut_r_L1D1_D2_2S = 3.8/krprojshiftdisk;
+const int cut_r_L2D1_D2_2S = 3.4/krprojshiftdisk;
+const int cut_r_L1L2_D3_2S = 3.6/krprojshiftdisk;
+const int cut_r_D1D2_D3_2S = 3.6/krprojshiftdisk;
+const int cut_r_L1D1_D3_2S = 3.6/krprojshiftdisk;
+const int cut_r_L2D1_D3_2S = 3.8/krprojshiftdisk;
+const int cut_r_L1L2_D4_2S = 3.6/krprojshiftdisk;
+const int cut_r_D1D2_D4_2S = 3.6/krprojshiftdisk;
+const int cut_r_L1D1_D4_2S = 3.5/krprojshiftdisk;
+const int cut_r_L2D1_D4_2S = 3.8/krprojshiftdisk;
+const int cut_r_D1D2_D5_2S = 3.6/krprojshiftdisk;
+const int cut_r_D3D4_D5_2S = 3.4/krprojshiftdisk;
+const int cut_r_L1D1_D5_2S = 3.7/krprojshiftdisk;
+
 
 // setup constants based on which seeding and which layer
 // MC cuts are constants by [layer] and [seeding]
 // [layer]: 0 = L1, 1 = L2, 2 = L3, 3 = L4, 4 = L5, 5 = L6
 // [seeding]:  0 = L1L2, 1 = L3L4, 2 = L5L6, 3 = D1D2, 4 = D3D4, 5 = L1D1, 6 = L2D1
 
-const int matchcut_phi[6][7] = {
-		{-1,            cut_p_L3L4_L1, cut_p_L5L6_L1, cut_p_D1D2_L1, cut_p_D3D4_L1, -1, cut_p_L2D1_L1},
-		{-1,            cut_p_L3L4_L2, cut_p_L5L6_L2, cut_p_D1D2_L2, -1,            -1, -1},
-		{cut_p_L1L2_L3, -1,            cut_p_L5L6_L3, -1,            -1,            -1, -1},
-		{cut_p_L1L2_L4, -1,            cut_p_L5L6_L4, -1,            -1,            -1, -1},
-		{cut_p_L1L2_L5, cut_p_L3L4_L5, -1,            -1,            -1,            -1, -1},
-		{cut_p_L1L2_L6, cut_p_L3L4_L6, -1,            -1,            -1,            -1, -1}
+static int matchcut_phi[6][7] = {
+		{0,             cut_p_L3L4_L1, cut_p_L5L6_L1, cut_p_D1D2_L1, cut_p_D3D4_L1, 0, cut_p_L2D1_L1},
+		{0,             cut_p_L3L4_L2, cut_p_L5L6_L2, cut_p_D1D2_L2, 0,             0, 0},
+		{cut_p_L1L2_L3, 0,             cut_p_L5L6_L3, 0,             0,             0, 0},
+		{cut_p_L1L2_L4, 0,             cut_p_L5L6_L4, 0,             0,             0, 0},
+		{cut_p_L1L2_L5, cut_p_L3L4_L5, 0,             0,             0,             0, 0},
+		{cut_p_L1L2_L6, cut_p_L3L4_L6, 0,             0,             0,             0, 0}
 };
-const int matchcut_z[6][7] = {
-		{-1,            cut_z_L3L4_L1, cut_z_L5L6_L1, cut_z_D1D2_L1, cut_z_D3D4_L1, -1, cut_z_L2D1_L1},
-		{-1,            cut_z_L3L4_L2, cut_z_L5L6_L2, cut_z_D1D2_L2, -1,            -1, -1},
-		{cut_z_L1L2_L3, -1,            cut_z_L5L6_L3, -1,            -1,            -1, -1},
-		{cut_z_L1L2_L4, -1,            cut_z_L5L6_L4, -1,            -1,            -1, -1},
-		{cut_z_L1L2_L5, cut_z_L3L4_L5, -1,            -1,            -1,            -1, -1},
-		{cut_z_L1L2_L6, cut_z_L3L4_L6, -1,            -1,            -1,            -1, -1}
+static int matchcut_z[6][7] = {
+		{0,             cut_z_L3L4_L1, cut_z_L5L6_L1, cut_z_D1D2_L1, cut_z_D3D4_L1, 0, cut_z_L2D1_L1},
+		{0,             cut_z_L3L4_L2, cut_z_L5L6_L2, cut_z_D1D2_L2, 0,             0, 0},
+		{cut_z_L1L2_L3, 0,             cut_z_L5L6_L3, 0,             0,             0, 0},
+		{cut_z_L1L2_L4, 0,             cut_z_L5L6_L4, 0,             0,             0, 0},
+		{cut_z_L1L2_L5, cut_z_L3L4_L5, 0,             0,             0,             0, 0},
+		{cut_z_L1L2_L6, cut_z_L3L4_L6, 0,             0,             0,             0, 0}
+};
+
+// setup constants based on which seeding and which layer
+// MC cuts are constants by [disk] and [seeding]
+// [disk]: 0 = D1, 1 = D2, 2 = D3, 3 = D4, 4 = D5
+// [seeding]:  0 = L1L2, 1 = L3L4, 2 = L5L6, 3 = D1D2, 4 = D3D4, 5 = L1D1, 6 = L2D1
+
+static int matchcut_phi_d_PS[5][7] = {
+		{cut_p_L1L2_D1_PS, 0, 0, 0,                cut_p_D3D4_D1_PS, 0,                0},
+		{cut_p_L1L2_D2_PS, 0, 0, 0,                cut_p_D3D4_D2_PS, cut_p_L1D1_D2_PS, cut_p_L2D1_D2_PS},
+		{cut_p_L1L2_D3_PS, 0, 0, cut_p_D1D2_D3_PS, 0,                cut_p_L1D1_D3_PS, cut_p_L2D1_D3_PS},
+		{cut_p_L1L2_D4_PS, 0, 0, cut_p_D1D2_D4_PS, 0,                cut_p_L1D1_D4_PS, cut_p_L2D1_D4_PS},
+		{0,                0, 0, cut_p_D1D2_D5_PS, cut_p_D3D4_D5_PS, cut_p_L1D1_D5_PS, 0}
+};
+static int matchcut_phi_d_2S[5][7] = {
+		{cut_p_L1L2_D1_2S, cut_p_L3L4_D1_2S, 0, 0,                0,                0,                0},
+		{cut_p_L1L2_D2_2S, cut_p_L3L4_D2_2S, 0, 0,                0,                cut_p_L1D1_D2_2S, cut_p_L2D1_D2_2S},
+		{cut_p_L1L2_D3_2S, 0,                0, cut_p_D1D2_D3_2S, 0,                cut_p_L1D1_D3_2S, cut_p_L2D1_D3_2S},
+		{cut_p_L1L2_D4_2S, 0,                0, cut_p_D1D2_D4_2S, 0,                cut_p_L1D1_D4_2S, cut_p_L2D1_D4_2S},
+		{0,                0,                0, cut_p_D1D2_D5_2S, cut_p_D3D4_D5_2S, cut_p_L1D1_D5_2S, 0}
+};
+static int matchcut_r_d_PS[5][7] = {
+		{cut_r_L1L2_D1_PS, 0, 0, 0,                cut_r_D3D4_D1_PS, 0,                0},
+		{cut_r_L1L2_D2_PS, 0, 0, 0,                cut_r_D3D4_D2_PS, cut_r_L1D1_D2_PS, cut_r_L2D1_D2_PS},
+		{cut_r_L1L2_D3_PS, 0, 0, cut_r_D1D2_D3_PS, 0,                cut_r_L1D1_D3_PS, cut_r_L2D1_D3_PS},
+		{cut_r_L1L2_D4_PS, 0, 0, cut_r_D1D2_D4_PS, 0,                cut_r_L1D1_D4_PS, cut_r_L2D1_D4_PS},
+		{0,                0, 0, cut_r_D1D2_D5_PS, cut_r_D3D4_D5_PS, cut_r_L1D1_D5_PS, 0}
+};
+static int matchcut_r_d_2S[5][7] = {
+		{cut_r_L1L2_D1_2S, cut_r_L3L4_D1_2S, 0, 0,                0,                0,                0},
+		{cut_r_L1L2_D2_2S, cut_r_L3L4_D2_2S, 0, 0,                0,                cut_r_L1D1_D2_2S, cut_r_L2D1_D2_2S},
+		{cut_r_L1L2_D3_2S, 0,                0, cut_r_D1D2_D3_2S, 0,                cut_r_L1D1_D3_2S, cut_r_L2D1_D3_2S},
+		{cut_r_L1L2_D4_2S, 0,                0, cut_r_D1D2_D4_2S, 0,                cut_r_L1D1_D4_2S, cut_r_L2D1_D4_2S},
+		{0,                0,                0, cut_r_D1D2_D5_2S, cut_r_D3D4_D5_2S, cut_r_L1D1_D5_2S, 0}
 };
 
 void MatchCalculator(
-	const int seed,
 	const int layer,
     HLSCandidateMatch CM_PHI1_PHI1[MAX_nCM],
 	HLSCandidateMatch CM_PHI1_PHI2[MAX_nCM],
@@ -113,8 +229,20 @@ void MatchCalculator(
 	const ap_uint<7>  n_CM_PHI1_PHI4,
 	HLSAllStubs       AS_PHI1[MAX_nSTUB],
 	HLSProjection     Proj_PHI1[MAX_nPROJ],
-	HLSFullMatch      FM_PHI1[MAX_nFM],
-	ap_uint<7>        n_FM_PHI1
+	HLSFullMatch      FM_seed0[MAX_nFM],
+	HLSFullMatch      FM_seed1[MAX_nFM],
+	HLSFullMatch      FM_seed2[MAX_nFM],
+	HLSFullMatch      FM_seed3[MAX_nFM],
+	HLSFullMatch      FM_seed4[MAX_nFM],
+	HLSFullMatch      FM_seed5[MAX_nFM],
+	HLSFullMatch      FM_seed6[MAX_nFM],
+	ap_uint<7>        & n_FM_seed0,
+	ap_uint<7>        & n_FM_seed1,
+	ap_uint<7>        & n_FM_seed2,
+	ap_uint<7>        & n_FM_seed3,
+	ap_uint<7>        & n_FM_seed4,
+	ap_uint<7>        & n_FM_seed5,
+	ap_uint<7>        & n_FM_seed6
     );
 
 template< int width >


### PR DESCRIPTION
- The tracklet seed is extracted from the top bits of the projection (instead of as a parameter to MC)
- Write out the FM based on the tracklet seed (should later clean this to remove FMs that are not used for each layer)
- Improved test bench comparison between hw and sw
- Using "range" instead of shifts to extract bits from memories
- Added disc constants in MC header (although the disc / other layers are not yet implemented). 

