### PR TITLE
Fix crash when running ProjectionRouter C-simulation

### DIFF
--- a/TestBenches/FileReadUtility.hh
+++ b/TestBenches/FileReadUtility.hh
@@ -56,6 +56,7 @@ std::vector<std::string> split(const std::string& s, char delimiter)
   std::istringstream sstream(s);
   
   while (getline(sstream, token, delimiter)) {
+    if (token=="") continue;
     tokens.push_back(token);
   }
   


### PR DESCRIPTION
ProjectionRouter C-simulation crashed related to the new if-else statement in [writeMemFromFile](https://github.com/cms-tracklet/firmware-hls/blob/master/TestBenches/FileReadUtility.hh#L85). 
This is because split() in TestBenches/FileReadUtility.hh only split string by single space, while TrackletProjection memory printouts use a mixture of single and double space delimiters. 