### PR TITLE
Changes to make HLS co-simulation happy

### DIFF
--- a/TrackletAlgorithm/AllProjectionMemory.hh
+++ b/TrackletAlgorithm/AllProjectionMemory.hh
@@ -5,7 +5,7 @@
 #include "MemoryTemplate.hh"
 
 // AllProjectionBase is where we define the bit widths, which depend on the class template parameter.
-template<regionType AProjType> class AllProjectionBase {};
+template<int AProjType> class AllProjectionBase {};
 
 template<>
 class AllProjectionBase<BARRELPS>
@@ -66,7 +66,7 @@ public:
 
 
 // Data object definition
-template<regionType AProjType>
+template<int AProjType>
 class AllProjection : public AllProjectionBase<AProjType>
 {
 public:
@@ -201,7 +201,7 @@ private:
 };
 
 // Memory definition
-template<regionType AProjType> using AllProjectionMemory = MemoryTemplate<AllProjection<AProjType>, 3, kNBits_MemAddr>;
+template<int AProjType> using AllProjectionMemory = MemoryTemplate<AllProjection<AProjType>, 3, kNBits_MemAddr>;
 // FIXME: double check number of bits for bx and for memory address
 
 #endif

--- a/TrackletAlgorithm/ProjectionRouterTop.cpp
+++ b/TrackletAlgorithm/ProjectionRouterTop.cpp
@@ -1,24 +1,24 @@
 #include "ProjectionRouterTop.h"
 
 void ProjectionRouterTop(BXType bx,
-                         const TrackletProjectionMemory<BARRELPS>* const tproj1,
-                         const TrackletProjectionMemory<BARRELPS>* const tproj2,
-                         const TrackletProjectionMemory<BARRELPS>* const tproj3,
-                         const TrackletProjectionMemory<BARRELPS>* const tproj4,
-                         const TrackletProjectionMemory<BARRELPS>* const tproj5,
-                         const TrackletProjectionMemory<BARRELPS>* const tproj6,
-                         const TrackletProjectionMemory<BARRELPS>* const tproj7,
-                         const TrackletProjectionMemory<BARRELPS>* const tproj8,
+                         const TrackletProjectionMemory<BARRELPS>* tproj1,
+                         const TrackletProjectionMemory<BARRELPS>* tproj2,
+                         const TrackletProjectionMemory<BARRELPS>* tproj3,
+                         const TrackletProjectionMemory<BARRELPS>* tproj4,
+                         const TrackletProjectionMemory<BARRELPS>* tproj5,
+                         const TrackletProjectionMemory<BARRELPS>* tproj6,
+                         const TrackletProjectionMemory<BARRELPS>* tproj7,
+                         const TrackletProjectionMemory<BARRELPS>* tproj8,
                          BXType& bx_o,
-                         AllProjectionMemory<BARRELPS>* const allproj,
-                         VMProjectionMemory<BARREL>* const vmproj1,
-                         VMProjectionMemory<BARREL>* const vmproj2,
-                         VMProjectionMemory<BARREL>* const vmproj3,
-                         VMProjectionMemory<BARREL>* const vmproj4,
-                         VMProjectionMemory<BARREL>* const vmproj5,
-                         VMProjectionMemory<BARREL>* const vmproj6,
-                         VMProjectionMemory<BARREL>* const vmproj7,
-                         VMProjectionMemory<BARREL>* const vmproj8
+                         AllProjectionMemory<BARRELPS>* allproj,
+                         VMProjectionMemory<BARREL>* vmproj1,
+                         VMProjectionMemory<BARREL>* vmproj2,
+                         VMProjectionMemory<BARREL>* vmproj3,
+                         VMProjectionMemory<BARREL>* vmproj4,
+                         VMProjectionMemory<BARREL>* vmproj5,
+                         VMProjectionMemory<BARREL>* vmproj6,
+                         VMProjectionMemory<BARREL>* vmproj7,
+                         VMProjectionMemory<BARREL>* vmproj8
                          )
 {
   // PR_L3PHIC

--- a/TrackletAlgorithm/ProjectionRouterTop.h
+++ b/TrackletAlgorithm/ProjectionRouterTop.h
@@ -4,24 +4,24 @@
 #include "ProjectionRouter.hh"
 
 void ProjectionRouterTop(BXType bx,
-                         const TrackletProjectionMemory<BARRELPS>* const,
-                         const TrackletProjectionMemory<BARRELPS>* const,
-                         const TrackletProjectionMemory<BARRELPS>* const,
-                         const TrackletProjectionMemory<BARRELPS>* const,
-                         const TrackletProjectionMemory<BARRELPS>* const,
-                         const TrackletProjectionMemory<BARRELPS>* const,
-                         const TrackletProjectionMemory<BARRELPS>* const,
-                         const TrackletProjectionMemory<BARRELPS>* const,
+                         const TrackletProjectionMemory<BARRELPS>*,
+                         const TrackletProjectionMemory<BARRELPS>*,
+                         const TrackletProjectionMemory<BARRELPS>*,
+                         const TrackletProjectionMemory<BARRELPS>*,
+                         const TrackletProjectionMemory<BARRELPS>*,
+                         const TrackletProjectionMemory<BARRELPS>*,
+                         const TrackletProjectionMemory<BARRELPS>*,
+                         const TrackletProjectionMemory<BARRELPS>*,
                          BXType&,
-                         AllProjectionMemory<BARRELPS>* const,
-                         VMProjectionMemory<BARREL>* const,
-                         VMProjectionMemory<BARREL>* const,
-                         VMProjectionMemory<BARREL>* const,
-                         VMProjectionMemory<BARREL>* const,
-                         VMProjectionMemory<BARREL>* const,
-                         VMProjectionMemory<BARREL>* const,
-                         VMProjectionMemory<BARREL>* const,
-                         VMProjectionMemory<BARREL>* const
+                         AllProjectionMemory<BARRELPS>*,
+                         VMProjectionMemory<BARREL>*,
+                         VMProjectionMemory<BARREL>*,
+                         VMProjectionMemory<BARREL>*,
+                         VMProjectionMemory<BARREL>*,
+                         VMProjectionMemory<BARREL>*,
+                         VMProjectionMemory<BARREL>*,
+                         VMProjectionMemory<BARREL>*,
+                         VMProjectionMemory<BARREL>*
                          );
 
 #endif

--- a/TrackletAlgorithm/TrackletProjectionMemory.hh
+++ b/TrackletAlgorithm/TrackletProjectionMemory.hh
@@ -6,7 +6,7 @@
 
 // TrackletProjectionBase is where we define the bit widths, which depend on
 // the class template parameter.
-template<regionType TProjType> class TrackletProjectionBase {};
+template<int TProjType> class TrackletProjectionBase {};
 
 template<>
 class TrackletProjectionBase<BARRELPS>
@@ -61,7 +61,7 @@ public:
 
 
 // Data object definition
-template<regionType TProjType>
+template<int TProjType>
 class TrackletProjection : public TrackletProjectionBase<TProjType>
 {
 public:
@@ -170,7 +170,7 @@ private:
 };
 
 // Memory definition
-template<regionType TProjType> using TrackletProjectionMemory = MemoryTemplate<TrackletProjection<TProjType>, 1, kNBits_MemAddr>;
+template<int TProjType> using TrackletProjectionMemory = MemoryTemplate<TrackletProjection<TProjType>, 1, kNBits_MemAddr>;
 // FIXME: double check number of bits for bx and for memory address
 
 #endif

--- a/TrackletAlgorithm/VMProjectionMemory.hh
+++ b/TrackletAlgorithm/VMProjectionMemory.hh
@@ -5,7 +5,7 @@
 #include "MemoryTemplate.hh"
 
 // VMProjectionBase is where we define the bit widths, which depend on the class template parameter.
-template<regionType VMProjType> class VMProjectionBase {};
+template<int VMProjType> class VMProjectionBase {};
 
 template<>
 class VMProjectionBase<BARREL>
@@ -41,7 +41,7 @@ public:
 
 
 // Data object definition
-template<regionType VMProjType>
+template<int VMProjType>
 class VMProjection : public VMProjectionBase<VMProjType>
 {
 public:
@@ -153,7 +153,7 @@ private:
 };
 
 // Memory definition
-template<regionType VMProjType> using VMProjectionMemory = MemoryTemplate<VMProjection<VMProjType>, 1, kNBits_MemAddr>;
+template<int VMProjType> using VMProjectionMemory = MemoryTemplate<VMProjection<VMProjType>, 1, kNBits_MemAddr>;
 // FIXME: double check number of bits for bx and for memory address
 
 #endif


### PR DESCRIPTION
This pull request includes changes that seem needed to make the project run successfully at the Co-simulation step. This commit is primarily for discussions and currently only involves the ProjectionRouter and its connected memory modules.

There was a known issue that the co-simulation fails due to C compilation errors for most of the projects in the repo, even though the C-simulation and synthesis steps are successful. E.g. for the ProjectionRouter project with top function "ProjectionRouterTop", the co-simulation generates a file "apatb_ProjectionRouterTop.cpp", which causes invalid conversion from int type to enum when declaring memory objects[1] and linker errors[2].

For [1], a quick walkaround is in the memory classes replacing all enum type "regionType" in the template parameter to "int". This makes the co-simulation happy at a cost of some code readability. Note that the processing functions can still use enum "regionType" to instantiate memory objects.

For [2], there are very similar issues reported on the Xilinx forums [here](https://forums.xilinx.com/t5/Vivado-High-Level-Synthesis-HLS/Cosim-Fails-with-error-quot-undefined-reference-to-AESL-ORIG-DUT/m-p/712360) and [here](https://forums.xilinx.com/t5/Vivado-High-Level-Synthesis-HLS/Run-C-RTL-co-simulation-failed/m-p/675109). But I didn't find their solutions very helpful for our case. After spending some time digging up the error, Derek and I found that the culprit responsible for the linker error is the "const" keyword for the pointers at the top function interface. We don't understand why at all... but the project runs successfully at co-simulation after removing the "const" for the pointers in the "ProjectionRouterTop" function arguments. The memory object can still have "const" keyword. Note that for functions that are inside the top level function, they can still have const pointer arguments, so we can still have const pointers to const memory objects for inputs, and const pointers to non-const memory objects for outputs.


[1] INFO: [COSIM 212-47] Using XSIM for RTL simulation.
INFO: [COSIM 212-14] Instrumenting C test bench ...
   Build using "/nfs/opt/Xilinx/Vivado/2018.2/tps/lnx64/gcc-6.2.0/bin/g++"
   Compiling ProjectionRouter_test.cpp_pre.cpp.tb.cpp
In file included from /mnt/scratch/zt75/firmware-hls/TestBenches/ProjectionRouter_test.cpp:16:0:
apatb_ProjectionRouterTop.h:9:50: error: invalid conversion from ‘int’ to ‘regionType’ [-fpermissive]
 const struct MemoryTemplate<TrackletProjection<0 >, 1, 7 >* tproj1,
                                                  ^
apatb_ProjectionRouterTop.h:10:50: error: invalid conversion from ‘int’ to ‘regionType’ [-fpermissive]
 const struct MemoryTemplate<TrackletProjection<0 >, 1, 7 >* tproj2,
                                                  ^

make: *** [obj/ProjectionRouter_test.cpp_pre.cpp.tb.o] Error 1
ERROR: [COSIM 212-317] C++ compile error.
ERROR: [COSIM 212-321] EXE file generate failed.
ERROR: [COSIM 212-321] EXE file generate failed.
ERROR: [COSIM 212-331] Aborting co-simulation: C simulation failed, compilation errors.

[2] INFO: [COSIM 212-47] Using XSIM for RTL simulation.
INFO: [COSIM 212-14] Instrumenting C test bench ...
   Build using "/nfs/opt/Xilinx/Vivado/2018.2/tps/lnx64/gcc-6.2.0/bin/g++"
   Compiling ProjectionRouter_test.cpp_pre.cpp.tb.cpp
   Compiling ProjectionRouterTop.cpp_pre.cpp.tb.cpp
   Compiling apatb_ProjectionRouterTop.cpp
   Generating cosim.tv.exe
In file included from apatb_ProjectionRouterTop.cpp:20:0:
/nfs/opt/Xilinx/Vivado/2018.2/include/ap_stream.h:70:2: warning: #warning AP_STREAM macros are deprecated. Please use hls::stream<> from "hls_stream.h" instead. [-Wcpp]
 #warning AP_STREAM macros are deprecated. Please use hls::stream<> from "hls_stream.h" instead.
  ^~~~~~~
obj/apatb_ProjectionRouterTop.o: In function `AESL_WRAP_ProjectionRouterTop(ap_uint<3>, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, ap_uint<3>&, MemoryTemplate<AllProjection<0>, 3u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*)':
/mnt/scratch/zt75/firmware-hls/project/projrouter/solution1/sim/wrapc/apatb_ProjectionRouterTop.cpp:8255: undefined reference to `ProjectionRouterTop(ap_uint<3>, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, MemoryTemplate<TrackletProjection<0>, 1u, 7u> const*, ap_uint<3>&, MemoryTemplate<AllProjection<0>, 3u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*, MemoryTemplate<VMProjection<3>, 1u, 7u> const*)'
collect2: error: ld returned 1 exit status
make: *** [cosim.tv.exe] Error 1
ERROR: [COSIM 212-317] C++ compile error.
ERROR: [COSIM 212-321] EXE file generate failed.
ERROR: [COSIM 212-321] EXE file generate failed.
ERROR: [COSIM 212-331] Aborting co-simulation: C simulation failed, compilation errors.