### PR TITLE
fix sizes for z deriv and phi deriv

### DIFF
--- a/TrackletAlgorithm/AllProjectionMemory.hh
+++ b/TrackletAlgorithm/AllProjectionMemory.hh
@@ -5,8 +5,8 @@
 #include "MemoryTemplate.hh"
 
 // Bit size for AllProjectionMemory fields
-constexpr unsigned int kAProjZDSize = 8;
-constexpr unsigned int kAProjPhiDSize = 7;
+constexpr unsigned int kAProjZDSize = 10;
+constexpr unsigned int kAProjPhiDSize = 10;
 constexpr unsigned int kAProjZSize = 12;
 constexpr unsigned int kAProjPhiSize = 14;
 constexpr unsigned int kAProjTCIndexSize = 14;


### PR DESCRIPTION
New PR to fix my previous commit. 
Z derivative and phi derivative for AP memory are now both 10 bits.