### PR TITLE
Use array for nentries port inside tf_mem*.vhd & replace clogb2

### DIFF
--- a/IntegrationTests/PRMEMC/hdl/SectorProcessor.vhd
+++ b/IntegrationTests/PRMEMC/hdl/SectorProcessor.vhd
@@ -67,13 +67,11 @@ entity SectorProcessor is
     FM_L1L2_L3PHIC_dataarray_data_V_enb      : in std_logic;
     FM_L1L2_L3PHIC_dataarray_data_V_readaddr : in std_logic_vector(7 downto 0);
     FM_L1L2_L3PHIC_dataarray_data_V_dout     : out std_logic_vector(44 downto 0);
-    FM_L1L2_L3PHIC_nentries_0_V_dout : out std_logic_vector(6 downto 0);
-    FM_L1L2_L3PHIC_nentries_1_V_dout : out std_logic_vector(6 downto 0);
+    FM_L1L2_L3PHIC_nentries_VV_dout : out t_arr2_7b;
     FM_L5L6_L3PHIC_dataarray_data_V_enb      : in std_logic;
     FM_L5L6_L3PHIC_dataarray_data_V_readaddr : in std_logic_vector(7 downto 0);
     FM_L5L6_L3PHIC_dataarray_data_V_dout     : out std_logic_vector(44 downto 0);
-    FM_L5L6_L3PHIC_nentries_0_V_dout : out std_logic_vector(6 downto 0);
-    FM_L5L6_L3PHIC_nentries_1_V_dout : out std_logic_vector(6 downto 0)
+    FM_L5L6_L3PHIC_nentries_VV_dout : out t_arr2_7b
 );
 
 
@@ -85,131 +83,67 @@ architecture rtl of SectorProcessor is
   signal TPROJ_L1L2F_L3PHIC_dataarray_data_V_enb      : std_logic;
   signal TPROJ_L1L2F_L3PHIC_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal TPROJ_L1L2F_L3PHIC_dataarray_data_V_dout     : std_logic_vector(59 downto 0);
-  signal TPROJ_L1L2F_L3PHIC_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal TPROJ_L1L2F_L3PHIC_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal TPROJ_L1L2F_L3PHIC_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal TPROJ_L1L2G_L3PHIC_dataarray_data_V_enb      : std_logic;
   signal TPROJ_L1L2G_L3PHIC_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal TPROJ_L1L2G_L3PHIC_dataarray_data_V_dout     : std_logic_vector(59 downto 0);
-  signal TPROJ_L1L2G_L3PHIC_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal TPROJ_L1L2G_L3PHIC_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal TPROJ_L1L2G_L3PHIC_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal TPROJ_L1L2H_L3PHIC_dataarray_data_V_enb      : std_logic;
   signal TPROJ_L1L2H_L3PHIC_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal TPROJ_L1L2H_L3PHIC_dataarray_data_V_dout     : std_logic_vector(59 downto 0);
-  signal TPROJ_L1L2H_L3PHIC_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal TPROJ_L1L2H_L3PHIC_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal TPROJ_L1L2H_L3PHIC_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal TPROJ_L1L2I_L3PHIC_dataarray_data_V_enb      : std_logic;
   signal TPROJ_L1L2I_L3PHIC_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal TPROJ_L1L2I_L3PHIC_dataarray_data_V_dout     : std_logic_vector(59 downto 0);
-  signal TPROJ_L1L2I_L3PHIC_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal TPROJ_L1L2I_L3PHIC_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal TPROJ_L1L2I_L3PHIC_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal TPROJ_L1L2J_L3PHIC_dataarray_data_V_enb      : std_logic;
   signal TPROJ_L1L2J_L3PHIC_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal TPROJ_L1L2J_L3PHIC_dataarray_data_V_dout     : std_logic_vector(59 downto 0);
-  signal TPROJ_L1L2J_L3PHIC_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal TPROJ_L1L2J_L3PHIC_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal TPROJ_L1L2J_L3PHIC_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal TPROJ_L5L6B_L3PHIC_dataarray_data_V_enb      : std_logic;
   signal TPROJ_L5L6B_L3PHIC_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal TPROJ_L5L6B_L3PHIC_dataarray_data_V_dout     : std_logic_vector(59 downto 0);
-  signal TPROJ_L5L6B_L3PHIC_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal TPROJ_L5L6B_L3PHIC_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal TPROJ_L5L6B_L3PHIC_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal TPROJ_L5L6C_L3PHIC_dataarray_data_V_enb      : std_logic;
   signal TPROJ_L5L6C_L3PHIC_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal TPROJ_L5L6C_L3PHIC_dataarray_data_V_dout     : std_logic_vector(59 downto 0);
-  signal TPROJ_L5L6C_L3PHIC_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal TPROJ_L5L6C_L3PHIC_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal TPROJ_L5L6C_L3PHIC_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal TPROJ_L5L6D_L3PHIC_dataarray_data_V_enb      : std_logic;
   signal TPROJ_L5L6D_L3PHIC_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal TPROJ_L5L6D_L3PHIC_dataarray_data_V_dout     : std_logic_vector(59 downto 0);
-  signal TPROJ_L5L6D_L3PHIC_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal TPROJ_L5L6D_L3PHIC_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal TPROJ_L5L6D_L3PHIC_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal VMSME_L3PHIC17n1_dataarray_data_V_enb      : std_logic;
   signal VMSME_L3PHIC17n1_dataarray_data_V_readaddr : std_logic_vector(9 downto 0);
   signal VMSME_L3PHIC17n1_dataarray_data_V_dout     : std_logic_vector(12 downto 0);
-  signal VMSME_L3PHIC17n1_nentries_0_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC17n1_nentries_1_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC17n1_nentries_2_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC17n1_nentries_3_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC17n1_nentries_4_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC17n1_nentries_5_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC17n1_nentries_6_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC17n1_nentries_7_VV_dout : t_arr8_5b; -- (#bin)
+  signal VMSME_L3PHIC17n1_nentries_VVV_dout : t_arr8_8_5b; -- (#page)(#bin)
   signal VMSME_L3PHIC18n1_dataarray_data_V_enb      : std_logic;
   signal VMSME_L3PHIC18n1_dataarray_data_V_readaddr : std_logic_vector(9 downto 0);
   signal VMSME_L3PHIC18n1_dataarray_data_V_dout     : std_logic_vector(12 downto 0);
-  signal VMSME_L3PHIC18n1_nentries_0_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC18n1_nentries_1_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC18n1_nentries_2_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC18n1_nentries_3_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC18n1_nentries_4_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC18n1_nentries_5_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC18n1_nentries_6_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC18n1_nentries_7_VV_dout : t_arr8_5b; -- (#bin)
+  signal VMSME_L3PHIC18n1_nentries_VVV_dout : t_arr8_8_5b; -- (#page)(#bin)
   signal VMSME_L3PHIC19n1_dataarray_data_V_enb      : std_logic;
   signal VMSME_L3PHIC19n1_dataarray_data_V_readaddr : std_logic_vector(9 downto 0);
   signal VMSME_L3PHIC19n1_dataarray_data_V_dout     : std_logic_vector(12 downto 0);
-  signal VMSME_L3PHIC19n1_nentries_0_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC19n1_nentries_1_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC19n1_nentries_2_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC19n1_nentries_3_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC19n1_nentries_4_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC19n1_nentries_5_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC19n1_nentries_6_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC19n1_nentries_7_VV_dout : t_arr8_5b; -- (#bin)
+  signal VMSME_L3PHIC19n1_nentries_VVV_dout : t_arr8_8_5b; -- (#page)(#bin)
   signal VMSME_L3PHIC20n1_dataarray_data_V_enb      : std_logic;
   signal VMSME_L3PHIC20n1_dataarray_data_V_readaddr : std_logic_vector(9 downto 0);
   signal VMSME_L3PHIC20n1_dataarray_data_V_dout     : std_logic_vector(12 downto 0);
-  signal VMSME_L3PHIC20n1_nentries_0_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC20n1_nentries_1_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC20n1_nentries_2_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC20n1_nentries_3_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC20n1_nentries_4_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC20n1_nentries_5_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC20n1_nentries_6_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC20n1_nentries_7_VV_dout : t_arr8_5b; -- (#bin)
+  signal VMSME_L3PHIC20n1_nentries_VVV_dout : t_arr8_8_5b; -- (#page)(#bin)
   signal VMSME_L3PHIC21n1_dataarray_data_V_enb      : std_logic;
   signal VMSME_L3PHIC21n1_dataarray_data_V_readaddr : std_logic_vector(9 downto 0);
   signal VMSME_L3PHIC21n1_dataarray_data_V_dout     : std_logic_vector(12 downto 0);
-  signal VMSME_L3PHIC21n1_nentries_0_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC21n1_nentries_1_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC21n1_nentries_2_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC21n1_nentries_3_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC21n1_nentries_4_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC21n1_nentries_5_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC21n1_nentries_6_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC21n1_nentries_7_VV_dout : t_arr8_5b; -- (#bin)
+  signal VMSME_L3PHIC21n1_nentries_VVV_dout : t_arr8_8_5b; -- (#page)(#bin)
   signal VMSME_L3PHIC22n1_dataarray_data_V_enb      : std_logic;
   signal VMSME_L3PHIC22n1_dataarray_data_V_readaddr : std_logic_vector(9 downto 0);
   signal VMSME_L3PHIC22n1_dataarray_data_V_dout     : std_logic_vector(12 downto 0);
-  signal VMSME_L3PHIC22n1_nentries_0_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC22n1_nentries_1_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC22n1_nentries_2_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC22n1_nentries_3_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC22n1_nentries_4_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC22n1_nentries_5_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC22n1_nentries_6_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC22n1_nentries_7_VV_dout : t_arr8_5b; -- (#bin)
+  signal VMSME_L3PHIC22n1_nentries_VVV_dout : t_arr8_8_5b; -- (#page)(#bin)
   signal VMSME_L3PHIC23n1_dataarray_data_V_enb      : std_logic;
   signal VMSME_L3PHIC23n1_dataarray_data_V_readaddr : std_logic_vector(9 downto 0);
   signal VMSME_L3PHIC23n1_dataarray_data_V_dout     : std_logic_vector(12 downto 0);
-  signal VMSME_L3PHIC23n1_nentries_0_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC23n1_nentries_1_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC23n1_nentries_2_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC23n1_nentries_3_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC23n1_nentries_4_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC23n1_nentries_5_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC23n1_nentries_6_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC23n1_nentries_7_VV_dout : t_arr8_5b; -- (#bin)
+  signal VMSME_L3PHIC23n1_nentries_VVV_dout : t_arr8_8_5b; -- (#page)(#bin)
   signal VMSME_L3PHIC24n1_dataarray_data_V_enb      : std_logic;
   signal VMSME_L3PHIC24n1_dataarray_data_V_readaddr : std_logic_vector(9 downto 0);
   signal VMSME_L3PHIC24n1_dataarray_data_V_dout     : std_logic_vector(12 downto 0);
-  signal VMSME_L3PHIC24n1_nentries_0_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC24n1_nentries_1_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC24n1_nentries_2_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC24n1_nentries_3_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC24n1_nentries_4_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC24n1_nentries_5_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC24n1_nentries_6_VV_dout : t_arr8_5b; -- (#bin)
-  signal VMSME_L3PHIC24n1_nentries_7_VV_dout : t_arr8_5b; -- (#bin)
+  signal VMSME_L3PHIC24n1_nentries_VVV_dout : t_arr8_8_5b; -- (#page)(#bin)
   signal AS_L3PHICn6_dataarray_data_V_enb      : std_logic;
   signal AS_L3PHICn6_dataarray_data_V_readaddr : std_logic_vector(9 downto 0);
   signal AS_L3PHICn6_dataarray_data_V_dout     : std_logic_vector(35 downto 0);
@@ -219,128 +153,112 @@ architecture rtl of SectorProcessor is
   signal VMPROJ_L3PHIC17_dataarray_data_V_enb      : std_logic;
   signal VMPROJ_L3PHIC17_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC17_dataarray_data_V_dout     : std_logic_vector(20 downto 0);
-  signal VMPROJ_L3PHIC17_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal VMPROJ_L3PHIC17_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal VMPROJ_L3PHIC17_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal VMPROJ_L3PHIC18_dataarray_data_V_wea       : std_logic;
   signal VMPROJ_L3PHIC18_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC18_dataarray_data_V_din       : std_logic_vector(20 downto 0);
   signal VMPROJ_L3PHIC18_dataarray_data_V_enb      : std_logic;
   signal VMPROJ_L3PHIC18_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC18_dataarray_data_V_dout     : std_logic_vector(20 downto 0);
-  signal VMPROJ_L3PHIC18_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal VMPROJ_L3PHIC18_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal VMPROJ_L3PHIC18_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal VMPROJ_L3PHIC19_dataarray_data_V_wea       : std_logic;
   signal VMPROJ_L3PHIC19_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC19_dataarray_data_V_din       : std_logic_vector(20 downto 0);
   signal VMPROJ_L3PHIC19_dataarray_data_V_enb      : std_logic;
   signal VMPROJ_L3PHIC19_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC19_dataarray_data_V_dout     : std_logic_vector(20 downto 0);
-  signal VMPROJ_L3PHIC19_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal VMPROJ_L3PHIC19_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal VMPROJ_L3PHIC19_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal VMPROJ_L3PHIC20_dataarray_data_V_wea       : std_logic;
   signal VMPROJ_L3PHIC20_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC20_dataarray_data_V_din       : std_logic_vector(20 downto 0);
   signal VMPROJ_L3PHIC20_dataarray_data_V_enb      : std_logic;
   signal VMPROJ_L3PHIC20_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC20_dataarray_data_V_dout     : std_logic_vector(20 downto 0);
-  signal VMPROJ_L3PHIC20_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal VMPROJ_L3PHIC20_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal VMPROJ_L3PHIC20_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal VMPROJ_L3PHIC21_dataarray_data_V_wea       : std_logic;
   signal VMPROJ_L3PHIC21_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC21_dataarray_data_V_din       : std_logic_vector(20 downto 0);
   signal VMPROJ_L3PHIC21_dataarray_data_V_enb      : std_logic;
   signal VMPROJ_L3PHIC21_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC21_dataarray_data_V_dout     : std_logic_vector(20 downto 0);
-  signal VMPROJ_L3PHIC21_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal VMPROJ_L3PHIC21_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal VMPROJ_L3PHIC21_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal VMPROJ_L3PHIC22_dataarray_data_V_wea       : std_logic;
   signal VMPROJ_L3PHIC22_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC22_dataarray_data_V_din       : std_logic_vector(20 downto 0);
   signal VMPROJ_L3PHIC22_dataarray_data_V_enb      : std_logic;
   signal VMPROJ_L3PHIC22_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC22_dataarray_data_V_dout     : std_logic_vector(20 downto 0);
-  signal VMPROJ_L3PHIC22_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal VMPROJ_L3PHIC22_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal VMPROJ_L3PHIC22_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal VMPROJ_L3PHIC23_dataarray_data_V_wea       : std_logic;
   signal VMPROJ_L3PHIC23_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC23_dataarray_data_V_din       : std_logic_vector(20 downto 0);
   signal VMPROJ_L3PHIC23_dataarray_data_V_enb      : std_logic;
   signal VMPROJ_L3PHIC23_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC23_dataarray_data_V_dout     : std_logic_vector(20 downto 0);
-  signal VMPROJ_L3PHIC23_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal VMPROJ_L3PHIC23_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal VMPROJ_L3PHIC23_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal VMPROJ_L3PHIC24_dataarray_data_V_wea       : std_logic;
   signal VMPROJ_L3PHIC24_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC24_dataarray_data_V_din       : std_logic_vector(20 downto 0);
   signal VMPROJ_L3PHIC24_dataarray_data_V_enb      : std_logic;
   signal VMPROJ_L3PHIC24_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal VMPROJ_L3PHIC24_dataarray_data_V_dout     : std_logic_vector(20 downto 0);
-  signal VMPROJ_L3PHIC24_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal VMPROJ_L3PHIC24_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal VMPROJ_L3PHIC24_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal CM_L3PHIC17_dataarray_data_V_wea       : std_logic;
   signal CM_L3PHIC17_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC17_dataarray_data_V_din       : std_logic_vector(13 downto 0);
   signal CM_L3PHIC17_dataarray_data_V_enb      : std_logic;
   signal CM_L3PHIC17_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC17_dataarray_data_V_dout     : std_logic_vector(13 downto 0);
-  signal CM_L3PHIC17_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal CM_L3PHIC17_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal CM_L3PHIC17_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal CM_L3PHIC18_dataarray_data_V_wea       : std_logic;
   signal CM_L3PHIC18_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC18_dataarray_data_V_din       : std_logic_vector(13 downto 0);
   signal CM_L3PHIC18_dataarray_data_V_enb      : std_logic;
   signal CM_L3PHIC18_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC18_dataarray_data_V_dout     : std_logic_vector(13 downto 0);
-  signal CM_L3PHIC18_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal CM_L3PHIC18_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal CM_L3PHIC18_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal CM_L3PHIC19_dataarray_data_V_wea       : std_logic;
   signal CM_L3PHIC19_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC19_dataarray_data_V_din       : std_logic_vector(13 downto 0);
   signal CM_L3PHIC19_dataarray_data_V_enb      : std_logic;
   signal CM_L3PHIC19_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC19_dataarray_data_V_dout     : std_logic_vector(13 downto 0);
-  signal CM_L3PHIC19_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal CM_L3PHIC19_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal CM_L3PHIC19_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal CM_L3PHIC20_dataarray_data_V_wea       : std_logic;
   signal CM_L3PHIC20_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC20_dataarray_data_V_din       : std_logic_vector(13 downto 0);
   signal CM_L3PHIC20_dataarray_data_V_enb      : std_logic;
   signal CM_L3PHIC20_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC20_dataarray_data_V_dout     : std_logic_vector(13 downto 0);
-  signal CM_L3PHIC20_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal CM_L3PHIC20_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal CM_L3PHIC20_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal CM_L3PHIC21_dataarray_data_V_wea       : std_logic;
   signal CM_L3PHIC21_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC21_dataarray_data_V_din       : std_logic_vector(13 downto 0);
   signal CM_L3PHIC21_dataarray_data_V_enb      : std_logic;
   signal CM_L3PHIC21_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC21_dataarray_data_V_dout     : std_logic_vector(13 downto 0);
-  signal CM_L3PHIC21_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal CM_L3PHIC21_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal CM_L3PHIC21_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal CM_L3PHIC22_dataarray_data_V_wea       : std_logic;
   signal CM_L3PHIC22_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC22_dataarray_data_V_din       : std_logic_vector(13 downto 0);
   signal CM_L3PHIC22_dataarray_data_V_enb      : std_logic;
   signal CM_L3PHIC22_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC22_dataarray_data_V_dout     : std_logic_vector(13 downto 0);
-  signal CM_L3PHIC22_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal CM_L3PHIC22_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal CM_L3PHIC22_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal CM_L3PHIC23_dataarray_data_V_wea       : std_logic;
   signal CM_L3PHIC23_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC23_dataarray_data_V_din       : std_logic_vector(13 downto 0);
   signal CM_L3PHIC23_dataarray_data_V_enb      : std_logic;
   signal CM_L3PHIC23_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC23_dataarray_data_V_dout     : std_logic_vector(13 downto 0);
-  signal CM_L3PHIC23_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal CM_L3PHIC23_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal CM_L3PHIC23_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal CM_L3PHIC24_dataarray_data_V_wea       : std_logic;
   signal CM_L3PHIC24_dataarray_data_V_writeaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC24_dataarray_data_V_din       : std_logic_vector(13 downto 0);
   signal CM_L3PHIC24_dataarray_data_V_enb      : std_logic;
   signal CM_L3PHIC24_dataarray_data_V_readaddr : std_logic_vector(7 downto 0);
   signal CM_L3PHIC24_dataarray_data_V_dout     : std_logic_vector(13 downto 0);
-  signal CM_L3PHIC24_nentries_0_V_dout : std_logic_vector(6 downto 0);
-  signal CM_L3PHIC24_nentries_1_V_dout : std_logic_vector(6 downto 0);
+  signal CM_L3PHIC24_nentries_VV_dout : t_arr2_7b; -- (#page)
   signal AP_L3PHIC_dataarray_data_V_wea       : std_logic;
   signal AP_L3PHIC_dataarray_data_V_writeaddr : std_logic_vector(9 downto 0);
   signal AP_L3PHIC_dataarray_data_V_din       : std_logic_vector(59 downto 0);
@@ -377,7 +295,7 @@ architecture rtl of SectorProcessor is
   TPROJ_L1L2F_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 60,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -394,21 +312,14 @@ architecture rtl of SectorProcessor is
       addrb     => TPROJ_L1L2F_L3PHIC_dataarray_data_V_readaddr,
       doutb     => TPROJ_L1L2F_L3PHIC_dataarray_data_V_dout,
       sync_nent => ProjectionRouter_start,
-      nent_o0  => TPROJ_L1L2F_L3PHIC_nentries_0_V_dout,
-      nent_o1  => TPROJ_L1L2F_L3PHIC_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => TPROJ_L1L2F_L3PHIC_nentries_VV_dout
   );
 
 
   TPROJ_L1L2G_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 60,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -425,21 +336,14 @@ architecture rtl of SectorProcessor is
       addrb     => TPROJ_L1L2G_L3PHIC_dataarray_data_V_readaddr,
       doutb     => TPROJ_L1L2G_L3PHIC_dataarray_data_V_dout,
       sync_nent => ProjectionRouter_start,
-      nent_o0  => TPROJ_L1L2G_L3PHIC_nentries_0_V_dout,
-      nent_o1  => TPROJ_L1L2G_L3PHIC_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => TPROJ_L1L2G_L3PHIC_nentries_VV_dout
   );
 
 
   TPROJ_L1L2H_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 60,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -456,21 +360,14 @@ architecture rtl of SectorProcessor is
       addrb     => TPROJ_L1L2H_L3PHIC_dataarray_data_V_readaddr,
       doutb     => TPROJ_L1L2H_L3PHIC_dataarray_data_V_dout,
       sync_nent => ProjectionRouter_start,
-      nent_o0  => TPROJ_L1L2H_L3PHIC_nentries_0_V_dout,
-      nent_o1  => TPROJ_L1L2H_L3PHIC_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => TPROJ_L1L2H_L3PHIC_nentries_VV_dout
   );
 
 
   TPROJ_L1L2I_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 60,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -487,21 +384,14 @@ architecture rtl of SectorProcessor is
       addrb     => TPROJ_L1L2I_L3PHIC_dataarray_data_V_readaddr,
       doutb     => TPROJ_L1L2I_L3PHIC_dataarray_data_V_dout,
       sync_nent => ProjectionRouter_start,
-      nent_o0  => TPROJ_L1L2I_L3PHIC_nentries_0_V_dout,
-      nent_o1  => TPROJ_L1L2I_L3PHIC_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => TPROJ_L1L2I_L3PHIC_nentries_VV_dout
   );
 
 
   TPROJ_L1L2J_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 60,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -518,21 +408,14 @@ architecture rtl of SectorProcessor is
       addrb     => TPROJ_L1L2J_L3PHIC_dataarray_data_V_readaddr,
       doutb     => TPROJ_L1L2J_L3PHIC_dataarray_data_V_dout,
       sync_nent => ProjectionRouter_start,
-      nent_o0  => TPROJ_L1L2J_L3PHIC_nentries_0_V_dout,
-      nent_o1  => TPROJ_L1L2J_L3PHIC_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => TPROJ_L1L2J_L3PHIC_nentries_VV_dout
   );
 
 
   TPROJ_L5L6B_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 60,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -549,21 +432,14 @@ architecture rtl of SectorProcessor is
       addrb     => TPROJ_L5L6B_L3PHIC_dataarray_data_V_readaddr,
       doutb     => TPROJ_L5L6B_L3PHIC_dataarray_data_V_dout,
       sync_nent => ProjectionRouter_start,
-      nent_o0  => TPROJ_L5L6B_L3PHIC_nentries_0_V_dout,
-      nent_o1  => TPROJ_L5L6B_L3PHIC_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => TPROJ_L5L6B_L3PHIC_nentries_VV_dout
   );
 
 
   TPROJ_L5L6C_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 60,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -580,21 +456,14 @@ architecture rtl of SectorProcessor is
       addrb     => TPROJ_L5L6C_L3PHIC_dataarray_data_V_readaddr,
       doutb     => TPROJ_L5L6C_L3PHIC_dataarray_data_V_dout,
       sync_nent => ProjectionRouter_start,
-      nent_o0  => TPROJ_L5L6C_L3PHIC_nentries_0_V_dout,
-      nent_o1  => TPROJ_L5L6C_L3PHIC_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => TPROJ_L5L6C_L3PHIC_nentries_VV_dout
   );
 
 
   TPROJ_L5L6D_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 60,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -611,21 +480,14 @@ architecture rtl of SectorProcessor is
       addrb     => TPROJ_L5L6D_L3PHIC_dataarray_data_V_readaddr,
       doutb     => TPROJ_L5L6D_L3PHIC_dataarray_data_V_dout,
       sync_nent => ProjectionRouter_start,
-      nent_o0  => TPROJ_L5L6D_L3PHIC_nentries_0_V_dout,
-      nent_o1  => TPROJ_L5L6D_L3PHIC_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => TPROJ_L5L6D_L3PHIC_nentries_VV_dout
   );
 
 
   VMSME_L3PHIC17n1 : entity work.tf_mem_bin
     generic map (
       RAM_WIDTH       => 13,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -642,21 +504,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMSME_L3PHIC17n1_dataarray_data_V_readaddr,
       doutb     => VMSME_L3PHIC17n1_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMSME_L3PHIC17n1_nentries_0_VV_dout,
-      nent_o1  => VMSME_L3PHIC17n1_nentries_1_VV_dout,
-      nent_o2  => VMSME_L3PHIC17n1_nentries_2_VV_dout,
-      nent_o3  => VMSME_L3PHIC17n1_nentries_3_VV_dout,
-      nent_o4  => VMSME_L3PHIC17n1_nentries_4_VV_dout,
-      nent_o5  => VMSME_L3PHIC17n1_nentries_5_VV_dout,
-      nent_o6  => VMSME_L3PHIC17n1_nentries_6_VV_dout,
-      nent_o7  => VMSME_L3PHIC17n1_nentries_7_VV_dout
+      nent_o    => VMSME_L3PHIC17n1_nentries_VVV_dout
   );
 
 
   VMSME_L3PHIC18n1 : entity work.tf_mem_bin
     generic map (
       RAM_WIDTH       => 13,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -673,21 +528,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMSME_L3PHIC18n1_dataarray_data_V_readaddr,
       doutb     => VMSME_L3PHIC18n1_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMSME_L3PHIC18n1_nentries_0_VV_dout,
-      nent_o1  => VMSME_L3PHIC18n1_nentries_1_VV_dout,
-      nent_o2  => VMSME_L3PHIC18n1_nentries_2_VV_dout,
-      nent_o3  => VMSME_L3PHIC18n1_nentries_3_VV_dout,
-      nent_o4  => VMSME_L3PHIC18n1_nentries_4_VV_dout,
-      nent_o5  => VMSME_L3PHIC18n1_nentries_5_VV_dout,
-      nent_o6  => VMSME_L3PHIC18n1_nentries_6_VV_dout,
-      nent_o7  => VMSME_L3PHIC18n1_nentries_7_VV_dout
+      nent_o    => VMSME_L3PHIC18n1_nentries_VVV_dout
   );
 
 
   VMSME_L3PHIC19n1 : entity work.tf_mem_bin
     generic map (
       RAM_WIDTH       => 13,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -704,21 +552,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMSME_L3PHIC19n1_dataarray_data_V_readaddr,
       doutb     => VMSME_L3PHIC19n1_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMSME_L3PHIC19n1_nentries_0_VV_dout,
-      nent_o1  => VMSME_L3PHIC19n1_nentries_1_VV_dout,
-      nent_o2  => VMSME_L3PHIC19n1_nentries_2_VV_dout,
-      nent_o3  => VMSME_L3PHIC19n1_nentries_3_VV_dout,
-      nent_o4  => VMSME_L3PHIC19n1_nentries_4_VV_dout,
-      nent_o5  => VMSME_L3PHIC19n1_nentries_5_VV_dout,
-      nent_o6  => VMSME_L3PHIC19n1_nentries_6_VV_dout,
-      nent_o7  => VMSME_L3PHIC19n1_nentries_7_VV_dout
+      nent_o    => VMSME_L3PHIC19n1_nentries_VVV_dout
   );
 
 
   VMSME_L3PHIC20n1 : entity work.tf_mem_bin
     generic map (
       RAM_WIDTH       => 13,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -735,21 +576,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMSME_L3PHIC20n1_dataarray_data_V_readaddr,
       doutb     => VMSME_L3PHIC20n1_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMSME_L3PHIC20n1_nentries_0_VV_dout,
-      nent_o1  => VMSME_L3PHIC20n1_nentries_1_VV_dout,
-      nent_o2  => VMSME_L3PHIC20n1_nentries_2_VV_dout,
-      nent_o3  => VMSME_L3PHIC20n1_nentries_3_VV_dout,
-      nent_o4  => VMSME_L3PHIC20n1_nentries_4_VV_dout,
-      nent_o5  => VMSME_L3PHIC20n1_nentries_5_VV_dout,
-      nent_o6  => VMSME_L3PHIC20n1_nentries_6_VV_dout,
-      nent_o7  => VMSME_L3PHIC20n1_nentries_7_VV_dout
+      nent_o    => VMSME_L3PHIC20n1_nentries_VVV_dout
   );
 
 
   VMSME_L3PHIC21n1 : entity work.tf_mem_bin
     generic map (
       RAM_WIDTH       => 13,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -766,21 +600,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMSME_L3PHIC21n1_dataarray_data_V_readaddr,
       doutb     => VMSME_L3PHIC21n1_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMSME_L3PHIC21n1_nentries_0_VV_dout,
-      nent_o1  => VMSME_L3PHIC21n1_nentries_1_VV_dout,
-      nent_o2  => VMSME_L3PHIC21n1_nentries_2_VV_dout,
-      nent_o3  => VMSME_L3PHIC21n1_nentries_3_VV_dout,
-      nent_o4  => VMSME_L3PHIC21n1_nentries_4_VV_dout,
-      nent_o5  => VMSME_L3PHIC21n1_nentries_5_VV_dout,
-      nent_o6  => VMSME_L3PHIC21n1_nentries_6_VV_dout,
-      nent_o7  => VMSME_L3PHIC21n1_nentries_7_VV_dout
+      nent_o    => VMSME_L3PHIC21n1_nentries_VVV_dout
   );
 
 
   VMSME_L3PHIC22n1 : entity work.tf_mem_bin
     generic map (
       RAM_WIDTH       => 13,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -797,21 +624,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMSME_L3PHIC22n1_dataarray_data_V_readaddr,
       doutb     => VMSME_L3PHIC22n1_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMSME_L3PHIC22n1_nentries_0_VV_dout,
-      nent_o1  => VMSME_L3PHIC22n1_nentries_1_VV_dout,
-      nent_o2  => VMSME_L3PHIC22n1_nentries_2_VV_dout,
-      nent_o3  => VMSME_L3PHIC22n1_nentries_3_VV_dout,
-      nent_o4  => VMSME_L3PHIC22n1_nentries_4_VV_dout,
-      nent_o5  => VMSME_L3PHIC22n1_nentries_5_VV_dout,
-      nent_o6  => VMSME_L3PHIC22n1_nentries_6_VV_dout,
-      nent_o7  => VMSME_L3PHIC22n1_nentries_7_VV_dout
+      nent_o    => VMSME_L3PHIC22n1_nentries_VVV_dout
   );
 
 
   VMSME_L3PHIC23n1 : entity work.tf_mem_bin
     generic map (
       RAM_WIDTH       => 13,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -828,21 +648,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMSME_L3PHIC23n1_dataarray_data_V_readaddr,
       doutb     => VMSME_L3PHIC23n1_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMSME_L3PHIC23n1_nentries_0_VV_dout,
-      nent_o1  => VMSME_L3PHIC23n1_nentries_1_VV_dout,
-      nent_o2  => VMSME_L3PHIC23n1_nentries_2_VV_dout,
-      nent_o3  => VMSME_L3PHIC23n1_nentries_3_VV_dout,
-      nent_o4  => VMSME_L3PHIC23n1_nentries_4_VV_dout,
-      nent_o5  => VMSME_L3PHIC23n1_nentries_5_VV_dout,
-      nent_o6  => VMSME_L3PHIC23n1_nentries_6_VV_dout,
-      nent_o7  => VMSME_L3PHIC23n1_nentries_7_VV_dout
+      nent_o    => VMSME_L3PHIC23n1_nentries_VVV_dout
   );
 
 
   VMSME_L3PHIC24n1 : entity work.tf_mem_bin
     generic map (
       RAM_WIDTH       => 13,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -859,21 +672,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMSME_L3PHIC24n1_dataarray_data_V_readaddr,
       doutb     => VMSME_L3PHIC24n1_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMSME_L3PHIC24n1_nentries_0_VV_dout,
-      nent_o1  => VMSME_L3PHIC24n1_nentries_1_VV_dout,
-      nent_o2  => VMSME_L3PHIC24n1_nentries_2_VV_dout,
-      nent_o3  => VMSME_L3PHIC24n1_nentries_3_VV_dout,
-      nent_o4  => VMSME_L3PHIC24n1_nentries_4_VV_dout,
-      nent_o5  => VMSME_L3PHIC24n1_nentries_5_VV_dout,
-      nent_o6  => VMSME_L3PHIC24n1_nentries_6_VV_dout,
-      nent_o7  => VMSME_L3PHIC24n1_nentries_7_VV_dout
+      nent_o    => VMSME_L3PHIC24n1_nentries_VVV_dout
   );
 
 
   AS_L3PHICn6 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 36,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -890,21 +696,14 @@ architecture rtl of SectorProcessor is
       addrb     => AS_L3PHICn6_dataarray_data_V_readaddr,
       doutb     => AS_L3PHICn6_dataarray_data_V_dout,
       sync_nent => MatchCalculator_start,
-      nent_o0  => open,
-      nent_o1  => open,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => open
   );
 
 
   VMPROJ_L3PHIC17 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 21,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -921,21 +720,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMPROJ_L3PHIC17_dataarray_data_V_readaddr,
       doutb     => VMPROJ_L3PHIC17_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMPROJ_L3PHIC17_nentries_0_V_dout,
-      nent_o1  => VMPROJ_L3PHIC17_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => VMPROJ_L3PHIC17_nentries_VV_dout
   );
 
 
   VMPROJ_L3PHIC18 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 21,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -952,21 +744,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMPROJ_L3PHIC18_dataarray_data_V_readaddr,
       doutb     => VMPROJ_L3PHIC18_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMPROJ_L3PHIC18_nentries_0_V_dout,
-      nent_o1  => VMPROJ_L3PHIC18_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => VMPROJ_L3PHIC18_nentries_VV_dout
   );
 
 
   VMPROJ_L3PHIC19 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 21,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -983,21 +768,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMPROJ_L3PHIC19_dataarray_data_V_readaddr,
       doutb     => VMPROJ_L3PHIC19_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMPROJ_L3PHIC19_nentries_0_V_dout,
-      nent_o1  => VMPROJ_L3PHIC19_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => VMPROJ_L3PHIC19_nentries_VV_dout
   );
 
 
   VMPROJ_L3PHIC20 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 21,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1014,21 +792,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMPROJ_L3PHIC20_dataarray_data_V_readaddr,
       doutb     => VMPROJ_L3PHIC20_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMPROJ_L3PHIC20_nentries_0_V_dout,
-      nent_o1  => VMPROJ_L3PHIC20_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => VMPROJ_L3PHIC20_nentries_VV_dout
   );
 
 
   VMPROJ_L3PHIC21 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 21,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1045,21 +816,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMPROJ_L3PHIC21_dataarray_data_V_readaddr,
       doutb     => VMPROJ_L3PHIC21_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMPROJ_L3PHIC21_nentries_0_V_dout,
-      nent_o1  => VMPROJ_L3PHIC21_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => VMPROJ_L3PHIC21_nentries_VV_dout
   );
 
 
   VMPROJ_L3PHIC22 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 21,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1076,21 +840,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMPROJ_L3PHIC22_dataarray_data_V_readaddr,
       doutb     => VMPROJ_L3PHIC22_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMPROJ_L3PHIC22_nentries_0_V_dout,
-      nent_o1  => VMPROJ_L3PHIC22_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => VMPROJ_L3PHIC22_nentries_VV_dout
   );
 
 
   VMPROJ_L3PHIC23 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 21,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1107,21 +864,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMPROJ_L3PHIC23_dataarray_data_V_readaddr,
       doutb     => VMPROJ_L3PHIC23_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMPROJ_L3PHIC23_nentries_0_V_dout,
-      nent_o1  => VMPROJ_L3PHIC23_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => VMPROJ_L3PHIC23_nentries_VV_dout
   );
 
 
   VMPROJ_L3PHIC24 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 21,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1138,21 +888,14 @@ architecture rtl of SectorProcessor is
       addrb     => VMPROJ_L3PHIC24_dataarray_data_V_readaddr,
       doutb     => VMPROJ_L3PHIC24_dataarray_data_V_dout,
       sync_nent => MatchEngine_start,
-      nent_o0  => VMPROJ_L3PHIC24_nentries_0_V_dout,
-      nent_o1  => VMPROJ_L3PHIC24_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => VMPROJ_L3PHIC24_nentries_VV_dout
   );
 
 
   CM_L3PHIC17 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 14,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1169,21 +912,14 @@ architecture rtl of SectorProcessor is
       addrb     => CM_L3PHIC17_dataarray_data_V_readaddr,
       doutb     => CM_L3PHIC17_dataarray_data_V_dout,
       sync_nent => MatchCalculator_start,
-      nent_o0  => CM_L3PHIC17_nentries_0_V_dout,
-      nent_o1  => CM_L3PHIC17_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => CM_L3PHIC17_nentries_VV_dout
   );
 
 
   CM_L3PHIC18 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 14,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1200,21 +936,14 @@ architecture rtl of SectorProcessor is
       addrb     => CM_L3PHIC18_dataarray_data_V_readaddr,
       doutb     => CM_L3PHIC18_dataarray_data_V_dout,
       sync_nent => MatchCalculator_start,
-      nent_o0  => CM_L3PHIC18_nentries_0_V_dout,
-      nent_o1  => CM_L3PHIC18_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => CM_L3PHIC18_nentries_VV_dout
   );
 
 
   CM_L3PHIC19 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 14,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1231,21 +960,14 @@ architecture rtl of SectorProcessor is
       addrb     => CM_L3PHIC19_dataarray_data_V_readaddr,
       doutb     => CM_L3PHIC19_dataarray_data_V_dout,
       sync_nent => MatchCalculator_start,
-      nent_o0  => CM_L3PHIC19_nentries_0_V_dout,
-      nent_o1  => CM_L3PHIC19_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => CM_L3PHIC19_nentries_VV_dout
   );
 
 
   CM_L3PHIC20 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 14,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1262,21 +984,14 @@ architecture rtl of SectorProcessor is
       addrb     => CM_L3PHIC20_dataarray_data_V_readaddr,
       doutb     => CM_L3PHIC20_dataarray_data_V_dout,
       sync_nent => MatchCalculator_start,
-      nent_o0  => CM_L3PHIC20_nentries_0_V_dout,
-      nent_o1  => CM_L3PHIC20_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => CM_L3PHIC20_nentries_VV_dout
   );
 
 
   CM_L3PHIC21 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 14,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1293,21 +1008,14 @@ architecture rtl of SectorProcessor is
       addrb     => CM_L3PHIC21_dataarray_data_V_readaddr,
       doutb     => CM_L3PHIC21_dataarray_data_V_dout,
       sync_nent => MatchCalculator_start,
-      nent_o0  => CM_L3PHIC21_nentries_0_V_dout,
-      nent_o1  => CM_L3PHIC21_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => CM_L3PHIC21_nentries_VV_dout
   );
 
 
   CM_L3PHIC22 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 14,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1324,21 +1032,14 @@ architecture rtl of SectorProcessor is
       addrb     => CM_L3PHIC22_dataarray_data_V_readaddr,
       doutb     => CM_L3PHIC22_dataarray_data_V_dout,
       sync_nent => MatchCalculator_start,
-      nent_o0  => CM_L3PHIC22_nentries_0_V_dout,
-      nent_o1  => CM_L3PHIC22_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => CM_L3PHIC22_nentries_VV_dout
   );
 
 
   CM_L3PHIC23 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 14,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1355,21 +1056,14 @@ architecture rtl of SectorProcessor is
       addrb     => CM_L3PHIC23_dataarray_data_V_readaddr,
       doutb     => CM_L3PHIC23_dataarray_data_V_dout,
       sync_nent => MatchCalculator_start,
-      nent_o0  => CM_L3PHIC23_nentries_0_V_dout,
-      nent_o1  => CM_L3PHIC23_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => CM_L3PHIC23_nentries_VV_dout
   );
 
 
   CM_L3PHIC24 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 14,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1386,21 +1080,14 @@ architecture rtl of SectorProcessor is
       addrb     => CM_L3PHIC24_dataarray_data_V_readaddr,
       doutb     => CM_L3PHIC24_dataarray_data_V_dout,
       sync_nent => MatchCalculator_start,
-      nent_o0  => CM_L3PHIC24_nentries_0_V_dout,
-      nent_o1  => CM_L3PHIC24_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => CM_L3PHIC24_nentries_VV_dout
   );
 
 
   AP_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 60,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1417,21 +1104,14 @@ architecture rtl of SectorProcessor is
       addrb     => AP_L3PHIC_dataarray_data_V_readaddr,
       doutb     => AP_L3PHIC_dataarray_data_V_dout,
       sync_nent => MatchCalculator_start,
-      nent_o0  => open,
-      nent_o1  => open,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => open
   );
 
 
   FM_L1L2_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 45,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1448,21 +1128,14 @@ architecture rtl of SectorProcessor is
       addrb     => FM_L1L2_L3PHIC_dataarray_data_V_readaddr,
       doutb     => FM_L1L2_L3PHIC_dataarray_data_V_dout,
       sync_nent => MatchCalculator_done,
-      nent_o0  => FM_L1L2_L3PHIC_nentries_0_V_dout,
-      nent_o1  => FM_L1L2_L3PHIC_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => FM_L1L2_L3PHIC_nentries_VV_dout
   );
 
 
   FM_L5L6_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 45,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -1479,14 +1152,7 @@ architecture rtl of SectorProcessor is
       addrb     => FM_L5L6_L3PHIC_dataarray_data_V_readaddr,
       doutb     => FM_L5L6_L3PHIC_dataarray_data_V_dout,
       sync_nent => MatchCalculator_done,
-      nent_o0  => FM_L5L6_L3PHIC_nentries_0_V_dout,
-      nent_o1  => FM_L5L6_L3PHIC_nentries_1_V_dout,
-      nent_o2  => open,
-      nent_o3  => open,
-      nent_o4  => open,
-      nent_o5  => open,
-      nent_o6  => open,
-      nent_o7  => open
+      nent_o    => FM_L5L6_L3PHIC_nentries_VV_dout
   );
 
   process(ProjectionRouter_done)
@@ -1505,82 +1171,82 @@ architecture rtl of SectorProcessor is
       bx_V          => bx_in_ProjectionRouter,
       bx_o_V        => bx_out_ProjectionRouter,
       bx_o_V_ap_vld => bx_out_ProjectionRouter_vld,
-      projin_0_dataarray_data_V_ce0         => TPROJ_L1L2F_L3PHIC_dataarray_data_V_enb,
-      projin_0_dataarray_data_V_address0    => TPROJ_L1L2F_L3PHIC_dataarray_data_V_readaddr,
-      projin_0_dataarray_data_V_q0            => TPROJ_L1L2F_L3PHIC_dataarray_data_V_dout,
-      projin_0_nentries_0_V        => TPROJ_L1L2F_L3PHIC_nentries_0_V_dout,
-      projin_0_nentries_1_V        => TPROJ_L1L2F_L3PHIC_nentries_1_V_dout,
-      projin_1_dataarray_data_V_ce0         => TPROJ_L1L2G_L3PHIC_dataarray_data_V_enb,
-      projin_1_dataarray_data_V_address0    => TPROJ_L1L2G_L3PHIC_dataarray_data_V_readaddr,
-      projin_1_dataarray_data_V_q0            => TPROJ_L1L2G_L3PHIC_dataarray_data_V_dout,
-      projin_1_nentries_0_V        => TPROJ_L1L2G_L3PHIC_nentries_0_V_dout,
-      projin_1_nentries_1_V        => TPROJ_L1L2G_L3PHIC_nentries_1_V_dout,
-      projin_2_dataarray_data_V_ce0         => TPROJ_L1L2H_L3PHIC_dataarray_data_V_enb,
-      projin_2_dataarray_data_V_address0    => TPROJ_L1L2H_L3PHIC_dataarray_data_V_readaddr,
-      projin_2_dataarray_data_V_q0            => TPROJ_L1L2H_L3PHIC_dataarray_data_V_dout,
-      projin_2_nentries_0_V        => TPROJ_L1L2H_L3PHIC_nentries_0_V_dout,
-      projin_2_nentries_1_V        => TPROJ_L1L2H_L3PHIC_nentries_1_V_dout,
-      projin_3_dataarray_data_V_ce0         => TPROJ_L1L2I_L3PHIC_dataarray_data_V_enb,
-      projin_3_dataarray_data_V_address0    => TPROJ_L1L2I_L3PHIC_dataarray_data_V_readaddr,
-      projin_3_dataarray_data_V_q0            => TPROJ_L1L2I_L3PHIC_dataarray_data_V_dout,
-      projin_3_nentries_0_V        => TPROJ_L1L2I_L3PHIC_nentries_0_V_dout,
-      projin_3_nentries_1_V        => TPROJ_L1L2I_L3PHIC_nentries_1_V_dout,
-      projin_4_dataarray_data_V_ce0         => TPROJ_L1L2J_L3PHIC_dataarray_data_V_enb,
-      projin_4_dataarray_data_V_address0    => TPROJ_L1L2J_L3PHIC_dataarray_data_V_readaddr,
-      projin_4_dataarray_data_V_q0            => TPROJ_L1L2J_L3PHIC_dataarray_data_V_dout,
-      projin_4_nentries_0_V        => TPROJ_L1L2J_L3PHIC_nentries_0_V_dout,
-      projin_4_nentries_1_V        => TPROJ_L1L2J_L3PHIC_nentries_1_V_dout,
-      projin_5_dataarray_data_V_ce0         => TPROJ_L5L6B_L3PHIC_dataarray_data_V_enb,
-      projin_5_dataarray_data_V_address0    => TPROJ_L5L6B_L3PHIC_dataarray_data_V_readaddr,
-      projin_5_dataarray_data_V_q0            => TPROJ_L5L6B_L3PHIC_dataarray_data_V_dout,
-      projin_5_nentries_0_V        => TPROJ_L5L6B_L3PHIC_nentries_0_V_dout,
-      projin_5_nentries_1_V        => TPROJ_L5L6B_L3PHIC_nentries_1_V_dout,
-      projin_6_dataarray_data_V_ce0         => TPROJ_L5L6C_L3PHIC_dataarray_data_V_enb,
-      projin_6_dataarray_data_V_address0    => TPROJ_L5L6C_L3PHIC_dataarray_data_V_readaddr,
-      projin_6_dataarray_data_V_q0            => TPROJ_L5L6C_L3PHIC_dataarray_data_V_dout,
-      projin_6_nentries_0_V        => TPROJ_L5L6C_L3PHIC_nentries_0_V_dout,
-      projin_6_nentries_1_V        => TPROJ_L5L6C_L3PHIC_nentries_1_V_dout,
-      projin_7_dataarray_data_V_ce0         => TPROJ_L5L6D_L3PHIC_dataarray_data_V_enb,
-      projin_7_dataarray_data_V_address0    => TPROJ_L5L6D_L3PHIC_dataarray_data_V_readaddr,
-      projin_7_dataarray_data_V_q0            => TPROJ_L5L6D_L3PHIC_dataarray_data_V_dout,
-      projin_7_nentries_0_V        => TPROJ_L5L6D_L3PHIC_nentries_0_V_dout,
-      projin_7_nentries_1_V        => TPROJ_L5L6D_L3PHIC_nentries_1_V_dout,
-      allprojout_dataarray_data_V_ce0         => open,
-      allprojout_dataarray_data_V_we0         => AP_L3PHIC_dataarray_data_V_wea,
-      allprojout_dataarray_data_V_address0    => AP_L3PHIC_dataarray_data_V_writeaddr,
-      allprojout_dataarray_data_V_d0          => AP_L3PHIC_dataarray_data_V_din,
-      vmprojout_0_dataarray_data_V_ce0         => open,
-      vmprojout_0_dataarray_data_V_we0         => VMPROJ_L3PHIC17_dataarray_data_V_wea,
-      vmprojout_0_dataarray_data_V_address0    => VMPROJ_L3PHIC17_dataarray_data_V_writeaddr,
-      vmprojout_0_dataarray_data_V_d0          => VMPROJ_L3PHIC17_dataarray_data_V_din,
-      vmprojout_1_dataarray_data_V_ce0         => open,
-      vmprojout_1_dataarray_data_V_we0         => VMPROJ_L3PHIC18_dataarray_data_V_wea,
-      vmprojout_1_dataarray_data_V_address0    => VMPROJ_L3PHIC18_dataarray_data_V_writeaddr,
-      vmprojout_1_dataarray_data_V_d0          => VMPROJ_L3PHIC18_dataarray_data_V_din,
-      vmprojout_2_dataarray_data_V_ce0         => open,
-      vmprojout_2_dataarray_data_V_we0         => VMPROJ_L3PHIC19_dataarray_data_V_wea,
-      vmprojout_2_dataarray_data_V_address0    => VMPROJ_L3PHIC19_dataarray_data_V_writeaddr,
-      vmprojout_2_dataarray_data_V_d0          => VMPROJ_L3PHIC19_dataarray_data_V_din,
-      vmprojout_3_dataarray_data_V_ce0         => open,
-      vmprojout_3_dataarray_data_V_we0         => VMPROJ_L3PHIC20_dataarray_data_V_wea,
-      vmprojout_3_dataarray_data_V_address0    => VMPROJ_L3PHIC20_dataarray_data_V_writeaddr,
-      vmprojout_3_dataarray_data_V_d0          => VMPROJ_L3PHIC20_dataarray_data_V_din,
-      vmprojout_4_dataarray_data_V_ce0         => open,
-      vmprojout_4_dataarray_data_V_we0         => VMPROJ_L3PHIC21_dataarray_data_V_wea,
-      vmprojout_4_dataarray_data_V_address0    => VMPROJ_L3PHIC21_dataarray_data_V_writeaddr,
-      vmprojout_4_dataarray_data_V_d0          => VMPROJ_L3PHIC21_dataarray_data_V_din,
-      vmprojout_5_dataarray_data_V_ce0         => open,
-      vmprojout_5_dataarray_data_V_we0         => VMPROJ_L3PHIC22_dataarray_data_V_wea,
-      vmprojout_5_dataarray_data_V_address0    => VMPROJ_L3PHIC22_dataarray_data_V_writeaddr,
-      vmprojout_5_dataarray_data_V_d0          => VMPROJ_L3PHIC22_dataarray_data_V_din,
-      vmprojout_6_dataarray_data_V_ce0         => open,
-      vmprojout_6_dataarray_data_V_we0         => VMPROJ_L3PHIC23_dataarray_data_V_wea,
-      vmprojout_6_dataarray_data_V_address0    => VMPROJ_L3PHIC23_dataarray_data_V_writeaddr,
-      vmprojout_6_dataarray_data_V_d0          => VMPROJ_L3PHIC23_dataarray_data_V_din,
-      vmprojout_7_dataarray_data_V_ce0         => open,
-      vmprojout_7_dataarray_data_V_we0         => VMPROJ_L3PHIC24_dataarray_data_V_wea,
-      vmprojout_7_dataarray_data_V_address0    => VMPROJ_L3PHIC24_dataarray_data_V_writeaddr,
-      vmprojout_7_dataarray_data_V_d0          => VMPROJ_L3PHIC24_dataarray_data_V_din
+      projin_0_dataarray_data_V_ce0       => TPROJ_L1L2F_L3PHIC_dataarray_data_V_enb,
+      projin_0_dataarray_data_V_address0  => TPROJ_L1L2F_L3PHIC_dataarray_data_V_readaddr,
+      projin_0_dataarray_data_V_q0        => TPROJ_L1L2F_L3PHIC_dataarray_data_V_dout,
+      projin_0_nentries_0_V               => TPROJ_L1L2F_L3PHIC_nentries_VV_dout(0),
+      projin_0_nentries_1_V               => TPROJ_L1L2F_L3PHIC_nentries_VV_dout(1),
+      projin_1_dataarray_data_V_ce0       => TPROJ_L1L2G_L3PHIC_dataarray_data_V_enb,
+      projin_1_dataarray_data_V_address0  => TPROJ_L1L2G_L3PHIC_dataarray_data_V_readaddr,
+      projin_1_dataarray_data_V_q0        => TPROJ_L1L2G_L3PHIC_dataarray_data_V_dout,
+      projin_1_nentries_0_V               => TPROJ_L1L2G_L3PHIC_nentries_VV_dout(0),
+      projin_1_nentries_1_V               => TPROJ_L1L2G_L3PHIC_nentries_VV_dout(1),
+      projin_2_dataarray_data_V_ce0       => TPROJ_L1L2H_L3PHIC_dataarray_data_V_enb,
+      projin_2_dataarray_data_V_address0  => TPROJ_L1L2H_L3PHIC_dataarray_data_V_readaddr,
+      projin_2_dataarray_data_V_q0        => TPROJ_L1L2H_L3PHIC_dataarray_data_V_dout,
+      projin_2_nentries_0_V               => TPROJ_L1L2H_L3PHIC_nentries_VV_dout(0),
+      projin_2_nentries_1_V               => TPROJ_L1L2H_L3PHIC_nentries_VV_dout(1),
+      projin_3_dataarray_data_V_ce0       => TPROJ_L1L2I_L3PHIC_dataarray_data_V_enb,
+      projin_3_dataarray_data_V_address0  => TPROJ_L1L2I_L3PHIC_dataarray_data_V_readaddr,
+      projin_3_dataarray_data_V_q0        => TPROJ_L1L2I_L3PHIC_dataarray_data_V_dout,
+      projin_3_nentries_0_V               => TPROJ_L1L2I_L3PHIC_nentries_VV_dout(0),
+      projin_3_nentries_1_V               => TPROJ_L1L2I_L3PHIC_nentries_VV_dout(1),
+      projin_4_dataarray_data_V_ce0       => TPROJ_L1L2J_L3PHIC_dataarray_data_V_enb,
+      projin_4_dataarray_data_V_address0  => TPROJ_L1L2J_L3PHIC_dataarray_data_V_readaddr,
+      projin_4_dataarray_data_V_q0        => TPROJ_L1L2J_L3PHIC_dataarray_data_V_dout,
+      projin_4_nentries_0_V               => TPROJ_L1L2J_L3PHIC_nentries_VV_dout(0),
+      projin_4_nentries_1_V               => TPROJ_L1L2J_L3PHIC_nentries_VV_dout(1),
+      projin_5_dataarray_data_V_ce0       => TPROJ_L5L6B_L3PHIC_dataarray_data_V_enb,
+      projin_5_dataarray_data_V_address0  => TPROJ_L5L6B_L3PHIC_dataarray_data_V_readaddr,
+      projin_5_dataarray_data_V_q0        => TPROJ_L5L6B_L3PHIC_dataarray_data_V_dout,
+      projin_5_nentries_0_V               => TPROJ_L5L6B_L3PHIC_nentries_VV_dout(0),
+      projin_5_nentries_1_V               => TPROJ_L5L6B_L3PHIC_nentries_VV_dout(1),
+      projin_6_dataarray_data_V_ce0       => TPROJ_L5L6C_L3PHIC_dataarray_data_V_enb,
+      projin_6_dataarray_data_V_address0  => TPROJ_L5L6C_L3PHIC_dataarray_data_V_readaddr,
+      projin_6_dataarray_data_V_q0        => TPROJ_L5L6C_L3PHIC_dataarray_data_V_dout,
+      projin_6_nentries_0_V               => TPROJ_L5L6C_L3PHIC_nentries_VV_dout(0),
+      projin_6_nentries_1_V               => TPROJ_L5L6C_L3PHIC_nentries_VV_dout(1),
+      projin_7_dataarray_data_V_ce0       => TPROJ_L5L6D_L3PHIC_dataarray_data_V_enb,
+      projin_7_dataarray_data_V_address0  => TPROJ_L5L6D_L3PHIC_dataarray_data_V_readaddr,
+      projin_7_dataarray_data_V_q0        => TPROJ_L5L6D_L3PHIC_dataarray_data_V_dout,
+      projin_7_nentries_0_V               => TPROJ_L5L6D_L3PHIC_nentries_VV_dout(0),
+      projin_7_nentries_1_V               => TPROJ_L5L6D_L3PHIC_nentries_VV_dout(1),
+      allprojout_dataarray_data_V_ce0       => open,
+      allprojout_dataarray_data_V_we0       => AP_L3PHIC_dataarray_data_V_wea,
+      allprojout_dataarray_data_V_address0  => AP_L3PHIC_dataarray_data_V_writeaddr,
+      allprojout_dataarray_data_V_d0        => AP_L3PHIC_dataarray_data_V_din,
+      vmprojout_0_dataarray_data_V_ce0       => open,
+      vmprojout_0_dataarray_data_V_we0       => VMPROJ_L3PHIC17_dataarray_data_V_wea,
+      vmprojout_0_dataarray_data_V_address0  => VMPROJ_L3PHIC17_dataarray_data_V_writeaddr,
+      vmprojout_0_dataarray_data_V_d0        => VMPROJ_L3PHIC17_dataarray_data_V_din,
+      vmprojout_1_dataarray_data_V_ce0       => open,
+      vmprojout_1_dataarray_data_V_we0       => VMPROJ_L3PHIC18_dataarray_data_V_wea,
+      vmprojout_1_dataarray_data_V_address0  => VMPROJ_L3PHIC18_dataarray_data_V_writeaddr,
+      vmprojout_1_dataarray_data_V_d0        => VMPROJ_L3PHIC18_dataarray_data_V_din,
+      vmprojout_2_dataarray_data_V_ce0       => open,
+      vmprojout_2_dataarray_data_V_we0       => VMPROJ_L3PHIC19_dataarray_data_V_wea,
+      vmprojout_2_dataarray_data_V_address0  => VMPROJ_L3PHIC19_dataarray_data_V_writeaddr,
+      vmprojout_2_dataarray_data_V_d0        => VMPROJ_L3PHIC19_dataarray_data_V_din,
+      vmprojout_3_dataarray_data_V_ce0       => open,
+      vmprojout_3_dataarray_data_V_we0       => VMPROJ_L3PHIC20_dataarray_data_V_wea,
+      vmprojout_3_dataarray_data_V_address0  => VMPROJ_L3PHIC20_dataarray_data_V_writeaddr,
+      vmprojout_3_dataarray_data_V_d0        => VMPROJ_L3PHIC20_dataarray_data_V_din,
+      vmprojout_4_dataarray_data_V_ce0       => open,
+      vmprojout_4_dataarray_data_V_we0       => VMPROJ_L3PHIC21_dataarray_data_V_wea,
+      vmprojout_4_dataarray_data_V_address0  => VMPROJ_L3PHIC21_dataarray_data_V_writeaddr,
+      vmprojout_4_dataarray_data_V_d0        => VMPROJ_L3PHIC21_dataarray_data_V_din,
+      vmprojout_5_dataarray_data_V_ce0       => open,
+      vmprojout_5_dataarray_data_V_we0       => VMPROJ_L3PHIC22_dataarray_data_V_wea,
+      vmprojout_5_dataarray_data_V_address0  => VMPROJ_L3PHIC22_dataarray_data_V_writeaddr,
+      vmprojout_5_dataarray_data_V_d0        => VMPROJ_L3PHIC22_dataarray_data_V_din,
+      vmprojout_6_dataarray_data_V_ce0       => open,
+      vmprojout_6_dataarray_data_V_we0       => VMPROJ_L3PHIC23_dataarray_data_V_wea,
+      vmprojout_6_dataarray_data_V_address0  => VMPROJ_L3PHIC23_dataarray_data_V_writeaddr,
+      vmprojout_6_dataarray_data_V_d0        => VMPROJ_L3PHIC23_dataarray_data_V_din,
+      vmprojout_7_dataarray_data_V_ce0       => open,
+      vmprojout_7_dataarray_data_V_we0       => VMPROJ_L3PHIC24_dataarray_data_V_wea,
+      vmprojout_7_dataarray_data_V_address0  => VMPROJ_L3PHIC24_dataarray_data_V_writeaddr,
+      vmprojout_7_dataarray_data_V_d0        => VMPROJ_L3PHIC24_dataarray_data_V_din
   );
 
 
@@ -1600,82 +1266,82 @@ architecture rtl of SectorProcessor is
       bx_V          => bx_out_ProjectionRouter,
       bx_o_V        => bx_out_MatchEngine,
       bx_o_V_ap_vld => bx_out_MatchEngine_vld,
-      inputStubData_dataarray_data_V_ce0         => VMSME_L3PHIC17n1_dataarray_data_V_enb,
-      inputStubData_dataarray_data_V_address0    => VMSME_L3PHIC17n1_dataarray_data_V_readaddr,
-      inputStubData_dataarray_data_V_q0            => VMSME_L3PHIC17n1_dataarray_data_V_dout,
-      inputStubData_nentries_0_V_0        => VMSME_L3PHIC17n1_nentries_0_VV_dout(0),
-      inputStubData_nentries_0_V_1        => VMSME_L3PHIC17n1_nentries_0_VV_dout(1),
-      inputStubData_nentries_0_V_2        => VMSME_L3PHIC17n1_nentries_0_VV_dout(2),
-      inputStubData_nentries_0_V_3        => VMSME_L3PHIC17n1_nentries_0_VV_dout(3),
-      inputStubData_nentries_0_V_4        => VMSME_L3PHIC17n1_nentries_0_VV_dout(4),
-      inputStubData_nentries_0_V_5        => VMSME_L3PHIC17n1_nentries_0_VV_dout(5),
-      inputStubData_nentries_0_V_6        => VMSME_L3PHIC17n1_nentries_0_VV_dout(6),
-      inputStubData_nentries_0_V_7        => VMSME_L3PHIC17n1_nentries_0_VV_dout(7),
-      inputStubData_nentries_1_V_0        => VMSME_L3PHIC17n1_nentries_1_VV_dout(0),
-      inputStubData_nentries_1_V_1        => VMSME_L3PHIC17n1_nentries_1_VV_dout(1),
-      inputStubData_nentries_1_V_2        => VMSME_L3PHIC17n1_nentries_1_VV_dout(2),
-      inputStubData_nentries_1_V_3        => VMSME_L3PHIC17n1_nentries_1_VV_dout(3),
-      inputStubData_nentries_1_V_4        => VMSME_L3PHIC17n1_nentries_1_VV_dout(4),
-      inputStubData_nentries_1_V_5        => VMSME_L3PHIC17n1_nentries_1_VV_dout(5),
-      inputStubData_nentries_1_V_6        => VMSME_L3PHIC17n1_nentries_1_VV_dout(6),
-      inputStubData_nentries_1_V_7        => VMSME_L3PHIC17n1_nentries_1_VV_dout(7),
-      inputStubData_nentries_2_V_0        => VMSME_L3PHIC17n1_nentries_2_VV_dout(0),
-      inputStubData_nentries_2_V_1        => VMSME_L3PHIC17n1_nentries_2_VV_dout(1),
-      inputStubData_nentries_2_V_2        => VMSME_L3PHIC17n1_nentries_2_VV_dout(2),
-      inputStubData_nentries_2_V_3        => VMSME_L3PHIC17n1_nentries_2_VV_dout(3),
-      inputStubData_nentries_2_V_4        => VMSME_L3PHIC17n1_nentries_2_VV_dout(4),
-      inputStubData_nentries_2_V_5        => VMSME_L3PHIC17n1_nentries_2_VV_dout(5),
-      inputStubData_nentries_2_V_6        => VMSME_L3PHIC17n1_nentries_2_VV_dout(6),
-      inputStubData_nentries_2_V_7        => VMSME_L3PHIC17n1_nentries_2_VV_dout(7),
-      inputStubData_nentries_3_V_0        => VMSME_L3PHIC17n1_nentries_3_VV_dout(0),
-      inputStubData_nentries_3_V_1        => VMSME_L3PHIC17n1_nentries_3_VV_dout(1),
-      inputStubData_nentries_3_V_2        => VMSME_L3PHIC17n1_nentries_3_VV_dout(2),
-      inputStubData_nentries_3_V_3        => VMSME_L3PHIC17n1_nentries_3_VV_dout(3),
-      inputStubData_nentries_3_V_4        => VMSME_L3PHIC17n1_nentries_3_VV_dout(4),
-      inputStubData_nentries_3_V_5        => VMSME_L3PHIC17n1_nentries_3_VV_dout(5),
-      inputStubData_nentries_3_V_6        => VMSME_L3PHIC17n1_nentries_3_VV_dout(6),
-      inputStubData_nentries_3_V_7        => VMSME_L3PHIC17n1_nentries_3_VV_dout(7),
-      inputStubData_nentries_4_V_0        => VMSME_L3PHIC17n1_nentries_4_VV_dout(0),
-      inputStubData_nentries_4_V_1        => VMSME_L3PHIC17n1_nentries_4_VV_dout(1),
-      inputStubData_nentries_4_V_2        => VMSME_L3PHIC17n1_nentries_4_VV_dout(2),
-      inputStubData_nentries_4_V_3        => VMSME_L3PHIC17n1_nentries_4_VV_dout(3),
-      inputStubData_nentries_4_V_4        => VMSME_L3PHIC17n1_nentries_4_VV_dout(4),
-      inputStubData_nentries_4_V_5        => VMSME_L3PHIC17n1_nentries_4_VV_dout(5),
-      inputStubData_nentries_4_V_6        => VMSME_L3PHIC17n1_nentries_4_VV_dout(6),
-      inputStubData_nentries_4_V_7        => VMSME_L3PHIC17n1_nentries_4_VV_dout(7),
-      inputStubData_nentries_5_V_0        => VMSME_L3PHIC17n1_nentries_5_VV_dout(0),
-      inputStubData_nentries_5_V_1        => VMSME_L3PHIC17n1_nentries_5_VV_dout(1),
-      inputStubData_nentries_5_V_2        => VMSME_L3PHIC17n1_nentries_5_VV_dout(2),
-      inputStubData_nentries_5_V_3        => VMSME_L3PHIC17n1_nentries_5_VV_dout(3),
-      inputStubData_nentries_5_V_4        => VMSME_L3PHIC17n1_nentries_5_VV_dout(4),
-      inputStubData_nentries_5_V_5        => VMSME_L3PHIC17n1_nentries_5_VV_dout(5),
-      inputStubData_nentries_5_V_6        => VMSME_L3PHIC17n1_nentries_5_VV_dout(6),
-      inputStubData_nentries_5_V_7        => VMSME_L3PHIC17n1_nentries_5_VV_dout(7),
-      inputStubData_nentries_6_V_0        => VMSME_L3PHIC17n1_nentries_6_VV_dout(0),
-      inputStubData_nentries_6_V_1        => VMSME_L3PHIC17n1_nentries_6_VV_dout(1),
-      inputStubData_nentries_6_V_2        => VMSME_L3PHIC17n1_nentries_6_VV_dout(2),
-      inputStubData_nentries_6_V_3        => VMSME_L3PHIC17n1_nentries_6_VV_dout(3),
-      inputStubData_nentries_6_V_4        => VMSME_L3PHIC17n1_nentries_6_VV_dout(4),
-      inputStubData_nentries_6_V_5        => VMSME_L3PHIC17n1_nentries_6_VV_dout(5),
-      inputStubData_nentries_6_V_6        => VMSME_L3PHIC17n1_nentries_6_VV_dout(6),
-      inputStubData_nentries_6_V_7        => VMSME_L3PHIC17n1_nentries_6_VV_dout(7),
-      inputStubData_nentries_7_V_0        => VMSME_L3PHIC17n1_nentries_7_VV_dout(0),
-      inputStubData_nentries_7_V_1        => VMSME_L3PHIC17n1_nentries_7_VV_dout(1),
-      inputStubData_nentries_7_V_2        => VMSME_L3PHIC17n1_nentries_7_VV_dout(2),
-      inputStubData_nentries_7_V_3        => VMSME_L3PHIC17n1_nentries_7_VV_dout(3),
-      inputStubData_nentries_7_V_4        => VMSME_L3PHIC17n1_nentries_7_VV_dout(4),
-      inputStubData_nentries_7_V_5        => VMSME_L3PHIC17n1_nentries_7_VV_dout(5),
-      inputStubData_nentries_7_V_6        => VMSME_L3PHIC17n1_nentries_7_VV_dout(6),
-      inputStubData_nentries_7_V_7        => VMSME_L3PHIC17n1_nentries_7_VV_dout(7),
-      inputProjectionData_dataarray_data_V_ce0         => VMPROJ_L3PHIC17_dataarray_data_V_enb,
-      inputProjectionData_dataarray_data_V_address0    => VMPROJ_L3PHIC17_dataarray_data_V_readaddr,
-      inputProjectionData_dataarray_data_V_q0            => VMPROJ_L3PHIC17_dataarray_data_V_dout,
-      inputProjectionData_nentries_0_V        => VMPROJ_L3PHIC17_nentries_0_V_dout,
-      inputProjectionData_nentries_1_V        => VMPROJ_L3PHIC17_nentries_1_V_dout,
-      outputCandidateMatch_dataarray_data_V_ce0         => open,
-      outputCandidateMatch_dataarray_data_V_we0         => CM_L3PHIC17_dataarray_data_V_wea,
-      outputCandidateMatch_dataarray_data_V_address0    => CM_L3PHIC17_dataarray_data_V_writeaddr,
-      outputCandidateMatch_dataarray_data_V_d0          => CM_L3PHIC17_dataarray_data_V_din
+      inputStubData_dataarray_data_V_ce0       => VMSME_L3PHIC17n1_dataarray_data_V_enb,
+      inputStubData_dataarray_data_V_address0  => VMSME_L3PHIC17n1_dataarray_data_V_readaddr,
+      inputStubData_dataarray_data_V_q0        => VMSME_L3PHIC17n1_dataarray_data_V_dout,
+      inputStubData_nentries_0_V_0     => VMSME_L3PHIC17n1_nentries_VVV_dout(0)(0),
+      inputStubData_nentries_0_V_1     => VMSME_L3PHIC17n1_nentries_VVV_dout(0)(1),
+      inputStubData_nentries_0_V_2     => VMSME_L3PHIC17n1_nentries_VVV_dout(0)(2),
+      inputStubData_nentries_0_V_3     => VMSME_L3PHIC17n1_nentries_VVV_dout(0)(3),
+      inputStubData_nentries_0_V_4     => VMSME_L3PHIC17n1_nentries_VVV_dout(0)(4),
+      inputStubData_nentries_0_V_5     => VMSME_L3PHIC17n1_nentries_VVV_dout(0)(5),
+      inputStubData_nentries_0_V_6     => VMSME_L3PHIC17n1_nentries_VVV_dout(0)(6),
+      inputStubData_nentries_0_V_7     => VMSME_L3PHIC17n1_nentries_VVV_dout(0)(7),
+      inputStubData_nentries_1_V_0     => VMSME_L3PHIC17n1_nentries_VVV_dout(1)(0),
+      inputStubData_nentries_1_V_1     => VMSME_L3PHIC17n1_nentries_VVV_dout(1)(1),
+      inputStubData_nentries_1_V_2     => VMSME_L3PHIC17n1_nentries_VVV_dout(1)(2),
+      inputStubData_nentries_1_V_3     => VMSME_L3PHIC17n1_nentries_VVV_dout(1)(3),
+      inputStubData_nentries_1_V_4     => VMSME_L3PHIC17n1_nentries_VVV_dout(1)(4),
+      inputStubData_nentries_1_V_5     => VMSME_L3PHIC17n1_nentries_VVV_dout(1)(5),
+      inputStubData_nentries_1_V_6     => VMSME_L3PHIC17n1_nentries_VVV_dout(1)(6),
+      inputStubData_nentries_1_V_7     => VMSME_L3PHIC17n1_nentries_VVV_dout(1)(7),
+      inputStubData_nentries_2_V_0     => VMSME_L3PHIC17n1_nentries_VVV_dout(2)(0),
+      inputStubData_nentries_2_V_1     => VMSME_L3PHIC17n1_nentries_VVV_dout(2)(1),
+      inputStubData_nentries_2_V_2     => VMSME_L3PHIC17n1_nentries_VVV_dout(2)(2),
+      inputStubData_nentries_2_V_3     => VMSME_L3PHIC17n1_nentries_VVV_dout(2)(3),
+      inputStubData_nentries_2_V_4     => VMSME_L3PHIC17n1_nentries_VVV_dout(2)(4),
+      inputStubData_nentries_2_V_5     => VMSME_L3PHIC17n1_nentries_VVV_dout(2)(5),
+      inputStubData_nentries_2_V_6     => VMSME_L3PHIC17n1_nentries_VVV_dout(2)(6),
+      inputStubData_nentries_2_V_7     => VMSME_L3PHIC17n1_nentries_VVV_dout(2)(7),
+      inputStubData_nentries_3_V_0     => VMSME_L3PHIC17n1_nentries_VVV_dout(3)(0),
+      inputStubData_nentries_3_V_1     => VMSME_L3PHIC17n1_nentries_VVV_dout(3)(1),
+      inputStubData_nentries_3_V_2     => VMSME_L3PHIC17n1_nentries_VVV_dout(3)(2),
+      inputStubData_nentries_3_V_3     => VMSME_L3PHIC17n1_nentries_VVV_dout(3)(3),
+      inputStubData_nentries_3_V_4     => VMSME_L3PHIC17n1_nentries_VVV_dout(3)(4),
+      inputStubData_nentries_3_V_5     => VMSME_L3PHIC17n1_nentries_VVV_dout(3)(5),
+      inputStubData_nentries_3_V_6     => VMSME_L3PHIC17n1_nentries_VVV_dout(3)(6),
+      inputStubData_nentries_3_V_7     => VMSME_L3PHIC17n1_nentries_VVV_dout(3)(7),
+      inputStubData_nentries_4_V_0     => VMSME_L3PHIC17n1_nentries_VVV_dout(4)(0),
+      inputStubData_nentries_4_V_1     => VMSME_L3PHIC17n1_nentries_VVV_dout(4)(1),
+      inputStubData_nentries_4_V_2     => VMSME_L3PHIC17n1_nentries_VVV_dout(4)(2),
+      inputStubData_nentries_4_V_3     => VMSME_L3PHIC17n1_nentries_VVV_dout(4)(3),
+      inputStubData_nentries_4_V_4     => VMSME_L3PHIC17n1_nentries_VVV_dout(4)(4),
+      inputStubData_nentries_4_V_5     => VMSME_L3PHIC17n1_nentries_VVV_dout(4)(5),
+      inputStubData_nentries_4_V_6     => VMSME_L3PHIC17n1_nentries_VVV_dout(4)(6),
+      inputStubData_nentries_4_V_7     => VMSME_L3PHIC17n1_nentries_VVV_dout(4)(7),
+      inputStubData_nentries_5_V_0     => VMSME_L3PHIC17n1_nentries_VVV_dout(5)(0),
+      inputStubData_nentries_5_V_1     => VMSME_L3PHIC17n1_nentries_VVV_dout(5)(1),
+      inputStubData_nentries_5_V_2     => VMSME_L3PHIC17n1_nentries_VVV_dout(5)(2),
+      inputStubData_nentries_5_V_3     => VMSME_L3PHIC17n1_nentries_VVV_dout(5)(3),
+      inputStubData_nentries_5_V_4     => VMSME_L3PHIC17n1_nentries_VVV_dout(5)(4),
+      inputStubData_nentries_5_V_5     => VMSME_L3PHIC17n1_nentries_VVV_dout(5)(5),
+      inputStubData_nentries_5_V_6     => VMSME_L3PHIC17n1_nentries_VVV_dout(5)(6),
+      inputStubData_nentries_5_V_7     => VMSME_L3PHIC17n1_nentries_VVV_dout(5)(7),
+      inputStubData_nentries_6_V_0     => VMSME_L3PHIC17n1_nentries_VVV_dout(6)(0),
+      inputStubData_nentries_6_V_1     => VMSME_L3PHIC17n1_nentries_VVV_dout(6)(1),
+      inputStubData_nentries_6_V_2     => VMSME_L3PHIC17n1_nentries_VVV_dout(6)(2),
+      inputStubData_nentries_6_V_3     => VMSME_L3PHIC17n1_nentries_VVV_dout(6)(3),
+      inputStubData_nentries_6_V_4     => VMSME_L3PHIC17n1_nentries_VVV_dout(6)(4),
+      inputStubData_nentries_6_V_5     => VMSME_L3PHIC17n1_nentries_VVV_dout(6)(5),
+      inputStubData_nentries_6_V_6     => VMSME_L3PHIC17n1_nentries_VVV_dout(6)(6),
+      inputStubData_nentries_6_V_7     => VMSME_L3PHIC17n1_nentries_VVV_dout(6)(7),
+      inputStubData_nentries_7_V_0     => VMSME_L3PHIC17n1_nentries_VVV_dout(7)(0),
+      inputStubData_nentries_7_V_1     => VMSME_L3PHIC17n1_nentries_VVV_dout(7)(1),
+      inputStubData_nentries_7_V_2     => VMSME_L3PHIC17n1_nentries_VVV_dout(7)(2),
+      inputStubData_nentries_7_V_3     => VMSME_L3PHIC17n1_nentries_VVV_dout(7)(3),
+      inputStubData_nentries_7_V_4     => VMSME_L3PHIC17n1_nentries_VVV_dout(7)(4),
+      inputStubData_nentries_7_V_5     => VMSME_L3PHIC17n1_nentries_VVV_dout(7)(5),
+      inputStubData_nentries_7_V_6     => VMSME_L3PHIC17n1_nentries_VVV_dout(7)(6),
+      inputStubData_nentries_7_V_7     => VMSME_L3PHIC17n1_nentries_VVV_dout(7)(7),
+      inputProjectionData_dataarray_data_V_ce0       => VMPROJ_L3PHIC17_dataarray_data_V_enb,
+      inputProjectionData_dataarray_data_V_address0  => VMPROJ_L3PHIC17_dataarray_data_V_readaddr,
+      inputProjectionData_dataarray_data_V_q0        => VMPROJ_L3PHIC17_dataarray_data_V_dout,
+      inputProjectionData_nentries_0_V               => VMPROJ_L3PHIC17_nentries_VV_dout(0),
+      inputProjectionData_nentries_1_V               => VMPROJ_L3PHIC17_nentries_VV_dout(1),
+      outputCandidateMatch_dataarray_data_V_ce0       => open,
+      outputCandidateMatch_dataarray_data_V_we0       => CM_L3PHIC17_dataarray_data_V_wea,
+      outputCandidateMatch_dataarray_data_V_address0  => CM_L3PHIC17_dataarray_data_V_writeaddr,
+      outputCandidateMatch_dataarray_data_V_d0        => CM_L3PHIC17_dataarray_data_V_din
   );
 
 
@@ -1688,82 +1354,82 @@ architecture rtl of SectorProcessor is
       ap_ready => open,
       ap_done  => open,
       bx_V          => bx_out_ProjectionRouter,
-      inputStubData_dataarray_data_V_ce0         => VMSME_L3PHIC18n1_dataarray_data_V_enb,
-      inputStubData_dataarray_data_V_address0    => VMSME_L3PHIC18n1_dataarray_data_V_readaddr,
-      inputStubData_dataarray_data_V_q0            => VMSME_L3PHIC18n1_dataarray_data_V_dout,
-      inputStubData_nentries_0_V_0        => VMSME_L3PHIC18n1_nentries_0_VV_dout(0),
-      inputStubData_nentries_0_V_1        => VMSME_L3PHIC18n1_nentries_0_VV_dout(1),
-      inputStubData_nentries_0_V_2        => VMSME_L3PHIC18n1_nentries_0_VV_dout(2),
-      inputStubData_nentries_0_V_3        => VMSME_L3PHIC18n1_nentries_0_VV_dout(3),
-      inputStubData_nentries_0_V_4        => VMSME_L3PHIC18n1_nentries_0_VV_dout(4),
-      inputStubData_nentries_0_V_5        => VMSME_L3PHIC18n1_nentries_0_VV_dout(5),
-      inputStubData_nentries_0_V_6        => VMSME_L3PHIC18n1_nentries_0_VV_dout(6),
-      inputStubData_nentries_0_V_7        => VMSME_L3PHIC18n1_nentries_0_VV_dout(7),
-      inputStubData_nentries_1_V_0        => VMSME_L3PHIC18n1_nentries_1_VV_dout(0),
-      inputStubData_nentries_1_V_1        => VMSME_L3PHIC18n1_nentries_1_VV_dout(1),
-      inputStubData_nentries_1_V_2        => VMSME_L3PHIC18n1_nentries_1_VV_dout(2),
-      inputStubData_nentries_1_V_3        => VMSME_L3PHIC18n1_nentries_1_VV_dout(3),
-      inputStubData_nentries_1_V_4        => VMSME_L3PHIC18n1_nentries_1_VV_dout(4),
-      inputStubData_nentries_1_V_5        => VMSME_L3PHIC18n1_nentries_1_VV_dout(5),
-      inputStubData_nentries_1_V_6        => VMSME_L3PHIC18n1_nentries_1_VV_dout(6),
-      inputStubData_nentries_1_V_7        => VMSME_L3PHIC18n1_nentries_1_VV_dout(7),
-      inputStubData_nentries_2_V_0        => VMSME_L3PHIC18n1_nentries_2_VV_dout(0),
-      inputStubData_nentries_2_V_1        => VMSME_L3PHIC18n1_nentries_2_VV_dout(1),
-      inputStubData_nentries_2_V_2        => VMSME_L3PHIC18n1_nentries_2_VV_dout(2),
-      inputStubData_nentries_2_V_3        => VMSME_L3PHIC18n1_nentries_2_VV_dout(3),
-      inputStubData_nentries_2_V_4        => VMSME_L3PHIC18n1_nentries_2_VV_dout(4),
-      inputStubData_nentries_2_V_5        => VMSME_L3PHIC18n1_nentries_2_VV_dout(5),
-      inputStubData_nentries_2_V_6        => VMSME_L3PHIC18n1_nentries_2_VV_dout(6),
-      inputStubData_nentries_2_V_7        => VMSME_L3PHIC18n1_nentries_2_VV_dout(7),
-      inputStubData_nentries_3_V_0        => VMSME_L3PHIC18n1_nentries_3_VV_dout(0),
-      inputStubData_nentries_3_V_1        => VMSME_L3PHIC18n1_nentries_3_VV_dout(1),
-      inputStubData_nentries_3_V_2        => VMSME_L3PHIC18n1_nentries_3_VV_dout(2),
-      inputStubData_nentries_3_V_3        => VMSME_L3PHIC18n1_nentries_3_VV_dout(3),
-      inputStubData_nentries_3_V_4        => VMSME_L3PHIC18n1_nentries_3_VV_dout(4),
-      inputStubData_nentries_3_V_5        => VMSME_L3PHIC18n1_nentries_3_VV_dout(5),
-      inputStubData_nentries_3_V_6        => VMSME_L3PHIC18n1_nentries_3_VV_dout(6),
-      inputStubData_nentries_3_V_7        => VMSME_L3PHIC18n1_nentries_3_VV_dout(7),
-      inputStubData_nentries_4_V_0        => VMSME_L3PHIC18n1_nentries_4_VV_dout(0),
-      inputStubData_nentries_4_V_1        => VMSME_L3PHIC18n1_nentries_4_VV_dout(1),
-      inputStubData_nentries_4_V_2        => VMSME_L3PHIC18n1_nentries_4_VV_dout(2),
-      inputStubData_nentries_4_V_3        => VMSME_L3PHIC18n1_nentries_4_VV_dout(3),
-      inputStubData_nentries_4_V_4        => VMSME_L3PHIC18n1_nentries_4_VV_dout(4),
-      inputStubData_nentries_4_V_5        => VMSME_L3PHIC18n1_nentries_4_VV_dout(5),
-      inputStubData_nentries_4_V_6        => VMSME_L3PHIC18n1_nentries_4_VV_dout(6),
-      inputStubData_nentries_4_V_7        => VMSME_L3PHIC18n1_nentries_4_VV_dout(7),
-      inputStubData_nentries_5_V_0        => VMSME_L3PHIC18n1_nentries_5_VV_dout(0),
-      inputStubData_nentries_5_V_1        => VMSME_L3PHIC18n1_nentries_5_VV_dout(1),
-      inputStubData_nentries_5_V_2        => VMSME_L3PHIC18n1_nentries_5_VV_dout(2),
-      inputStubData_nentries_5_V_3        => VMSME_L3PHIC18n1_nentries_5_VV_dout(3),
-      inputStubData_nentries_5_V_4        => VMSME_L3PHIC18n1_nentries_5_VV_dout(4),
-      inputStubData_nentries_5_V_5        => VMSME_L3PHIC18n1_nentries_5_VV_dout(5),
-      inputStubData_nentries_5_V_6        => VMSME_L3PHIC18n1_nentries_5_VV_dout(6),
-      inputStubData_nentries_5_V_7        => VMSME_L3PHIC18n1_nentries_5_VV_dout(7),
-      inputStubData_nentries_6_V_0        => VMSME_L3PHIC18n1_nentries_6_VV_dout(0),
-      inputStubData_nentries_6_V_1        => VMSME_L3PHIC18n1_nentries_6_VV_dout(1),
-      inputStubData_nentries_6_V_2        => VMSME_L3PHIC18n1_nentries_6_VV_dout(2),
-      inputStubData_nentries_6_V_3        => VMSME_L3PHIC18n1_nentries_6_VV_dout(3),
-      inputStubData_nentries_6_V_4        => VMSME_L3PHIC18n1_nentries_6_VV_dout(4),
-      inputStubData_nentries_6_V_5        => VMSME_L3PHIC18n1_nentries_6_VV_dout(5),
-      inputStubData_nentries_6_V_6        => VMSME_L3PHIC18n1_nentries_6_VV_dout(6),
-      inputStubData_nentries_6_V_7        => VMSME_L3PHIC18n1_nentries_6_VV_dout(7),
-      inputStubData_nentries_7_V_0        => VMSME_L3PHIC18n1_nentries_7_VV_dout(0),
-      inputStubData_nentries_7_V_1        => VMSME_L3PHIC18n1_nentries_7_VV_dout(1),
-      inputStubData_nentries_7_V_2        => VMSME_L3PHIC18n1_nentries_7_VV_dout(2),
-      inputStubData_nentries_7_V_3        => VMSME_L3PHIC18n1_nentries_7_VV_dout(3),
-      inputStubData_nentries_7_V_4        => VMSME_L3PHIC18n1_nentries_7_VV_dout(4),
-      inputStubData_nentries_7_V_5        => VMSME_L3PHIC18n1_nentries_7_VV_dout(5),
-      inputStubData_nentries_7_V_6        => VMSME_L3PHIC18n1_nentries_7_VV_dout(6),
-      inputStubData_nentries_7_V_7        => VMSME_L3PHIC18n1_nentries_7_VV_dout(7),
-      inputProjectionData_dataarray_data_V_ce0         => VMPROJ_L3PHIC18_dataarray_data_V_enb,
-      inputProjectionData_dataarray_data_V_address0    => VMPROJ_L3PHIC18_dataarray_data_V_readaddr,
-      inputProjectionData_dataarray_data_V_q0            => VMPROJ_L3PHIC18_dataarray_data_V_dout,
-      inputProjectionData_nentries_0_V        => VMPROJ_L3PHIC18_nentries_0_V_dout,
-      inputProjectionData_nentries_1_V        => VMPROJ_L3PHIC18_nentries_1_V_dout,
-      outputCandidateMatch_dataarray_data_V_ce0         => open,
-      outputCandidateMatch_dataarray_data_V_we0         => CM_L3PHIC18_dataarray_data_V_wea,
-      outputCandidateMatch_dataarray_data_V_address0    => CM_L3PHIC18_dataarray_data_V_writeaddr,
-      outputCandidateMatch_dataarray_data_V_d0          => CM_L3PHIC18_dataarray_data_V_din
+      inputStubData_dataarray_data_V_ce0       => VMSME_L3PHIC18n1_dataarray_data_V_enb,
+      inputStubData_dataarray_data_V_address0  => VMSME_L3PHIC18n1_dataarray_data_V_readaddr,
+      inputStubData_dataarray_data_V_q0        => VMSME_L3PHIC18n1_dataarray_data_V_dout,
+      inputStubData_nentries_0_V_0     => VMSME_L3PHIC18n1_nentries_VVV_dout(0)(0),
+      inputStubData_nentries_0_V_1     => VMSME_L3PHIC18n1_nentries_VVV_dout(0)(1),
+      inputStubData_nentries_0_V_2     => VMSME_L3PHIC18n1_nentries_VVV_dout(0)(2),
+      inputStubData_nentries_0_V_3     => VMSME_L3PHIC18n1_nentries_VVV_dout(0)(3),
+      inputStubData_nentries_0_V_4     => VMSME_L3PHIC18n1_nentries_VVV_dout(0)(4),
+      inputStubData_nentries_0_V_5     => VMSME_L3PHIC18n1_nentries_VVV_dout(0)(5),
+      inputStubData_nentries_0_V_6     => VMSME_L3PHIC18n1_nentries_VVV_dout(0)(6),
+      inputStubData_nentries_0_V_7     => VMSME_L3PHIC18n1_nentries_VVV_dout(0)(7),
+      inputStubData_nentries_1_V_0     => VMSME_L3PHIC18n1_nentries_VVV_dout(1)(0),
+      inputStubData_nentries_1_V_1     => VMSME_L3PHIC18n1_nentries_VVV_dout(1)(1),
+      inputStubData_nentries_1_V_2     => VMSME_L3PHIC18n1_nentries_VVV_dout(1)(2),
+      inputStubData_nentries_1_V_3     => VMSME_L3PHIC18n1_nentries_VVV_dout(1)(3),
+      inputStubData_nentries_1_V_4     => VMSME_L3PHIC18n1_nentries_VVV_dout(1)(4),
+      inputStubData_nentries_1_V_5     => VMSME_L3PHIC18n1_nentries_VVV_dout(1)(5),
+      inputStubData_nentries_1_V_6     => VMSME_L3PHIC18n1_nentries_VVV_dout(1)(6),
+      inputStubData_nentries_1_V_7     => VMSME_L3PHIC18n1_nentries_VVV_dout(1)(7),
+      inputStubData_nentries_2_V_0     => VMSME_L3PHIC18n1_nentries_VVV_dout(2)(0),
+      inputStubData_nentries_2_V_1     => VMSME_L3PHIC18n1_nentries_VVV_dout(2)(1),
+      inputStubData_nentries_2_V_2     => VMSME_L3PHIC18n1_nentries_VVV_dout(2)(2),
+      inputStubData_nentries_2_V_3     => VMSME_L3PHIC18n1_nentries_VVV_dout(2)(3),
+      inputStubData_nentries_2_V_4     => VMSME_L3PHIC18n1_nentries_VVV_dout(2)(4),
+      inputStubData_nentries_2_V_5     => VMSME_L3PHIC18n1_nentries_VVV_dout(2)(5),
+      inputStubData_nentries_2_V_6     => VMSME_L3PHIC18n1_nentries_VVV_dout(2)(6),
+      inputStubData_nentries_2_V_7     => VMSME_L3PHIC18n1_nentries_VVV_dout(2)(7),
+      inputStubData_nentries_3_V_0     => VMSME_L3PHIC18n1_nentries_VVV_dout(3)(0),
+      inputStubData_nentries_3_V_1     => VMSME_L3PHIC18n1_nentries_VVV_dout(3)(1),
+      inputStubData_nentries_3_V_2     => VMSME_L3PHIC18n1_nentries_VVV_dout(3)(2),
+      inputStubData_nentries_3_V_3     => VMSME_L3PHIC18n1_nentries_VVV_dout(3)(3),
+      inputStubData_nentries_3_V_4     => VMSME_L3PHIC18n1_nentries_VVV_dout(3)(4),
+      inputStubData_nentries_3_V_5     => VMSME_L3PHIC18n1_nentries_VVV_dout(3)(5),
+      inputStubData_nentries_3_V_6     => VMSME_L3PHIC18n1_nentries_VVV_dout(3)(6),
+      inputStubData_nentries_3_V_7     => VMSME_L3PHIC18n1_nentries_VVV_dout(3)(7),
+      inputStubData_nentries_4_V_0     => VMSME_L3PHIC18n1_nentries_VVV_dout(4)(0),
+      inputStubData_nentries_4_V_1     => VMSME_L3PHIC18n1_nentries_VVV_dout(4)(1),
+      inputStubData_nentries_4_V_2     => VMSME_L3PHIC18n1_nentries_VVV_dout(4)(2),
+      inputStubData_nentries_4_V_3     => VMSME_L3PHIC18n1_nentries_VVV_dout(4)(3),
+      inputStubData_nentries_4_V_4     => VMSME_L3PHIC18n1_nentries_VVV_dout(4)(4),
+      inputStubData_nentries_4_V_5     => VMSME_L3PHIC18n1_nentries_VVV_dout(4)(5),
+      inputStubData_nentries_4_V_6     => VMSME_L3PHIC18n1_nentries_VVV_dout(4)(6),
+      inputStubData_nentries_4_V_7     => VMSME_L3PHIC18n1_nentries_VVV_dout(4)(7),
+      inputStubData_nentries_5_V_0     => VMSME_L3PHIC18n1_nentries_VVV_dout(5)(0),
+      inputStubData_nentries_5_V_1     => VMSME_L3PHIC18n1_nentries_VVV_dout(5)(1),
+      inputStubData_nentries_5_V_2     => VMSME_L3PHIC18n1_nentries_VVV_dout(5)(2),
+      inputStubData_nentries_5_V_3     => VMSME_L3PHIC18n1_nentries_VVV_dout(5)(3),
+      inputStubData_nentries_5_V_4     => VMSME_L3PHIC18n1_nentries_VVV_dout(5)(4),
+      inputStubData_nentries_5_V_5     => VMSME_L3PHIC18n1_nentries_VVV_dout(5)(5),
+      inputStubData_nentries_5_V_6     => VMSME_L3PHIC18n1_nentries_VVV_dout(5)(6),
+      inputStubData_nentries_5_V_7     => VMSME_L3PHIC18n1_nentries_VVV_dout(5)(7),
+      inputStubData_nentries_6_V_0     => VMSME_L3PHIC18n1_nentries_VVV_dout(6)(0),
+      inputStubData_nentries_6_V_1     => VMSME_L3PHIC18n1_nentries_VVV_dout(6)(1),
+      inputStubData_nentries_6_V_2     => VMSME_L3PHIC18n1_nentries_VVV_dout(6)(2),
+      inputStubData_nentries_6_V_3     => VMSME_L3PHIC18n1_nentries_VVV_dout(6)(3),
+      inputStubData_nentries_6_V_4     => VMSME_L3PHIC18n1_nentries_VVV_dout(6)(4),
+      inputStubData_nentries_6_V_5     => VMSME_L3PHIC18n1_nentries_VVV_dout(6)(5),
+      inputStubData_nentries_6_V_6     => VMSME_L3PHIC18n1_nentries_VVV_dout(6)(6),
+      inputStubData_nentries_6_V_7     => VMSME_L3PHIC18n1_nentries_VVV_dout(6)(7),
+      inputStubData_nentries_7_V_0     => VMSME_L3PHIC18n1_nentries_VVV_dout(7)(0),
+      inputStubData_nentries_7_V_1     => VMSME_L3PHIC18n1_nentries_VVV_dout(7)(1),
+      inputStubData_nentries_7_V_2     => VMSME_L3PHIC18n1_nentries_VVV_dout(7)(2),
+      inputStubData_nentries_7_V_3     => VMSME_L3PHIC18n1_nentries_VVV_dout(7)(3),
+      inputStubData_nentries_7_V_4     => VMSME_L3PHIC18n1_nentries_VVV_dout(7)(4),
+      inputStubData_nentries_7_V_5     => VMSME_L3PHIC18n1_nentries_VVV_dout(7)(5),
+      inputStubData_nentries_7_V_6     => VMSME_L3PHIC18n1_nentries_VVV_dout(7)(6),
+      inputStubData_nentries_7_V_7     => VMSME_L3PHIC18n1_nentries_VVV_dout(7)(7),
+      inputProjectionData_dataarray_data_V_ce0       => VMPROJ_L3PHIC18_dataarray_data_V_enb,
+      inputProjectionData_dataarray_data_V_address0  => VMPROJ_L3PHIC18_dataarray_data_V_readaddr,
+      inputProjectionData_dataarray_data_V_q0        => VMPROJ_L3PHIC18_dataarray_data_V_dout,
+      inputProjectionData_nentries_0_V               => VMPROJ_L3PHIC18_nentries_VV_dout(0),
+      inputProjectionData_nentries_1_V               => VMPROJ_L3PHIC18_nentries_VV_dout(1),
+      outputCandidateMatch_dataarray_data_V_ce0       => open,
+      outputCandidateMatch_dataarray_data_V_we0       => CM_L3PHIC18_dataarray_data_V_wea,
+      outputCandidateMatch_dataarray_data_V_address0  => CM_L3PHIC18_dataarray_data_V_writeaddr,
+      outputCandidateMatch_dataarray_data_V_d0        => CM_L3PHIC18_dataarray_data_V_din
   );
 
 
@@ -1776,82 +1442,82 @@ architecture rtl of SectorProcessor is
       ap_ready => open,
       ap_done  => open,
       bx_V          => bx_out_ProjectionRouter,
-      inputStubData_dataarray_data_V_ce0         => VMSME_L3PHIC19n1_dataarray_data_V_enb,
-      inputStubData_dataarray_data_V_address0    => VMSME_L3PHIC19n1_dataarray_data_V_readaddr,
-      inputStubData_dataarray_data_V_q0            => VMSME_L3PHIC19n1_dataarray_data_V_dout,
-      inputStubData_nentries_0_V_0        => VMSME_L3PHIC19n1_nentries_0_VV_dout(0),
-      inputStubData_nentries_0_V_1        => VMSME_L3PHIC19n1_nentries_0_VV_dout(1),
-      inputStubData_nentries_0_V_2        => VMSME_L3PHIC19n1_nentries_0_VV_dout(2),
-      inputStubData_nentries_0_V_3        => VMSME_L3PHIC19n1_nentries_0_VV_dout(3),
-      inputStubData_nentries_0_V_4        => VMSME_L3PHIC19n1_nentries_0_VV_dout(4),
-      inputStubData_nentries_0_V_5        => VMSME_L3PHIC19n1_nentries_0_VV_dout(5),
-      inputStubData_nentries_0_V_6        => VMSME_L3PHIC19n1_nentries_0_VV_dout(6),
-      inputStubData_nentries_0_V_7        => VMSME_L3PHIC19n1_nentries_0_VV_dout(7),
-      inputStubData_nentries_1_V_0        => VMSME_L3PHIC19n1_nentries_1_VV_dout(0),
-      inputStubData_nentries_1_V_1        => VMSME_L3PHIC19n1_nentries_1_VV_dout(1),
-      inputStubData_nentries_1_V_2        => VMSME_L3PHIC19n1_nentries_1_VV_dout(2),
-      inputStubData_nentries_1_V_3        => VMSME_L3PHIC19n1_nentries_1_VV_dout(3),
-      inputStubData_nentries_1_V_4        => VMSME_L3PHIC19n1_nentries_1_VV_dout(4),
-      inputStubData_nentries_1_V_5        => VMSME_L3PHIC19n1_nentries_1_VV_dout(5),
-      inputStubData_nentries_1_V_6        => VMSME_L3PHIC19n1_nentries_1_VV_dout(6),
-      inputStubData_nentries_1_V_7        => VMSME_L3PHIC19n1_nentries_1_VV_dout(7),
-      inputStubData_nentries_2_V_0        => VMSME_L3PHIC19n1_nentries_2_VV_dout(0),
-      inputStubData_nentries_2_V_1        => VMSME_L3PHIC19n1_nentries_2_VV_dout(1),
-      inputStubData_nentries_2_V_2        => VMSME_L3PHIC19n1_nentries_2_VV_dout(2),
-      inputStubData_nentries_2_V_3        => VMSME_L3PHIC19n1_nentries_2_VV_dout(3),
-      inputStubData_nentries_2_V_4        => VMSME_L3PHIC19n1_nentries_2_VV_dout(4),
-      inputStubData_nentries_2_V_5        => VMSME_L3PHIC19n1_nentries_2_VV_dout(5),
-      inputStubData_nentries_2_V_6        => VMSME_L3PHIC19n1_nentries_2_VV_dout(6),
-      inputStubData_nentries_2_V_7        => VMSME_L3PHIC19n1_nentries_2_VV_dout(7),
-      inputStubData_nentries_3_V_0        => VMSME_L3PHIC19n1_nentries_3_VV_dout(0),
-      inputStubData_nentries_3_V_1        => VMSME_L3PHIC19n1_nentries_3_VV_dout(1),
-      inputStubData_nentries_3_V_2        => VMSME_L3PHIC19n1_nentries_3_VV_dout(2),
-      inputStubData_nentries_3_V_3        => VMSME_L3PHIC19n1_nentries_3_VV_dout(3),
-      inputStubData_nentries_3_V_4        => VMSME_L3PHIC19n1_nentries_3_VV_dout(4),
-      inputStubData_nentries_3_V_5        => VMSME_L3PHIC19n1_nentries_3_VV_dout(5),
-      inputStubData_nentries_3_V_6        => VMSME_L3PHIC19n1_nentries_3_VV_dout(6),
-      inputStubData_nentries_3_V_7        => VMSME_L3PHIC19n1_nentries_3_VV_dout(7),
-      inputStubData_nentries_4_V_0        => VMSME_L3PHIC19n1_nentries_4_VV_dout(0),
-      inputStubData_nentries_4_V_1        => VMSME_L3PHIC19n1_nentries_4_VV_dout(1),
-      inputStubData_nentries_4_V_2        => VMSME_L3PHIC19n1_nentries_4_VV_dout(2),
-      inputStubData_nentries_4_V_3        => VMSME_L3PHIC19n1_nentries_4_VV_dout(3),
-      inputStubData_nentries_4_V_4        => VMSME_L3PHIC19n1_nentries_4_VV_dout(4),
-      inputStubData_nentries_4_V_5        => VMSME_L3PHIC19n1_nentries_4_VV_dout(5),
-      inputStubData_nentries_4_V_6        => VMSME_L3PHIC19n1_nentries_4_VV_dout(6),
-      inputStubData_nentries_4_V_7        => VMSME_L3PHIC19n1_nentries_4_VV_dout(7),
-      inputStubData_nentries_5_V_0        => VMSME_L3PHIC19n1_nentries_5_VV_dout(0),
-      inputStubData_nentries_5_V_1        => VMSME_L3PHIC19n1_nentries_5_VV_dout(1),
-      inputStubData_nentries_5_V_2        => VMSME_L3PHIC19n1_nentries_5_VV_dout(2),
-      inputStubData_nentries_5_V_3        => VMSME_L3PHIC19n1_nentries_5_VV_dout(3),
-      inputStubData_nentries_5_V_4        => VMSME_L3PHIC19n1_nentries_5_VV_dout(4),
-      inputStubData_nentries_5_V_5        => VMSME_L3PHIC19n1_nentries_5_VV_dout(5),
-      inputStubData_nentries_5_V_6        => VMSME_L3PHIC19n1_nentries_5_VV_dout(6),
-      inputStubData_nentries_5_V_7        => VMSME_L3PHIC19n1_nentries_5_VV_dout(7),
-      inputStubData_nentries_6_V_0        => VMSME_L3PHIC19n1_nentries_6_VV_dout(0),
-      inputStubData_nentries_6_V_1        => VMSME_L3PHIC19n1_nentries_6_VV_dout(1),
-      inputStubData_nentries_6_V_2        => VMSME_L3PHIC19n1_nentries_6_VV_dout(2),
-      inputStubData_nentries_6_V_3        => VMSME_L3PHIC19n1_nentries_6_VV_dout(3),
-      inputStubData_nentries_6_V_4        => VMSME_L3PHIC19n1_nentries_6_VV_dout(4),
-      inputStubData_nentries_6_V_5        => VMSME_L3PHIC19n1_nentries_6_VV_dout(5),
-      inputStubData_nentries_6_V_6        => VMSME_L3PHIC19n1_nentries_6_VV_dout(6),
-      inputStubData_nentries_6_V_7        => VMSME_L3PHIC19n1_nentries_6_VV_dout(7),
-      inputStubData_nentries_7_V_0        => VMSME_L3PHIC19n1_nentries_7_VV_dout(0),
-      inputStubData_nentries_7_V_1        => VMSME_L3PHIC19n1_nentries_7_VV_dout(1),
-      inputStubData_nentries_7_V_2        => VMSME_L3PHIC19n1_nentries_7_VV_dout(2),
-      inputStubData_nentries_7_V_3        => VMSME_L3PHIC19n1_nentries_7_VV_dout(3),
-      inputStubData_nentries_7_V_4        => VMSME_L3PHIC19n1_nentries_7_VV_dout(4),
-      inputStubData_nentries_7_V_5        => VMSME_L3PHIC19n1_nentries_7_VV_dout(5),
-      inputStubData_nentries_7_V_6        => VMSME_L3PHIC19n1_nentries_7_VV_dout(6),
-      inputStubData_nentries_7_V_7        => VMSME_L3PHIC19n1_nentries_7_VV_dout(7),
-      inputProjectionData_dataarray_data_V_ce0         => VMPROJ_L3PHIC19_dataarray_data_V_enb,
-      inputProjectionData_dataarray_data_V_address0    => VMPROJ_L3PHIC19_dataarray_data_V_readaddr,
-      inputProjectionData_dataarray_data_V_q0            => VMPROJ_L3PHIC19_dataarray_data_V_dout,
-      inputProjectionData_nentries_0_V        => VMPROJ_L3PHIC19_nentries_0_V_dout,
-      inputProjectionData_nentries_1_V        => VMPROJ_L3PHIC19_nentries_1_V_dout,
-      outputCandidateMatch_dataarray_data_V_ce0         => open,
-      outputCandidateMatch_dataarray_data_V_we0         => CM_L3PHIC19_dataarray_data_V_wea,
-      outputCandidateMatch_dataarray_data_V_address0    => CM_L3PHIC19_dataarray_data_V_writeaddr,
-      outputCandidateMatch_dataarray_data_V_d0          => CM_L3PHIC19_dataarray_data_V_din
+      inputStubData_dataarray_data_V_ce0       => VMSME_L3PHIC19n1_dataarray_data_V_enb,
+      inputStubData_dataarray_data_V_address0  => VMSME_L3PHIC19n1_dataarray_data_V_readaddr,
+      inputStubData_dataarray_data_V_q0        => VMSME_L3PHIC19n1_dataarray_data_V_dout,
+      inputStubData_nentries_0_V_0     => VMSME_L3PHIC19n1_nentries_VVV_dout(0)(0),
+      inputStubData_nentries_0_V_1     => VMSME_L3PHIC19n1_nentries_VVV_dout(0)(1),
+      inputStubData_nentries_0_V_2     => VMSME_L3PHIC19n1_nentries_VVV_dout(0)(2),
+      inputStubData_nentries_0_V_3     => VMSME_L3PHIC19n1_nentries_VVV_dout(0)(3),
+      inputStubData_nentries_0_V_4     => VMSME_L3PHIC19n1_nentries_VVV_dout(0)(4),
+      inputStubData_nentries_0_V_5     => VMSME_L3PHIC19n1_nentries_VVV_dout(0)(5),
+      inputStubData_nentries_0_V_6     => VMSME_L3PHIC19n1_nentries_VVV_dout(0)(6),
+      inputStubData_nentries_0_V_7     => VMSME_L3PHIC19n1_nentries_VVV_dout(0)(7),
+      inputStubData_nentries_1_V_0     => VMSME_L3PHIC19n1_nentries_VVV_dout(1)(0),
+      inputStubData_nentries_1_V_1     => VMSME_L3PHIC19n1_nentries_VVV_dout(1)(1),
+      inputStubData_nentries_1_V_2     => VMSME_L3PHIC19n1_nentries_VVV_dout(1)(2),
+      inputStubData_nentries_1_V_3     => VMSME_L3PHIC19n1_nentries_VVV_dout(1)(3),
+      inputStubData_nentries_1_V_4     => VMSME_L3PHIC19n1_nentries_VVV_dout(1)(4),
+      inputStubData_nentries_1_V_5     => VMSME_L3PHIC19n1_nentries_VVV_dout(1)(5),
+      inputStubData_nentries_1_V_6     => VMSME_L3PHIC19n1_nentries_VVV_dout(1)(6),
+      inputStubData_nentries_1_V_7     => VMSME_L3PHIC19n1_nentries_VVV_dout(1)(7),
+      inputStubData_nentries_2_V_0     => VMSME_L3PHIC19n1_nentries_VVV_dout(2)(0),
+      inputStubData_nentries_2_V_1     => VMSME_L3PHIC19n1_nentries_VVV_dout(2)(1),
+      inputStubData_nentries_2_V_2     => VMSME_L3PHIC19n1_nentries_VVV_dout(2)(2),
+      inputStubData_nentries_2_V_3     => VMSME_L3PHIC19n1_nentries_VVV_dout(2)(3),
+      inputStubData_nentries_2_V_4     => VMSME_L3PHIC19n1_nentries_VVV_dout(2)(4),
+      inputStubData_nentries_2_V_5     => VMSME_L3PHIC19n1_nentries_VVV_dout(2)(5),
+      inputStubData_nentries_2_V_6     => VMSME_L3PHIC19n1_nentries_VVV_dout(2)(6),
+      inputStubData_nentries_2_V_7     => VMSME_L3PHIC19n1_nentries_VVV_dout(2)(7),
+      inputStubData_nentries_3_V_0     => VMSME_L3PHIC19n1_nentries_VVV_dout(3)(0),
+      inputStubData_nentries_3_V_1     => VMSME_L3PHIC19n1_nentries_VVV_dout(3)(1),
+      inputStubData_nentries_3_V_2     => VMSME_L3PHIC19n1_nentries_VVV_dout(3)(2),
+      inputStubData_nentries_3_V_3     => VMSME_L3PHIC19n1_nentries_VVV_dout(3)(3),
+      inputStubData_nentries_3_V_4     => VMSME_L3PHIC19n1_nentries_VVV_dout(3)(4),
+      inputStubData_nentries_3_V_5     => VMSME_L3PHIC19n1_nentries_VVV_dout(3)(5),
+      inputStubData_nentries_3_V_6     => VMSME_L3PHIC19n1_nentries_VVV_dout(3)(6),
+      inputStubData_nentries_3_V_7     => VMSME_L3PHIC19n1_nentries_VVV_dout(3)(7),
+      inputStubData_nentries_4_V_0     => VMSME_L3PHIC19n1_nentries_VVV_dout(4)(0),
+      inputStubData_nentries_4_V_1     => VMSME_L3PHIC19n1_nentries_VVV_dout(4)(1),
+      inputStubData_nentries_4_V_2     => VMSME_L3PHIC19n1_nentries_VVV_dout(4)(2),
+      inputStubData_nentries_4_V_3     => VMSME_L3PHIC19n1_nentries_VVV_dout(4)(3),
+      inputStubData_nentries_4_V_4     => VMSME_L3PHIC19n1_nentries_VVV_dout(4)(4),
+      inputStubData_nentries_4_V_5     => VMSME_L3PHIC19n1_nentries_VVV_dout(4)(5),
+      inputStubData_nentries_4_V_6     => VMSME_L3PHIC19n1_nentries_VVV_dout(4)(6),
+      inputStubData_nentries_4_V_7     => VMSME_L3PHIC19n1_nentries_VVV_dout(4)(7),
+      inputStubData_nentries_5_V_0     => VMSME_L3PHIC19n1_nentries_VVV_dout(5)(0),
+      inputStubData_nentries_5_V_1     => VMSME_L3PHIC19n1_nentries_VVV_dout(5)(1),
+      inputStubData_nentries_5_V_2     => VMSME_L3PHIC19n1_nentries_VVV_dout(5)(2),
+      inputStubData_nentries_5_V_3     => VMSME_L3PHIC19n1_nentries_VVV_dout(5)(3),
+      inputStubData_nentries_5_V_4     => VMSME_L3PHIC19n1_nentries_VVV_dout(5)(4),
+      inputStubData_nentries_5_V_5     => VMSME_L3PHIC19n1_nentries_VVV_dout(5)(5),
+      inputStubData_nentries_5_V_6     => VMSME_L3PHIC19n1_nentries_VVV_dout(5)(6),
+      inputStubData_nentries_5_V_7     => VMSME_L3PHIC19n1_nentries_VVV_dout(5)(7),
+      inputStubData_nentries_6_V_0     => VMSME_L3PHIC19n1_nentries_VVV_dout(6)(0),
+      inputStubData_nentries_6_V_1     => VMSME_L3PHIC19n1_nentries_VVV_dout(6)(1),
+      inputStubData_nentries_6_V_2     => VMSME_L3PHIC19n1_nentries_VVV_dout(6)(2),
+      inputStubData_nentries_6_V_3     => VMSME_L3PHIC19n1_nentries_VVV_dout(6)(3),
+      inputStubData_nentries_6_V_4     => VMSME_L3PHIC19n1_nentries_VVV_dout(6)(4),
+      inputStubData_nentries_6_V_5     => VMSME_L3PHIC19n1_nentries_VVV_dout(6)(5),
+      inputStubData_nentries_6_V_6     => VMSME_L3PHIC19n1_nentries_VVV_dout(6)(6),
+      inputStubData_nentries_6_V_7     => VMSME_L3PHIC19n1_nentries_VVV_dout(6)(7),
+      inputStubData_nentries_7_V_0     => VMSME_L3PHIC19n1_nentries_VVV_dout(7)(0),
+      inputStubData_nentries_7_V_1     => VMSME_L3PHIC19n1_nentries_VVV_dout(7)(1),
+      inputStubData_nentries_7_V_2     => VMSME_L3PHIC19n1_nentries_VVV_dout(7)(2),
+      inputStubData_nentries_7_V_3     => VMSME_L3PHIC19n1_nentries_VVV_dout(7)(3),
+      inputStubData_nentries_7_V_4     => VMSME_L3PHIC19n1_nentries_VVV_dout(7)(4),
+      inputStubData_nentries_7_V_5     => VMSME_L3PHIC19n1_nentries_VVV_dout(7)(5),
+      inputStubData_nentries_7_V_6     => VMSME_L3PHIC19n1_nentries_VVV_dout(7)(6),
+      inputStubData_nentries_7_V_7     => VMSME_L3PHIC19n1_nentries_VVV_dout(7)(7),
+      inputProjectionData_dataarray_data_V_ce0       => VMPROJ_L3PHIC19_dataarray_data_V_enb,
+      inputProjectionData_dataarray_data_V_address0  => VMPROJ_L3PHIC19_dataarray_data_V_readaddr,
+      inputProjectionData_dataarray_data_V_q0        => VMPROJ_L3PHIC19_dataarray_data_V_dout,
+      inputProjectionData_nentries_0_V               => VMPROJ_L3PHIC19_nentries_VV_dout(0),
+      inputProjectionData_nentries_1_V               => VMPROJ_L3PHIC19_nentries_VV_dout(1),
+      outputCandidateMatch_dataarray_data_V_ce0       => open,
+      outputCandidateMatch_dataarray_data_V_we0       => CM_L3PHIC19_dataarray_data_V_wea,
+      outputCandidateMatch_dataarray_data_V_address0  => CM_L3PHIC19_dataarray_data_V_writeaddr,
+      outputCandidateMatch_dataarray_data_V_d0        => CM_L3PHIC19_dataarray_data_V_din
   );
 
 
@@ -1864,82 +1530,82 @@ architecture rtl of SectorProcessor is
       ap_ready => open,
       ap_done  => open,
       bx_V          => bx_out_ProjectionRouter,
-      inputStubData_dataarray_data_V_ce0         => VMSME_L3PHIC20n1_dataarray_data_V_enb,
-      inputStubData_dataarray_data_V_address0    => VMSME_L3PHIC20n1_dataarray_data_V_readaddr,
-      inputStubData_dataarray_data_V_q0            => VMSME_L3PHIC20n1_dataarray_data_V_dout,
-      inputStubData_nentries_0_V_0        => VMSME_L3PHIC20n1_nentries_0_VV_dout(0),
-      inputStubData_nentries_0_V_1        => VMSME_L3PHIC20n1_nentries_0_VV_dout(1),
-      inputStubData_nentries_0_V_2        => VMSME_L3PHIC20n1_nentries_0_VV_dout(2),
-      inputStubData_nentries_0_V_3        => VMSME_L3PHIC20n1_nentries_0_VV_dout(3),
-      inputStubData_nentries_0_V_4        => VMSME_L3PHIC20n1_nentries_0_VV_dout(4),
-      inputStubData_nentries_0_V_5        => VMSME_L3PHIC20n1_nentries_0_VV_dout(5),
-      inputStubData_nentries_0_V_6        => VMSME_L3PHIC20n1_nentries_0_VV_dout(6),
-      inputStubData_nentries_0_V_7        => VMSME_L3PHIC20n1_nentries_0_VV_dout(7),
-      inputStubData_nentries_1_V_0        => VMSME_L3PHIC20n1_nentries_1_VV_dout(0),
-      inputStubData_nentries_1_V_1        => VMSME_L3PHIC20n1_nentries_1_VV_dout(1),
-      inputStubData_nentries_1_V_2        => VMSME_L3PHIC20n1_nentries_1_VV_dout(2),
-      inputStubData_nentries_1_V_3        => VMSME_L3PHIC20n1_nentries_1_VV_dout(3),
-      inputStubData_nentries_1_V_4        => VMSME_L3PHIC20n1_nentries_1_VV_dout(4),
-      inputStubData_nentries_1_V_5        => VMSME_L3PHIC20n1_nentries_1_VV_dout(5),
-      inputStubData_nentries_1_V_6        => VMSME_L3PHIC20n1_nentries_1_VV_dout(6),
-      inputStubData_nentries_1_V_7        => VMSME_L3PHIC20n1_nentries_1_VV_dout(7),
-      inputStubData_nentries_2_V_0        => VMSME_L3PHIC20n1_nentries_2_VV_dout(0),
-      inputStubData_nentries_2_V_1        => VMSME_L3PHIC20n1_nentries_2_VV_dout(1),
-      inputStubData_nentries_2_V_2        => VMSME_L3PHIC20n1_nentries_2_VV_dout(2),
-      inputStubData_nentries_2_V_3        => VMSME_L3PHIC20n1_nentries_2_VV_dout(3),
-      inputStubData_nentries_2_V_4        => VMSME_L3PHIC20n1_nentries_2_VV_dout(4),
-      inputStubData_nentries_2_V_5        => VMSME_L3PHIC20n1_nentries_2_VV_dout(5),
-      inputStubData_nentries_2_V_6        => VMSME_L3PHIC20n1_nentries_2_VV_dout(6),
-      inputStubData_nentries_2_V_7        => VMSME_L3PHIC20n1_nentries_2_VV_dout(7),
-      inputStubData_nentries_3_V_0        => VMSME_L3PHIC20n1_nentries_3_VV_dout(0),
-      inputStubData_nentries_3_V_1        => VMSME_L3PHIC20n1_nentries_3_VV_dout(1),
-      inputStubData_nentries_3_V_2        => VMSME_L3PHIC20n1_nentries_3_VV_dout(2),
-      inputStubData_nentries_3_V_3        => VMSME_L3PHIC20n1_nentries_3_VV_dout(3),
-      inputStubData_nentries_3_V_4        => VMSME_L3PHIC20n1_nentries_3_VV_dout(4),
-      inputStubData_nentries_3_V_5        => VMSME_L3PHIC20n1_nentries_3_VV_dout(5),
-      inputStubData_nentries_3_V_6        => VMSME_L3PHIC20n1_nentries_3_VV_dout(6),
-      inputStubData_nentries_3_V_7        => VMSME_L3PHIC20n1_nentries_3_VV_dout(7),
-      inputStubData_nentries_4_V_0        => VMSME_L3PHIC20n1_nentries_4_VV_dout(0),
-      inputStubData_nentries_4_V_1        => VMSME_L3PHIC20n1_nentries_4_VV_dout(1),
-      inputStubData_nentries_4_V_2        => VMSME_L3PHIC20n1_nentries_4_VV_dout(2),
-      inputStubData_nentries_4_V_3        => VMSME_L3PHIC20n1_nentries_4_VV_dout(3),
-      inputStubData_nentries_4_V_4        => VMSME_L3PHIC20n1_nentries_4_VV_dout(4),
-      inputStubData_nentries_4_V_5        => VMSME_L3PHIC20n1_nentries_4_VV_dout(5),
-      inputStubData_nentries_4_V_6        => VMSME_L3PHIC20n1_nentries_4_VV_dout(6),
-      inputStubData_nentries_4_V_7        => VMSME_L3PHIC20n1_nentries_4_VV_dout(7),
-      inputStubData_nentries_5_V_0        => VMSME_L3PHIC20n1_nentries_5_VV_dout(0),
-      inputStubData_nentries_5_V_1        => VMSME_L3PHIC20n1_nentries_5_VV_dout(1),
-      inputStubData_nentries_5_V_2        => VMSME_L3PHIC20n1_nentries_5_VV_dout(2),
-      inputStubData_nentries_5_V_3        => VMSME_L3PHIC20n1_nentries_5_VV_dout(3),
-      inputStubData_nentries_5_V_4        => VMSME_L3PHIC20n1_nentries_5_VV_dout(4),
-      inputStubData_nentries_5_V_5        => VMSME_L3PHIC20n1_nentries_5_VV_dout(5),
-      inputStubData_nentries_5_V_6        => VMSME_L3PHIC20n1_nentries_5_VV_dout(6),
-      inputStubData_nentries_5_V_7        => VMSME_L3PHIC20n1_nentries_5_VV_dout(7),
-      inputStubData_nentries_6_V_0        => VMSME_L3PHIC20n1_nentries_6_VV_dout(0),
-      inputStubData_nentries_6_V_1        => VMSME_L3PHIC20n1_nentries_6_VV_dout(1),
-      inputStubData_nentries_6_V_2        => VMSME_L3PHIC20n1_nentries_6_VV_dout(2),
-      inputStubData_nentries_6_V_3        => VMSME_L3PHIC20n1_nentries_6_VV_dout(3),
-      inputStubData_nentries_6_V_4        => VMSME_L3PHIC20n1_nentries_6_VV_dout(4),
-      inputStubData_nentries_6_V_5        => VMSME_L3PHIC20n1_nentries_6_VV_dout(5),
-      inputStubData_nentries_6_V_6        => VMSME_L3PHIC20n1_nentries_6_VV_dout(6),
-      inputStubData_nentries_6_V_7        => VMSME_L3PHIC20n1_nentries_6_VV_dout(7),
-      inputStubData_nentries_7_V_0        => VMSME_L3PHIC20n1_nentries_7_VV_dout(0),
-      inputStubData_nentries_7_V_1        => VMSME_L3PHIC20n1_nentries_7_VV_dout(1),
-      inputStubData_nentries_7_V_2        => VMSME_L3PHIC20n1_nentries_7_VV_dout(2),
-      inputStubData_nentries_7_V_3        => VMSME_L3PHIC20n1_nentries_7_VV_dout(3),
-      inputStubData_nentries_7_V_4        => VMSME_L3PHIC20n1_nentries_7_VV_dout(4),
-      inputStubData_nentries_7_V_5        => VMSME_L3PHIC20n1_nentries_7_VV_dout(5),
-      inputStubData_nentries_7_V_6        => VMSME_L3PHIC20n1_nentries_7_VV_dout(6),
-      inputStubData_nentries_7_V_7        => VMSME_L3PHIC20n1_nentries_7_VV_dout(7),
-      inputProjectionData_dataarray_data_V_ce0         => VMPROJ_L3PHIC20_dataarray_data_V_enb,
-      inputProjectionData_dataarray_data_V_address0    => VMPROJ_L3PHIC20_dataarray_data_V_readaddr,
-      inputProjectionData_dataarray_data_V_q0            => VMPROJ_L3PHIC20_dataarray_data_V_dout,
-      inputProjectionData_nentries_0_V        => VMPROJ_L3PHIC20_nentries_0_V_dout,
-      inputProjectionData_nentries_1_V        => VMPROJ_L3PHIC20_nentries_1_V_dout,
-      outputCandidateMatch_dataarray_data_V_ce0         => open,
-      outputCandidateMatch_dataarray_data_V_we0         => CM_L3PHIC20_dataarray_data_V_wea,
-      outputCandidateMatch_dataarray_data_V_address0    => CM_L3PHIC20_dataarray_data_V_writeaddr,
-      outputCandidateMatch_dataarray_data_V_d0          => CM_L3PHIC20_dataarray_data_V_din
+      inputStubData_dataarray_data_V_ce0       => VMSME_L3PHIC20n1_dataarray_data_V_enb,
+      inputStubData_dataarray_data_V_address0  => VMSME_L3PHIC20n1_dataarray_data_V_readaddr,
+      inputStubData_dataarray_data_V_q0        => VMSME_L3PHIC20n1_dataarray_data_V_dout,
+      inputStubData_nentries_0_V_0     => VMSME_L3PHIC20n1_nentries_VVV_dout(0)(0),
+      inputStubData_nentries_0_V_1     => VMSME_L3PHIC20n1_nentries_VVV_dout(0)(1),
+      inputStubData_nentries_0_V_2     => VMSME_L3PHIC20n1_nentries_VVV_dout(0)(2),
+      inputStubData_nentries_0_V_3     => VMSME_L3PHIC20n1_nentries_VVV_dout(0)(3),
+      inputStubData_nentries_0_V_4     => VMSME_L3PHIC20n1_nentries_VVV_dout(0)(4),
+      inputStubData_nentries_0_V_5     => VMSME_L3PHIC20n1_nentries_VVV_dout(0)(5),
+      inputStubData_nentries_0_V_6     => VMSME_L3PHIC20n1_nentries_VVV_dout(0)(6),
+      inputStubData_nentries_0_V_7     => VMSME_L3PHIC20n1_nentries_VVV_dout(0)(7),
+      inputStubData_nentries_1_V_0     => VMSME_L3PHIC20n1_nentries_VVV_dout(1)(0),
+      inputStubData_nentries_1_V_1     => VMSME_L3PHIC20n1_nentries_VVV_dout(1)(1),
+      inputStubData_nentries_1_V_2     => VMSME_L3PHIC20n1_nentries_VVV_dout(1)(2),
+      inputStubData_nentries_1_V_3     => VMSME_L3PHIC20n1_nentries_VVV_dout(1)(3),
+      inputStubData_nentries_1_V_4     => VMSME_L3PHIC20n1_nentries_VVV_dout(1)(4),
+      inputStubData_nentries_1_V_5     => VMSME_L3PHIC20n1_nentries_VVV_dout(1)(5),
+      inputStubData_nentries_1_V_6     => VMSME_L3PHIC20n1_nentries_VVV_dout(1)(6),
+      inputStubData_nentries_1_V_7     => VMSME_L3PHIC20n1_nentries_VVV_dout(1)(7),
+      inputStubData_nentries_2_V_0     => VMSME_L3PHIC20n1_nentries_VVV_dout(2)(0),
+      inputStubData_nentries_2_V_1     => VMSME_L3PHIC20n1_nentries_VVV_dout(2)(1),
+      inputStubData_nentries_2_V_2     => VMSME_L3PHIC20n1_nentries_VVV_dout(2)(2),
+      inputStubData_nentries_2_V_3     => VMSME_L3PHIC20n1_nentries_VVV_dout(2)(3),
+      inputStubData_nentries_2_V_4     => VMSME_L3PHIC20n1_nentries_VVV_dout(2)(4),
+      inputStubData_nentries_2_V_5     => VMSME_L3PHIC20n1_nentries_VVV_dout(2)(5),
+      inputStubData_nentries_2_V_6     => VMSME_L3PHIC20n1_nentries_VVV_dout(2)(6),
+      inputStubData_nentries_2_V_7     => VMSME_L3PHIC20n1_nentries_VVV_dout(2)(7),
+      inputStubData_nentries_3_V_0     => VMSME_L3PHIC20n1_nentries_VVV_dout(3)(0),
+      inputStubData_nentries_3_V_1     => VMSME_L3PHIC20n1_nentries_VVV_dout(3)(1),
+      inputStubData_nentries_3_V_2     => VMSME_L3PHIC20n1_nentries_VVV_dout(3)(2),
+      inputStubData_nentries_3_V_3     => VMSME_L3PHIC20n1_nentries_VVV_dout(3)(3),
+      inputStubData_nentries_3_V_4     => VMSME_L3PHIC20n1_nentries_VVV_dout(3)(4),
+      inputStubData_nentries_3_V_5     => VMSME_L3PHIC20n1_nentries_VVV_dout(3)(5),
+      inputStubData_nentries_3_V_6     => VMSME_L3PHIC20n1_nentries_VVV_dout(3)(6),
+      inputStubData_nentries_3_V_7     => VMSME_L3PHIC20n1_nentries_VVV_dout(3)(7),
+      inputStubData_nentries_4_V_0     => VMSME_L3PHIC20n1_nentries_VVV_dout(4)(0),
+      inputStubData_nentries_4_V_1     => VMSME_L3PHIC20n1_nentries_VVV_dout(4)(1),
+      inputStubData_nentries_4_V_2     => VMSME_L3PHIC20n1_nentries_VVV_dout(4)(2),
+      inputStubData_nentries_4_V_3     => VMSME_L3PHIC20n1_nentries_VVV_dout(4)(3),
+      inputStubData_nentries_4_V_4     => VMSME_L3PHIC20n1_nentries_VVV_dout(4)(4),
+      inputStubData_nentries_4_V_5     => VMSME_L3PHIC20n1_nentries_VVV_dout(4)(5),
+      inputStubData_nentries_4_V_6     => VMSME_L3PHIC20n1_nentries_VVV_dout(4)(6),
+      inputStubData_nentries_4_V_7     => VMSME_L3PHIC20n1_nentries_VVV_dout(4)(7),
+      inputStubData_nentries_5_V_0     => VMSME_L3PHIC20n1_nentries_VVV_dout(5)(0),
+      inputStubData_nentries_5_V_1     => VMSME_L3PHIC20n1_nentries_VVV_dout(5)(1),
+      inputStubData_nentries_5_V_2     => VMSME_L3PHIC20n1_nentries_VVV_dout(5)(2),
+      inputStubData_nentries_5_V_3     => VMSME_L3PHIC20n1_nentries_VVV_dout(5)(3),
+      inputStubData_nentries_5_V_4     => VMSME_L3PHIC20n1_nentries_VVV_dout(5)(4),
+      inputStubData_nentries_5_V_5     => VMSME_L3PHIC20n1_nentries_VVV_dout(5)(5),
+      inputStubData_nentries_5_V_6     => VMSME_L3PHIC20n1_nentries_VVV_dout(5)(6),
+      inputStubData_nentries_5_V_7     => VMSME_L3PHIC20n1_nentries_VVV_dout(5)(7),
+      inputStubData_nentries_6_V_0     => VMSME_L3PHIC20n1_nentries_VVV_dout(6)(0),
+      inputStubData_nentries_6_V_1     => VMSME_L3PHIC20n1_nentries_VVV_dout(6)(1),
+      inputStubData_nentries_6_V_2     => VMSME_L3PHIC20n1_nentries_VVV_dout(6)(2),
+      inputStubData_nentries_6_V_3     => VMSME_L3PHIC20n1_nentries_VVV_dout(6)(3),
+      inputStubData_nentries_6_V_4     => VMSME_L3PHIC20n1_nentries_VVV_dout(6)(4),
+      inputStubData_nentries_6_V_5     => VMSME_L3PHIC20n1_nentries_VVV_dout(6)(5),
+      inputStubData_nentries_6_V_6     => VMSME_L3PHIC20n1_nentries_VVV_dout(6)(6),
+      inputStubData_nentries_6_V_7     => VMSME_L3PHIC20n1_nentries_VVV_dout(6)(7),
+      inputStubData_nentries_7_V_0     => VMSME_L3PHIC20n1_nentries_VVV_dout(7)(0),
+      inputStubData_nentries_7_V_1     => VMSME_L3PHIC20n1_nentries_VVV_dout(7)(1),
+      inputStubData_nentries_7_V_2     => VMSME_L3PHIC20n1_nentries_VVV_dout(7)(2),
+      inputStubData_nentries_7_V_3     => VMSME_L3PHIC20n1_nentries_VVV_dout(7)(3),
+      inputStubData_nentries_7_V_4     => VMSME_L3PHIC20n1_nentries_VVV_dout(7)(4),
+      inputStubData_nentries_7_V_5     => VMSME_L3PHIC20n1_nentries_VVV_dout(7)(5),
+      inputStubData_nentries_7_V_6     => VMSME_L3PHIC20n1_nentries_VVV_dout(7)(6),
+      inputStubData_nentries_7_V_7     => VMSME_L3PHIC20n1_nentries_VVV_dout(7)(7),
+      inputProjectionData_dataarray_data_V_ce0       => VMPROJ_L3PHIC20_dataarray_data_V_enb,
+      inputProjectionData_dataarray_data_V_address0  => VMPROJ_L3PHIC20_dataarray_data_V_readaddr,
+      inputProjectionData_dataarray_data_V_q0        => VMPROJ_L3PHIC20_dataarray_data_V_dout,
+      inputProjectionData_nentries_0_V               => VMPROJ_L3PHIC20_nentries_VV_dout(0),
+      inputProjectionData_nentries_1_V               => VMPROJ_L3PHIC20_nentries_VV_dout(1),
+      outputCandidateMatch_dataarray_data_V_ce0       => open,
+      outputCandidateMatch_dataarray_data_V_we0       => CM_L3PHIC20_dataarray_data_V_wea,
+      outputCandidateMatch_dataarray_data_V_address0  => CM_L3PHIC20_dataarray_data_V_writeaddr,
+      outputCandidateMatch_dataarray_data_V_d0        => CM_L3PHIC20_dataarray_data_V_din
   );
 
 
@@ -1952,82 +1618,82 @@ architecture rtl of SectorProcessor is
       ap_ready => open,
       ap_done  => open,
       bx_V          => bx_out_ProjectionRouter,
-      inputStubData_dataarray_data_V_ce0         => VMSME_L3PHIC21n1_dataarray_data_V_enb,
-      inputStubData_dataarray_data_V_address0    => VMSME_L3PHIC21n1_dataarray_data_V_readaddr,
-      inputStubData_dataarray_data_V_q0            => VMSME_L3PHIC21n1_dataarray_data_V_dout,
-      inputStubData_nentries_0_V_0        => VMSME_L3PHIC21n1_nentries_0_VV_dout(0),
-      inputStubData_nentries_0_V_1        => VMSME_L3PHIC21n1_nentries_0_VV_dout(1),
-      inputStubData_nentries_0_V_2        => VMSME_L3PHIC21n1_nentries_0_VV_dout(2),
-      inputStubData_nentries_0_V_3        => VMSME_L3PHIC21n1_nentries_0_VV_dout(3),
-      inputStubData_nentries_0_V_4        => VMSME_L3PHIC21n1_nentries_0_VV_dout(4),
-      inputStubData_nentries_0_V_5        => VMSME_L3PHIC21n1_nentries_0_VV_dout(5),
-      inputStubData_nentries_0_V_6        => VMSME_L3PHIC21n1_nentries_0_VV_dout(6),
-      inputStubData_nentries_0_V_7        => VMSME_L3PHIC21n1_nentries_0_VV_dout(7),
-      inputStubData_nentries_1_V_0        => VMSME_L3PHIC21n1_nentries_1_VV_dout(0),
-      inputStubData_nentries_1_V_1        => VMSME_L3PHIC21n1_nentries_1_VV_dout(1),
-      inputStubData_nentries_1_V_2        => VMSME_L3PHIC21n1_nentries_1_VV_dout(2),
-      inputStubData_nentries_1_V_3        => VMSME_L3PHIC21n1_nentries_1_VV_dout(3),
-      inputStubData_nentries_1_V_4        => VMSME_L3PHIC21n1_nentries_1_VV_dout(4),
-      inputStubData_nentries_1_V_5        => VMSME_L3PHIC21n1_nentries_1_VV_dout(5),
-      inputStubData_nentries_1_V_6        => VMSME_L3PHIC21n1_nentries_1_VV_dout(6),
-      inputStubData_nentries_1_V_7        => VMSME_L3PHIC21n1_nentries_1_VV_dout(7),
-      inputStubData_nentries_2_V_0        => VMSME_L3PHIC21n1_nentries_2_VV_dout(0),
-      inputStubData_nentries_2_V_1        => VMSME_L3PHIC21n1_nentries_2_VV_dout(1),
-      inputStubData_nentries_2_V_2        => VMSME_L3PHIC21n1_nentries_2_VV_dout(2),
-      inputStubData_nentries_2_V_3        => VMSME_L3PHIC21n1_nentries_2_VV_dout(3),
-      inputStubData_nentries_2_V_4        => VMSME_L3PHIC21n1_nentries_2_VV_dout(4),
-      inputStubData_nentries_2_V_5        => VMSME_L3PHIC21n1_nentries_2_VV_dout(5),
-      inputStubData_nentries_2_V_6        => VMSME_L3PHIC21n1_nentries_2_VV_dout(6),
-      inputStubData_nentries_2_V_7        => VMSME_L3PHIC21n1_nentries_2_VV_dout(7),
-      inputStubData_nentries_3_V_0        => VMSME_L3PHIC21n1_nentries_3_VV_dout(0),
-      inputStubData_nentries_3_V_1        => VMSME_L3PHIC21n1_nentries_3_VV_dout(1),
-      inputStubData_nentries_3_V_2        => VMSME_L3PHIC21n1_nentries_3_VV_dout(2),
-      inputStubData_nentries_3_V_3        => VMSME_L3PHIC21n1_nentries_3_VV_dout(3),
-      inputStubData_nentries_3_V_4        => VMSME_L3PHIC21n1_nentries_3_VV_dout(4),
-      inputStubData_nentries_3_V_5        => VMSME_L3PHIC21n1_nentries_3_VV_dout(5),
-      inputStubData_nentries_3_V_6        => VMSME_L3PHIC21n1_nentries_3_VV_dout(6),
-      inputStubData_nentries_3_V_7        => VMSME_L3PHIC21n1_nentries_3_VV_dout(7),
-      inputStubData_nentries_4_V_0        => VMSME_L3PHIC21n1_nentries_4_VV_dout(0),
-      inputStubData_nentries_4_V_1        => VMSME_L3PHIC21n1_nentries_4_VV_dout(1),
-      inputStubData_nentries_4_V_2        => VMSME_L3PHIC21n1_nentries_4_VV_dout(2),
-      inputStubData_nentries_4_V_3        => VMSME_L3PHIC21n1_nentries_4_VV_dout(3),
-      inputStubData_nentries_4_V_4        => VMSME_L3PHIC21n1_nentries_4_VV_dout(4),
-      inputStubData_nentries_4_V_5        => VMSME_L3PHIC21n1_nentries_4_VV_dout(5),
-      inputStubData_nentries_4_V_6        => VMSME_L3PHIC21n1_nentries_4_VV_dout(6),
-      inputStubData_nentries_4_V_7        => VMSME_L3PHIC21n1_nentries_4_VV_dout(7),
-      inputStubData_nentries_5_V_0        => VMSME_L3PHIC21n1_nentries_5_VV_dout(0),
-      inputStubData_nentries_5_V_1        => VMSME_L3PHIC21n1_nentries_5_VV_dout(1),
-      inputStubData_nentries_5_V_2        => VMSME_L3PHIC21n1_nentries_5_VV_dout(2),
-      inputStubData_nentries_5_V_3        => VMSME_L3PHIC21n1_nentries_5_VV_dout(3),
-      inputStubData_nentries_5_V_4        => VMSME_L3PHIC21n1_nentries_5_VV_dout(4),
-      inputStubData_nentries_5_V_5        => VMSME_L3PHIC21n1_nentries_5_VV_dout(5),
-      inputStubData_nentries_5_V_6        => VMSME_L3PHIC21n1_nentries_5_VV_dout(6),
-      inputStubData_nentries_5_V_7        => VMSME_L3PHIC21n1_nentries_5_VV_dout(7),
-      inputStubData_nentries_6_V_0        => VMSME_L3PHIC21n1_nentries_6_VV_dout(0),
-      inputStubData_nentries_6_V_1        => VMSME_L3PHIC21n1_nentries_6_VV_dout(1),
-      inputStubData_nentries_6_V_2        => VMSME_L3PHIC21n1_nentries_6_VV_dout(2),
-      inputStubData_nentries_6_V_3        => VMSME_L3PHIC21n1_nentries_6_VV_dout(3),
-      inputStubData_nentries_6_V_4        => VMSME_L3PHIC21n1_nentries_6_VV_dout(4),
-      inputStubData_nentries_6_V_5        => VMSME_L3PHIC21n1_nentries_6_VV_dout(5),
-      inputStubData_nentries_6_V_6        => VMSME_L3PHIC21n1_nentries_6_VV_dout(6),
-      inputStubData_nentries_6_V_7        => VMSME_L3PHIC21n1_nentries_6_VV_dout(7),
-      inputStubData_nentries_7_V_0        => VMSME_L3PHIC21n1_nentries_7_VV_dout(0),
-      inputStubData_nentries_7_V_1        => VMSME_L3PHIC21n1_nentries_7_VV_dout(1),
-      inputStubData_nentries_7_V_2        => VMSME_L3PHIC21n1_nentries_7_VV_dout(2),
-      inputStubData_nentries_7_V_3        => VMSME_L3PHIC21n1_nentries_7_VV_dout(3),
-      inputStubData_nentries_7_V_4        => VMSME_L3PHIC21n1_nentries_7_VV_dout(4),
-      inputStubData_nentries_7_V_5        => VMSME_L3PHIC21n1_nentries_7_VV_dout(5),
-      inputStubData_nentries_7_V_6        => VMSME_L3PHIC21n1_nentries_7_VV_dout(6),
-      inputStubData_nentries_7_V_7        => VMSME_L3PHIC21n1_nentries_7_VV_dout(7),
-      inputProjectionData_dataarray_data_V_ce0         => VMPROJ_L3PHIC21_dataarray_data_V_enb,
-      inputProjectionData_dataarray_data_V_address0    => VMPROJ_L3PHIC21_dataarray_data_V_readaddr,
-      inputProjectionData_dataarray_data_V_q0            => VMPROJ_L3PHIC21_dataarray_data_V_dout,
-      inputProjectionData_nentries_0_V        => VMPROJ_L3PHIC21_nentries_0_V_dout,
-      inputProjectionData_nentries_1_V        => VMPROJ_L3PHIC21_nentries_1_V_dout,
-      outputCandidateMatch_dataarray_data_V_ce0         => open,
-      outputCandidateMatch_dataarray_data_V_we0         => CM_L3PHIC21_dataarray_data_V_wea,
-      outputCandidateMatch_dataarray_data_V_address0    => CM_L3PHIC21_dataarray_data_V_writeaddr,
-      outputCandidateMatch_dataarray_data_V_d0          => CM_L3PHIC21_dataarray_data_V_din
+      inputStubData_dataarray_data_V_ce0       => VMSME_L3PHIC21n1_dataarray_data_V_enb,
+      inputStubData_dataarray_data_V_address0  => VMSME_L3PHIC21n1_dataarray_data_V_readaddr,
+      inputStubData_dataarray_data_V_q0        => VMSME_L3PHIC21n1_dataarray_data_V_dout,
+      inputStubData_nentries_0_V_0     => VMSME_L3PHIC21n1_nentries_VVV_dout(0)(0),
+      inputStubData_nentries_0_V_1     => VMSME_L3PHIC21n1_nentries_VVV_dout(0)(1),
+      inputStubData_nentries_0_V_2     => VMSME_L3PHIC21n1_nentries_VVV_dout(0)(2),
+      inputStubData_nentries_0_V_3     => VMSME_L3PHIC21n1_nentries_VVV_dout(0)(3),
+      inputStubData_nentries_0_V_4     => VMSME_L3PHIC21n1_nentries_VVV_dout(0)(4),
+      inputStubData_nentries_0_V_5     => VMSME_L3PHIC21n1_nentries_VVV_dout(0)(5),
+      inputStubData_nentries_0_V_6     => VMSME_L3PHIC21n1_nentries_VVV_dout(0)(6),
+      inputStubData_nentries_0_V_7     => VMSME_L3PHIC21n1_nentries_VVV_dout(0)(7),
+      inputStubData_nentries_1_V_0     => VMSME_L3PHIC21n1_nentries_VVV_dout(1)(0),
+      inputStubData_nentries_1_V_1     => VMSME_L3PHIC21n1_nentries_VVV_dout(1)(1),
+      inputStubData_nentries_1_V_2     => VMSME_L3PHIC21n1_nentries_VVV_dout(1)(2),
+      inputStubData_nentries_1_V_3     => VMSME_L3PHIC21n1_nentries_VVV_dout(1)(3),
+      inputStubData_nentries_1_V_4     => VMSME_L3PHIC21n1_nentries_VVV_dout(1)(4),
+      inputStubData_nentries_1_V_5     => VMSME_L3PHIC21n1_nentries_VVV_dout(1)(5),
+      inputStubData_nentries_1_V_6     => VMSME_L3PHIC21n1_nentries_VVV_dout(1)(6),
+      inputStubData_nentries_1_V_7     => VMSME_L3PHIC21n1_nentries_VVV_dout(1)(7),
+      inputStubData_nentries_2_V_0     => VMSME_L3PHIC21n1_nentries_VVV_dout(2)(0),
+      inputStubData_nentries_2_V_1     => VMSME_L3PHIC21n1_nentries_VVV_dout(2)(1),
+      inputStubData_nentries_2_V_2     => VMSME_L3PHIC21n1_nentries_VVV_dout(2)(2),
+      inputStubData_nentries_2_V_3     => VMSME_L3PHIC21n1_nentries_VVV_dout(2)(3),
+      inputStubData_nentries_2_V_4     => VMSME_L3PHIC21n1_nentries_VVV_dout(2)(4),
+      inputStubData_nentries_2_V_5     => VMSME_L3PHIC21n1_nentries_VVV_dout(2)(5),
+      inputStubData_nentries_2_V_6     => VMSME_L3PHIC21n1_nentries_VVV_dout(2)(6),
+      inputStubData_nentries_2_V_7     => VMSME_L3PHIC21n1_nentries_VVV_dout(2)(7),
+      inputStubData_nentries_3_V_0     => VMSME_L3PHIC21n1_nentries_VVV_dout(3)(0),
+      inputStubData_nentries_3_V_1     => VMSME_L3PHIC21n1_nentries_VVV_dout(3)(1),
+      inputStubData_nentries_3_V_2     => VMSME_L3PHIC21n1_nentries_VVV_dout(3)(2),
+      inputStubData_nentries_3_V_3     => VMSME_L3PHIC21n1_nentries_VVV_dout(3)(3),
+      inputStubData_nentries_3_V_4     => VMSME_L3PHIC21n1_nentries_VVV_dout(3)(4),
+      inputStubData_nentries_3_V_5     => VMSME_L3PHIC21n1_nentries_VVV_dout(3)(5),
+      inputStubData_nentries_3_V_6     => VMSME_L3PHIC21n1_nentries_VVV_dout(3)(6),
+      inputStubData_nentries_3_V_7     => VMSME_L3PHIC21n1_nentries_VVV_dout(3)(7),
+      inputStubData_nentries_4_V_0     => VMSME_L3PHIC21n1_nentries_VVV_dout(4)(0),
+      inputStubData_nentries_4_V_1     => VMSME_L3PHIC21n1_nentries_VVV_dout(4)(1),
+      inputStubData_nentries_4_V_2     => VMSME_L3PHIC21n1_nentries_VVV_dout(4)(2),
+      inputStubData_nentries_4_V_3     => VMSME_L3PHIC21n1_nentries_VVV_dout(4)(3),
+      inputStubData_nentries_4_V_4     => VMSME_L3PHIC21n1_nentries_VVV_dout(4)(4),
+      inputStubData_nentries_4_V_5     => VMSME_L3PHIC21n1_nentries_VVV_dout(4)(5),
+      inputStubData_nentries_4_V_6     => VMSME_L3PHIC21n1_nentries_VVV_dout(4)(6),
+      inputStubData_nentries_4_V_7     => VMSME_L3PHIC21n1_nentries_VVV_dout(4)(7),
+      inputStubData_nentries_5_V_0     => VMSME_L3PHIC21n1_nentries_VVV_dout(5)(0),
+      inputStubData_nentries_5_V_1     => VMSME_L3PHIC21n1_nentries_VVV_dout(5)(1),
+      inputStubData_nentries_5_V_2     => VMSME_L3PHIC21n1_nentries_VVV_dout(5)(2),
+      inputStubData_nentries_5_V_3     => VMSME_L3PHIC21n1_nentries_VVV_dout(5)(3),
+      inputStubData_nentries_5_V_4     => VMSME_L3PHIC21n1_nentries_VVV_dout(5)(4),
+      inputStubData_nentries_5_V_5     => VMSME_L3PHIC21n1_nentries_VVV_dout(5)(5),
+      inputStubData_nentries_5_V_6     => VMSME_L3PHIC21n1_nentries_VVV_dout(5)(6),
+      inputStubData_nentries_5_V_7     => VMSME_L3PHIC21n1_nentries_VVV_dout(5)(7),
+      inputStubData_nentries_6_V_0     => VMSME_L3PHIC21n1_nentries_VVV_dout(6)(0),
+      inputStubData_nentries_6_V_1     => VMSME_L3PHIC21n1_nentries_VVV_dout(6)(1),
+      inputStubData_nentries_6_V_2     => VMSME_L3PHIC21n1_nentries_VVV_dout(6)(2),
+      inputStubData_nentries_6_V_3     => VMSME_L3PHIC21n1_nentries_VVV_dout(6)(3),
+      inputStubData_nentries_6_V_4     => VMSME_L3PHIC21n1_nentries_VVV_dout(6)(4),
+      inputStubData_nentries_6_V_5     => VMSME_L3PHIC21n1_nentries_VVV_dout(6)(5),
+      inputStubData_nentries_6_V_6     => VMSME_L3PHIC21n1_nentries_VVV_dout(6)(6),
+      inputStubData_nentries_6_V_7     => VMSME_L3PHIC21n1_nentries_VVV_dout(6)(7),
+      inputStubData_nentries_7_V_0     => VMSME_L3PHIC21n1_nentries_VVV_dout(7)(0),
+      inputStubData_nentries_7_V_1     => VMSME_L3PHIC21n1_nentries_VVV_dout(7)(1),
+      inputStubData_nentries_7_V_2     => VMSME_L3PHIC21n1_nentries_VVV_dout(7)(2),
+      inputStubData_nentries_7_V_3     => VMSME_L3PHIC21n1_nentries_VVV_dout(7)(3),
+      inputStubData_nentries_7_V_4     => VMSME_L3PHIC21n1_nentries_VVV_dout(7)(4),
+      inputStubData_nentries_7_V_5     => VMSME_L3PHIC21n1_nentries_VVV_dout(7)(5),
+      inputStubData_nentries_7_V_6     => VMSME_L3PHIC21n1_nentries_VVV_dout(7)(6),
+      inputStubData_nentries_7_V_7     => VMSME_L3PHIC21n1_nentries_VVV_dout(7)(7),
+      inputProjectionData_dataarray_data_V_ce0       => VMPROJ_L3PHIC21_dataarray_data_V_enb,
+      inputProjectionData_dataarray_data_V_address0  => VMPROJ_L3PHIC21_dataarray_data_V_readaddr,
+      inputProjectionData_dataarray_data_V_q0        => VMPROJ_L3PHIC21_dataarray_data_V_dout,
+      inputProjectionData_nentries_0_V               => VMPROJ_L3PHIC21_nentries_VV_dout(0),
+      inputProjectionData_nentries_1_V               => VMPROJ_L3PHIC21_nentries_VV_dout(1),
+      outputCandidateMatch_dataarray_data_V_ce0       => open,
+      outputCandidateMatch_dataarray_data_V_we0       => CM_L3PHIC21_dataarray_data_V_wea,
+      outputCandidateMatch_dataarray_data_V_address0  => CM_L3PHIC21_dataarray_data_V_writeaddr,
+      outputCandidateMatch_dataarray_data_V_d0        => CM_L3PHIC21_dataarray_data_V_din
   );
 
 
@@ -2040,82 +1706,82 @@ architecture rtl of SectorProcessor is
       ap_ready => open,
       ap_done  => open,
       bx_V          => bx_out_ProjectionRouter,
-      inputStubData_dataarray_data_V_ce0         => VMSME_L3PHIC22n1_dataarray_data_V_enb,
-      inputStubData_dataarray_data_V_address0    => VMSME_L3PHIC22n1_dataarray_data_V_readaddr,
-      inputStubData_dataarray_data_V_q0            => VMSME_L3PHIC22n1_dataarray_data_V_dout,
-      inputStubData_nentries_0_V_0        => VMSME_L3PHIC22n1_nentries_0_VV_dout(0),
-      inputStubData_nentries_0_V_1        => VMSME_L3PHIC22n1_nentries_0_VV_dout(1),
-      inputStubData_nentries_0_V_2        => VMSME_L3PHIC22n1_nentries_0_VV_dout(2),
-      inputStubData_nentries_0_V_3        => VMSME_L3PHIC22n1_nentries_0_VV_dout(3),
-      inputStubData_nentries_0_V_4        => VMSME_L3PHIC22n1_nentries_0_VV_dout(4),
-      inputStubData_nentries_0_V_5        => VMSME_L3PHIC22n1_nentries_0_VV_dout(5),
-      inputStubData_nentries_0_V_6        => VMSME_L3PHIC22n1_nentries_0_VV_dout(6),
-      inputStubData_nentries_0_V_7        => VMSME_L3PHIC22n1_nentries_0_VV_dout(7),
-      inputStubData_nentries_1_V_0        => VMSME_L3PHIC22n1_nentries_1_VV_dout(0),
-      inputStubData_nentries_1_V_1        => VMSME_L3PHIC22n1_nentries_1_VV_dout(1),
-      inputStubData_nentries_1_V_2        => VMSME_L3PHIC22n1_nentries_1_VV_dout(2),
-      inputStubData_nentries_1_V_3        => VMSME_L3PHIC22n1_nentries_1_VV_dout(3),
-      inputStubData_nentries_1_V_4        => VMSME_L3PHIC22n1_nentries_1_VV_dout(4),
-      inputStubData_nentries_1_V_5        => VMSME_L3PHIC22n1_nentries_1_VV_dout(5),
-      inputStubData_nentries_1_V_6        => VMSME_L3PHIC22n1_nentries_1_VV_dout(6),
-      inputStubData_nentries_1_V_7        => VMSME_L3PHIC22n1_nentries_1_VV_dout(7),
-      inputStubData_nentries_2_V_0        => VMSME_L3PHIC22n1_nentries_2_VV_dout(0),
-      inputStubData_nentries_2_V_1        => VMSME_L3PHIC22n1_nentries_2_VV_dout(1),
-      inputStubData_nentries_2_V_2        => VMSME_L3PHIC22n1_nentries_2_VV_dout(2),
-      inputStubData_nentries_2_V_3        => VMSME_L3PHIC22n1_nentries_2_VV_dout(3),
-      inputStubData_nentries_2_V_4        => VMSME_L3PHIC22n1_nentries_2_VV_dout(4),
-      inputStubData_nentries_2_V_5        => VMSME_L3PHIC22n1_nentries_2_VV_dout(5),
-      inputStubData_nentries_2_V_6        => VMSME_L3PHIC22n1_nentries_2_VV_dout(6),
-      inputStubData_nentries_2_V_7        => VMSME_L3PHIC22n1_nentries_2_VV_dout(7),
-      inputStubData_nentries_3_V_0        => VMSME_L3PHIC22n1_nentries_3_VV_dout(0),
-      inputStubData_nentries_3_V_1        => VMSME_L3PHIC22n1_nentries_3_VV_dout(1),
-      inputStubData_nentries_3_V_2        => VMSME_L3PHIC22n1_nentries_3_VV_dout(2),
-      inputStubData_nentries_3_V_3        => VMSME_L3PHIC22n1_nentries_3_VV_dout(3),
-      inputStubData_nentries_3_V_4        => VMSME_L3PHIC22n1_nentries_3_VV_dout(4),
-      inputStubData_nentries_3_V_5        => VMSME_L3PHIC22n1_nentries_3_VV_dout(5),
-      inputStubData_nentries_3_V_6        => VMSME_L3PHIC22n1_nentries_3_VV_dout(6),
-      inputStubData_nentries_3_V_7        => VMSME_L3PHIC22n1_nentries_3_VV_dout(7),
-      inputStubData_nentries_4_V_0        => VMSME_L3PHIC22n1_nentries_4_VV_dout(0),
-      inputStubData_nentries_4_V_1        => VMSME_L3PHIC22n1_nentries_4_VV_dout(1),
-      inputStubData_nentries_4_V_2        => VMSME_L3PHIC22n1_nentries_4_VV_dout(2),
-      inputStubData_nentries_4_V_3        => VMSME_L3PHIC22n1_nentries_4_VV_dout(3),
-      inputStubData_nentries_4_V_4        => VMSME_L3PHIC22n1_nentries_4_VV_dout(4),
-      inputStubData_nentries_4_V_5        => VMSME_L3PHIC22n1_nentries_4_VV_dout(5),
-      inputStubData_nentries_4_V_6        => VMSME_L3PHIC22n1_nentries_4_VV_dout(6),
-      inputStubData_nentries_4_V_7        => VMSME_L3PHIC22n1_nentries_4_VV_dout(7),
-      inputStubData_nentries_5_V_0        => VMSME_L3PHIC22n1_nentries_5_VV_dout(0),
-      inputStubData_nentries_5_V_1        => VMSME_L3PHIC22n1_nentries_5_VV_dout(1),
-      inputStubData_nentries_5_V_2        => VMSME_L3PHIC22n1_nentries_5_VV_dout(2),
-      inputStubData_nentries_5_V_3        => VMSME_L3PHIC22n1_nentries_5_VV_dout(3),
-      inputStubData_nentries_5_V_4        => VMSME_L3PHIC22n1_nentries_5_VV_dout(4),
-      inputStubData_nentries_5_V_5        => VMSME_L3PHIC22n1_nentries_5_VV_dout(5),
-      inputStubData_nentries_5_V_6        => VMSME_L3PHIC22n1_nentries_5_VV_dout(6),
-      inputStubData_nentries_5_V_7        => VMSME_L3PHIC22n1_nentries_5_VV_dout(7),
-      inputStubData_nentries_6_V_0        => VMSME_L3PHIC22n1_nentries_6_VV_dout(0),
-      inputStubData_nentries_6_V_1        => VMSME_L3PHIC22n1_nentries_6_VV_dout(1),
-      inputStubData_nentries_6_V_2        => VMSME_L3PHIC22n1_nentries_6_VV_dout(2),
-      inputStubData_nentries_6_V_3        => VMSME_L3PHIC22n1_nentries_6_VV_dout(3),
-      inputStubData_nentries_6_V_4        => VMSME_L3PHIC22n1_nentries_6_VV_dout(4),
-      inputStubData_nentries_6_V_5        => VMSME_L3PHIC22n1_nentries_6_VV_dout(5),
-      inputStubData_nentries_6_V_6        => VMSME_L3PHIC22n1_nentries_6_VV_dout(6),
-      inputStubData_nentries_6_V_7        => VMSME_L3PHIC22n1_nentries_6_VV_dout(7),
-      inputStubData_nentries_7_V_0        => VMSME_L3PHIC22n1_nentries_7_VV_dout(0),
-      inputStubData_nentries_7_V_1        => VMSME_L3PHIC22n1_nentries_7_VV_dout(1),
-      inputStubData_nentries_7_V_2        => VMSME_L3PHIC22n1_nentries_7_VV_dout(2),
-      inputStubData_nentries_7_V_3        => VMSME_L3PHIC22n1_nentries_7_VV_dout(3),
-      inputStubData_nentries_7_V_4        => VMSME_L3PHIC22n1_nentries_7_VV_dout(4),
-      inputStubData_nentries_7_V_5        => VMSME_L3PHIC22n1_nentries_7_VV_dout(5),
-      inputStubData_nentries_7_V_6        => VMSME_L3PHIC22n1_nentries_7_VV_dout(6),
-      inputStubData_nentries_7_V_7        => VMSME_L3PHIC22n1_nentries_7_VV_dout(7),
-      inputProjectionData_dataarray_data_V_ce0         => VMPROJ_L3PHIC22_dataarray_data_V_enb,
-      inputProjectionData_dataarray_data_V_address0    => VMPROJ_L3PHIC22_dataarray_data_V_readaddr,
-      inputProjectionData_dataarray_data_V_q0            => VMPROJ_L3PHIC22_dataarray_data_V_dout,
-      inputProjectionData_nentries_0_V        => VMPROJ_L3PHIC22_nentries_0_V_dout,
-      inputProjectionData_nentries_1_V        => VMPROJ_L3PHIC22_nentries_1_V_dout,
-      outputCandidateMatch_dataarray_data_V_ce0         => open,
-      outputCandidateMatch_dataarray_data_V_we0         => CM_L3PHIC22_dataarray_data_V_wea,
-      outputCandidateMatch_dataarray_data_V_address0    => CM_L3PHIC22_dataarray_data_V_writeaddr,
-      outputCandidateMatch_dataarray_data_V_d0          => CM_L3PHIC22_dataarray_data_V_din
+      inputStubData_dataarray_data_V_ce0       => VMSME_L3PHIC22n1_dataarray_data_V_enb,
+      inputStubData_dataarray_data_V_address0  => VMSME_L3PHIC22n1_dataarray_data_V_readaddr,
+      inputStubData_dataarray_data_V_q0        => VMSME_L3PHIC22n1_dataarray_data_V_dout,
+      inputStubData_nentries_0_V_0     => VMSME_L3PHIC22n1_nentries_VVV_dout(0)(0),
+      inputStubData_nentries_0_V_1     => VMSME_L3PHIC22n1_nentries_VVV_dout(0)(1),
+      inputStubData_nentries_0_V_2     => VMSME_L3PHIC22n1_nentries_VVV_dout(0)(2),
+      inputStubData_nentries_0_V_3     => VMSME_L3PHIC22n1_nentries_VVV_dout(0)(3),
+      inputStubData_nentries_0_V_4     => VMSME_L3PHIC22n1_nentries_VVV_dout(0)(4),
+      inputStubData_nentries_0_V_5     => VMSME_L3PHIC22n1_nentries_VVV_dout(0)(5),
+      inputStubData_nentries_0_V_6     => VMSME_L3PHIC22n1_nentries_VVV_dout(0)(6),
+      inputStubData_nentries_0_V_7     => VMSME_L3PHIC22n1_nentries_VVV_dout(0)(7),
+      inputStubData_nentries_1_V_0     => VMSME_L3PHIC22n1_nentries_VVV_dout(1)(0),
+      inputStubData_nentries_1_V_1     => VMSME_L3PHIC22n1_nentries_VVV_dout(1)(1),
+      inputStubData_nentries_1_V_2     => VMSME_L3PHIC22n1_nentries_VVV_dout(1)(2),
+      inputStubData_nentries_1_V_3     => VMSME_L3PHIC22n1_nentries_VVV_dout(1)(3),
+      inputStubData_nentries_1_V_4     => VMSME_L3PHIC22n1_nentries_VVV_dout(1)(4),
+      inputStubData_nentries_1_V_5     => VMSME_L3PHIC22n1_nentries_VVV_dout(1)(5),
+      inputStubData_nentries_1_V_6     => VMSME_L3PHIC22n1_nentries_VVV_dout(1)(6),
+      inputStubData_nentries_1_V_7     => VMSME_L3PHIC22n1_nentries_VVV_dout(1)(7),
+      inputStubData_nentries_2_V_0     => VMSME_L3PHIC22n1_nentries_VVV_dout(2)(0),
+      inputStubData_nentries_2_V_1     => VMSME_L3PHIC22n1_nentries_VVV_dout(2)(1),
+      inputStubData_nentries_2_V_2     => VMSME_L3PHIC22n1_nentries_VVV_dout(2)(2),
+      inputStubData_nentries_2_V_3     => VMSME_L3PHIC22n1_nentries_VVV_dout(2)(3),
+      inputStubData_nentries_2_V_4     => VMSME_L3PHIC22n1_nentries_VVV_dout(2)(4),
+      inputStubData_nentries_2_V_5     => VMSME_L3PHIC22n1_nentries_VVV_dout(2)(5),
+      inputStubData_nentries_2_V_6     => VMSME_L3PHIC22n1_nentries_VVV_dout(2)(6),
+      inputStubData_nentries_2_V_7     => VMSME_L3PHIC22n1_nentries_VVV_dout(2)(7),
+      inputStubData_nentries_3_V_0     => VMSME_L3PHIC22n1_nentries_VVV_dout(3)(0),
+      inputStubData_nentries_3_V_1     => VMSME_L3PHIC22n1_nentries_VVV_dout(3)(1),
+      inputStubData_nentries_3_V_2     => VMSME_L3PHIC22n1_nentries_VVV_dout(3)(2),
+      inputStubData_nentries_3_V_3     => VMSME_L3PHIC22n1_nentries_VVV_dout(3)(3),
+      inputStubData_nentries_3_V_4     => VMSME_L3PHIC22n1_nentries_VVV_dout(3)(4),
+      inputStubData_nentries_3_V_5     => VMSME_L3PHIC22n1_nentries_VVV_dout(3)(5),
+      inputStubData_nentries_3_V_6     => VMSME_L3PHIC22n1_nentries_VVV_dout(3)(6),
+      inputStubData_nentries_3_V_7     => VMSME_L3PHIC22n1_nentries_VVV_dout(3)(7),
+      inputStubData_nentries_4_V_0     => VMSME_L3PHIC22n1_nentries_VVV_dout(4)(0),
+      inputStubData_nentries_4_V_1     => VMSME_L3PHIC22n1_nentries_VVV_dout(4)(1),
+      inputStubData_nentries_4_V_2     => VMSME_L3PHIC22n1_nentries_VVV_dout(4)(2),
+      inputStubData_nentries_4_V_3     => VMSME_L3PHIC22n1_nentries_VVV_dout(4)(3),
+      inputStubData_nentries_4_V_4     => VMSME_L3PHIC22n1_nentries_VVV_dout(4)(4),
+      inputStubData_nentries_4_V_5     => VMSME_L3PHIC22n1_nentries_VVV_dout(4)(5),
+      inputStubData_nentries_4_V_6     => VMSME_L3PHIC22n1_nentries_VVV_dout(4)(6),
+      inputStubData_nentries_4_V_7     => VMSME_L3PHIC22n1_nentries_VVV_dout(4)(7),
+      inputStubData_nentries_5_V_0     => VMSME_L3PHIC22n1_nentries_VVV_dout(5)(0),
+      inputStubData_nentries_5_V_1     => VMSME_L3PHIC22n1_nentries_VVV_dout(5)(1),
+      inputStubData_nentries_5_V_2     => VMSME_L3PHIC22n1_nentries_VVV_dout(5)(2),
+      inputStubData_nentries_5_V_3     => VMSME_L3PHIC22n1_nentries_VVV_dout(5)(3),
+      inputStubData_nentries_5_V_4     => VMSME_L3PHIC22n1_nentries_VVV_dout(5)(4),
+      inputStubData_nentries_5_V_5     => VMSME_L3PHIC22n1_nentries_VVV_dout(5)(5),
+      inputStubData_nentries_5_V_6     => VMSME_L3PHIC22n1_nentries_VVV_dout(5)(6),
+      inputStubData_nentries_5_V_7     => VMSME_L3PHIC22n1_nentries_VVV_dout(5)(7),
+      inputStubData_nentries_6_V_0     => VMSME_L3PHIC22n1_nentries_VVV_dout(6)(0),
+      inputStubData_nentries_6_V_1     => VMSME_L3PHIC22n1_nentries_VVV_dout(6)(1),
+      inputStubData_nentries_6_V_2     => VMSME_L3PHIC22n1_nentries_VVV_dout(6)(2),
+      inputStubData_nentries_6_V_3     => VMSME_L3PHIC22n1_nentries_VVV_dout(6)(3),
+      inputStubData_nentries_6_V_4     => VMSME_L3PHIC22n1_nentries_VVV_dout(6)(4),
+      inputStubData_nentries_6_V_5     => VMSME_L3PHIC22n1_nentries_VVV_dout(6)(5),
+      inputStubData_nentries_6_V_6     => VMSME_L3PHIC22n1_nentries_VVV_dout(6)(6),
+      inputStubData_nentries_6_V_7     => VMSME_L3PHIC22n1_nentries_VVV_dout(6)(7),
+      inputStubData_nentries_7_V_0     => VMSME_L3PHIC22n1_nentries_VVV_dout(7)(0),
+      inputStubData_nentries_7_V_1     => VMSME_L3PHIC22n1_nentries_VVV_dout(7)(1),
+      inputStubData_nentries_7_V_2     => VMSME_L3PHIC22n1_nentries_VVV_dout(7)(2),
+      inputStubData_nentries_7_V_3     => VMSME_L3PHIC22n1_nentries_VVV_dout(7)(3),
+      inputStubData_nentries_7_V_4     => VMSME_L3PHIC22n1_nentries_VVV_dout(7)(4),
+      inputStubData_nentries_7_V_5     => VMSME_L3PHIC22n1_nentries_VVV_dout(7)(5),
+      inputStubData_nentries_7_V_6     => VMSME_L3PHIC22n1_nentries_VVV_dout(7)(6),
+      inputStubData_nentries_7_V_7     => VMSME_L3PHIC22n1_nentries_VVV_dout(7)(7),
+      inputProjectionData_dataarray_data_V_ce0       => VMPROJ_L3PHIC22_dataarray_data_V_enb,
+      inputProjectionData_dataarray_data_V_address0  => VMPROJ_L3PHIC22_dataarray_data_V_readaddr,
+      inputProjectionData_dataarray_data_V_q0        => VMPROJ_L3PHIC22_dataarray_data_V_dout,
+      inputProjectionData_nentries_0_V               => VMPROJ_L3PHIC22_nentries_VV_dout(0),
+      inputProjectionData_nentries_1_V               => VMPROJ_L3PHIC22_nentries_VV_dout(1),
+      outputCandidateMatch_dataarray_data_V_ce0       => open,
+      outputCandidateMatch_dataarray_data_V_we0       => CM_L3PHIC22_dataarray_data_V_wea,
+      outputCandidateMatch_dataarray_data_V_address0  => CM_L3PHIC22_dataarray_data_V_writeaddr,
+      outputCandidateMatch_dataarray_data_V_d0        => CM_L3PHIC22_dataarray_data_V_din
   );
 
 
@@ -2128,82 +1794,82 @@ architecture rtl of SectorProcessor is
       ap_ready => open,
       ap_done  => open,
       bx_V          => bx_out_ProjectionRouter,
-      inputStubData_dataarray_data_V_ce0         => VMSME_L3PHIC23n1_dataarray_data_V_enb,
-      inputStubData_dataarray_data_V_address0    => VMSME_L3PHIC23n1_dataarray_data_V_readaddr,
-      inputStubData_dataarray_data_V_q0            => VMSME_L3PHIC23n1_dataarray_data_V_dout,
-      inputStubData_nentries_0_V_0        => VMSME_L3PHIC23n1_nentries_0_VV_dout(0),
-      inputStubData_nentries_0_V_1        => VMSME_L3PHIC23n1_nentries_0_VV_dout(1),
-      inputStubData_nentries_0_V_2        => VMSME_L3PHIC23n1_nentries_0_VV_dout(2),
-      inputStubData_nentries_0_V_3        => VMSME_L3PHIC23n1_nentries_0_VV_dout(3),
-      inputStubData_nentries_0_V_4        => VMSME_L3PHIC23n1_nentries_0_VV_dout(4),
-      inputStubData_nentries_0_V_5        => VMSME_L3PHIC23n1_nentries_0_VV_dout(5),
-      inputStubData_nentries_0_V_6        => VMSME_L3PHIC23n1_nentries_0_VV_dout(6),
-      inputStubData_nentries_0_V_7        => VMSME_L3PHIC23n1_nentries_0_VV_dout(7),
-      inputStubData_nentries_1_V_0        => VMSME_L3PHIC23n1_nentries_1_VV_dout(0),
-      inputStubData_nentries_1_V_1        => VMSME_L3PHIC23n1_nentries_1_VV_dout(1),
-      inputStubData_nentries_1_V_2        => VMSME_L3PHIC23n1_nentries_1_VV_dout(2),
-      inputStubData_nentries_1_V_3        => VMSME_L3PHIC23n1_nentries_1_VV_dout(3),
-      inputStubData_nentries_1_V_4        => VMSME_L3PHIC23n1_nentries_1_VV_dout(4),
-      inputStubData_nentries_1_V_5        => VMSME_L3PHIC23n1_nentries_1_VV_dout(5),
-      inputStubData_nentries_1_V_6        => VMSME_L3PHIC23n1_nentries_1_VV_dout(6),
-      inputStubData_nentries_1_V_7        => VMSME_L3PHIC23n1_nentries_1_VV_dout(7),
-      inputStubData_nentries_2_V_0        => VMSME_L3PHIC23n1_nentries_2_VV_dout(0),
-      inputStubData_nentries_2_V_1        => VMSME_L3PHIC23n1_nentries_2_VV_dout(1),
-      inputStubData_nentries_2_V_2        => VMSME_L3PHIC23n1_nentries_2_VV_dout(2),
-      inputStubData_nentries_2_V_3        => VMSME_L3PHIC23n1_nentries_2_VV_dout(3),
-      inputStubData_nentries_2_V_4        => VMSME_L3PHIC23n1_nentries_2_VV_dout(4),
-      inputStubData_nentries_2_V_5        => VMSME_L3PHIC23n1_nentries_2_VV_dout(5),
-      inputStubData_nentries_2_V_6        => VMSME_L3PHIC23n1_nentries_2_VV_dout(6),
-      inputStubData_nentries_2_V_7        => VMSME_L3PHIC23n1_nentries_2_VV_dout(7),
-      inputStubData_nentries_3_V_0        => VMSME_L3PHIC23n1_nentries_3_VV_dout(0),
-      inputStubData_nentries_3_V_1        => VMSME_L3PHIC23n1_nentries_3_VV_dout(1),
-      inputStubData_nentries_3_V_2        => VMSME_L3PHIC23n1_nentries_3_VV_dout(2),
-      inputStubData_nentries_3_V_3        => VMSME_L3PHIC23n1_nentries_3_VV_dout(3),
-      inputStubData_nentries_3_V_4        => VMSME_L3PHIC23n1_nentries_3_VV_dout(4),
-      inputStubData_nentries_3_V_5        => VMSME_L3PHIC23n1_nentries_3_VV_dout(5),
-      inputStubData_nentries_3_V_6        => VMSME_L3PHIC23n1_nentries_3_VV_dout(6),
-      inputStubData_nentries_3_V_7        => VMSME_L3PHIC23n1_nentries_3_VV_dout(7),
-      inputStubData_nentries_4_V_0        => VMSME_L3PHIC23n1_nentries_4_VV_dout(0),
-      inputStubData_nentries_4_V_1        => VMSME_L3PHIC23n1_nentries_4_VV_dout(1),
-      inputStubData_nentries_4_V_2        => VMSME_L3PHIC23n1_nentries_4_VV_dout(2),
-      inputStubData_nentries_4_V_3        => VMSME_L3PHIC23n1_nentries_4_VV_dout(3),
-      inputStubData_nentries_4_V_4        => VMSME_L3PHIC23n1_nentries_4_VV_dout(4),
-      inputStubData_nentries_4_V_5        => VMSME_L3PHIC23n1_nentries_4_VV_dout(5),
-      inputStubData_nentries_4_V_6        => VMSME_L3PHIC23n1_nentries_4_VV_dout(6),
-      inputStubData_nentries_4_V_7        => VMSME_L3PHIC23n1_nentries_4_VV_dout(7),
-      inputStubData_nentries_5_V_0        => VMSME_L3PHIC23n1_nentries_5_VV_dout(0),
-      inputStubData_nentries_5_V_1        => VMSME_L3PHIC23n1_nentries_5_VV_dout(1),
-      inputStubData_nentries_5_V_2        => VMSME_L3PHIC23n1_nentries_5_VV_dout(2),
-      inputStubData_nentries_5_V_3        => VMSME_L3PHIC23n1_nentries_5_VV_dout(3),
-      inputStubData_nentries_5_V_4        => VMSME_L3PHIC23n1_nentries_5_VV_dout(4),
-      inputStubData_nentries_5_V_5        => VMSME_L3PHIC23n1_nentries_5_VV_dout(5),
-      inputStubData_nentries_5_V_6        => VMSME_L3PHIC23n1_nentries_5_VV_dout(6),
-      inputStubData_nentries_5_V_7        => VMSME_L3PHIC23n1_nentries_5_VV_dout(7),
-      inputStubData_nentries_6_V_0        => VMSME_L3PHIC23n1_nentries_6_VV_dout(0),
-      inputStubData_nentries_6_V_1        => VMSME_L3PHIC23n1_nentries_6_VV_dout(1),
-      inputStubData_nentries_6_V_2        => VMSME_L3PHIC23n1_nentries_6_VV_dout(2),
-      inputStubData_nentries_6_V_3        => VMSME_L3PHIC23n1_nentries_6_VV_dout(3),
-      inputStubData_nentries_6_V_4        => VMSME_L3PHIC23n1_nentries_6_VV_dout(4),
-      inputStubData_nentries_6_V_5        => VMSME_L3PHIC23n1_nentries_6_VV_dout(5),
-      inputStubData_nentries_6_V_6        => VMSME_L3PHIC23n1_nentries_6_VV_dout(6),
-      inputStubData_nentries_6_V_7        => VMSME_L3PHIC23n1_nentries_6_VV_dout(7),
-      inputStubData_nentries_7_V_0        => VMSME_L3PHIC23n1_nentries_7_VV_dout(0),
-      inputStubData_nentries_7_V_1        => VMSME_L3PHIC23n1_nentries_7_VV_dout(1),
-      inputStubData_nentries_7_V_2        => VMSME_L3PHIC23n1_nentries_7_VV_dout(2),
-      inputStubData_nentries_7_V_3        => VMSME_L3PHIC23n1_nentries_7_VV_dout(3),
-      inputStubData_nentries_7_V_4        => VMSME_L3PHIC23n1_nentries_7_VV_dout(4),
-      inputStubData_nentries_7_V_5        => VMSME_L3PHIC23n1_nentries_7_VV_dout(5),
-      inputStubData_nentries_7_V_6        => VMSME_L3PHIC23n1_nentries_7_VV_dout(6),
-      inputStubData_nentries_7_V_7        => VMSME_L3PHIC23n1_nentries_7_VV_dout(7),
-      inputProjectionData_dataarray_data_V_ce0         => VMPROJ_L3PHIC23_dataarray_data_V_enb,
-      inputProjectionData_dataarray_data_V_address0    => VMPROJ_L3PHIC23_dataarray_data_V_readaddr,
-      inputProjectionData_dataarray_data_V_q0            => VMPROJ_L3PHIC23_dataarray_data_V_dout,
-      inputProjectionData_nentries_0_V        => VMPROJ_L3PHIC23_nentries_0_V_dout,
-      inputProjectionData_nentries_1_V        => VMPROJ_L3PHIC23_nentries_1_V_dout,
-      outputCandidateMatch_dataarray_data_V_ce0         => open,
-      outputCandidateMatch_dataarray_data_V_we0         => CM_L3PHIC23_dataarray_data_V_wea,
-      outputCandidateMatch_dataarray_data_V_address0    => CM_L3PHIC23_dataarray_data_V_writeaddr,
-      outputCandidateMatch_dataarray_data_V_d0          => CM_L3PHIC23_dataarray_data_V_din
+      inputStubData_dataarray_data_V_ce0       => VMSME_L3PHIC23n1_dataarray_data_V_enb,
+      inputStubData_dataarray_data_V_address0  => VMSME_L3PHIC23n1_dataarray_data_V_readaddr,
+      inputStubData_dataarray_data_V_q0        => VMSME_L3PHIC23n1_dataarray_data_V_dout,
+      inputStubData_nentries_0_V_0     => VMSME_L3PHIC23n1_nentries_VVV_dout(0)(0),
+      inputStubData_nentries_0_V_1     => VMSME_L3PHIC23n1_nentries_VVV_dout(0)(1),
+      inputStubData_nentries_0_V_2     => VMSME_L3PHIC23n1_nentries_VVV_dout(0)(2),
+      inputStubData_nentries_0_V_3     => VMSME_L3PHIC23n1_nentries_VVV_dout(0)(3),
+      inputStubData_nentries_0_V_4     => VMSME_L3PHIC23n1_nentries_VVV_dout(0)(4),
+      inputStubData_nentries_0_V_5     => VMSME_L3PHIC23n1_nentries_VVV_dout(0)(5),
+      inputStubData_nentries_0_V_6     => VMSME_L3PHIC23n1_nentries_VVV_dout(0)(6),
+      inputStubData_nentries_0_V_7     => VMSME_L3PHIC23n1_nentries_VVV_dout(0)(7),
+      inputStubData_nentries_1_V_0     => VMSME_L3PHIC23n1_nentries_VVV_dout(1)(0),
+      inputStubData_nentries_1_V_1     => VMSME_L3PHIC23n1_nentries_VVV_dout(1)(1),
+      inputStubData_nentries_1_V_2     => VMSME_L3PHIC23n1_nentries_VVV_dout(1)(2),
+      inputStubData_nentries_1_V_3     => VMSME_L3PHIC23n1_nentries_VVV_dout(1)(3),
+      inputStubData_nentries_1_V_4     => VMSME_L3PHIC23n1_nentries_VVV_dout(1)(4),
+      inputStubData_nentries_1_V_5     => VMSME_L3PHIC23n1_nentries_VVV_dout(1)(5),
+      inputStubData_nentries_1_V_6     => VMSME_L3PHIC23n1_nentries_VVV_dout(1)(6),
+      inputStubData_nentries_1_V_7     => VMSME_L3PHIC23n1_nentries_VVV_dout(1)(7),
+      inputStubData_nentries_2_V_0     => VMSME_L3PHIC23n1_nentries_VVV_dout(2)(0),
+      inputStubData_nentries_2_V_1     => VMSME_L3PHIC23n1_nentries_VVV_dout(2)(1),
+      inputStubData_nentries_2_V_2     => VMSME_L3PHIC23n1_nentries_VVV_dout(2)(2),
+      inputStubData_nentries_2_V_3     => VMSME_L3PHIC23n1_nentries_VVV_dout(2)(3),
+      inputStubData_nentries_2_V_4     => VMSME_L3PHIC23n1_nentries_VVV_dout(2)(4),
+      inputStubData_nentries_2_V_5     => VMSME_L3PHIC23n1_nentries_VVV_dout(2)(5),
+      inputStubData_nentries_2_V_6     => VMSME_L3PHIC23n1_nentries_VVV_dout(2)(6),
+      inputStubData_nentries_2_V_7     => VMSME_L3PHIC23n1_nentries_VVV_dout(2)(7),
+      inputStubData_nentries_3_V_0     => VMSME_L3PHIC23n1_nentries_VVV_dout(3)(0),
+      inputStubData_nentries_3_V_1     => VMSME_L3PHIC23n1_nentries_VVV_dout(3)(1),
+      inputStubData_nentries_3_V_2     => VMSME_L3PHIC23n1_nentries_VVV_dout(3)(2),
+      inputStubData_nentries_3_V_3     => VMSME_L3PHIC23n1_nentries_VVV_dout(3)(3),
+      inputStubData_nentries_3_V_4     => VMSME_L3PHIC23n1_nentries_VVV_dout(3)(4),
+      inputStubData_nentries_3_V_5     => VMSME_L3PHIC23n1_nentries_VVV_dout(3)(5),
+      inputStubData_nentries_3_V_6     => VMSME_L3PHIC23n1_nentries_VVV_dout(3)(6),
+      inputStubData_nentries_3_V_7     => VMSME_L3PHIC23n1_nentries_VVV_dout(3)(7),
+      inputStubData_nentries_4_V_0     => VMSME_L3PHIC23n1_nentries_VVV_dout(4)(0),
+      inputStubData_nentries_4_V_1     => VMSME_L3PHIC23n1_nentries_VVV_dout(4)(1),
+      inputStubData_nentries_4_V_2     => VMSME_L3PHIC23n1_nentries_VVV_dout(4)(2),
+      inputStubData_nentries_4_V_3     => VMSME_L3PHIC23n1_nentries_VVV_dout(4)(3),
+      inputStubData_nentries_4_V_4     => VMSME_L3PHIC23n1_nentries_VVV_dout(4)(4),
+      inputStubData_nentries_4_V_5     => VMSME_L3PHIC23n1_nentries_VVV_dout(4)(5),
+      inputStubData_nentries_4_V_6     => VMSME_L3PHIC23n1_nentries_VVV_dout(4)(6),
+      inputStubData_nentries_4_V_7     => VMSME_L3PHIC23n1_nentries_VVV_dout(4)(7),
+      inputStubData_nentries_5_V_0     => VMSME_L3PHIC23n1_nentries_VVV_dout(5)(0),
+      inputStubData_nentries_5_V_1     => VMSME_L3PHIC23n1_nentries_VVV_dout(5)(1),
+      inputStubData_nentries_5_V_2     => VMSME_L3PHIC23n1_nentries_VVV_dout(5)(2),
+      inputStubData_nentries_5_V_3     => VMSME_L3PHIC23n1_nentries_VVV_dout(5)(3),
+      inputStubData_nentries_5_V_4     => VMSME_L3PHIC23n1_nentries_VVV_dout(5)(4),
+      inputStubData_nentries_5_V_5     => VMSME_L3PHIC23n1_nentries_VVV_dout(5)(5),
+      inputStubData_nentries_5_V_6     => VMSME_L3PHIC23n1_nentries_VVV_dout(5)(6),
+      inputStubData_nentries_5_V_7     => VMSME_L3PHIC23n1_nentries_VVV_dout(5)(7),
+      inputStubData_nentries_6_V_0     => VMSME_L3PHIC23n1_nentries_VVV_dout(6)(0),
+      inputStubData_nentries_6_V_1     => VMSME_L3PHIC23n1_nentries_VVV_dout(6)(1),
+      inputStubData_nentries_6_V_2     => VMSME_L3PHIC23n1_nentries_VVV_dout(6)(2),
+      inputStubData_nentries_6_V_3     => VMSME_L3PHIC23n1_nentries_VVV_dout(6)(3),
+      inputStubData_nentries_6_V_4     => VMSME_L3PHIC23n1_nentries_VVV_dout(6)(4),
+      inputStubData_nentries_6_V_5     => VMSME_L3PHIC23n1_nentries_VVV_dout(6)(5),
+      inputStubData_nentries_6_V_6     => VMSME_L3PHIC23n1_nentries_VVV_dout(6)(6),
+      inputStubData_nentries_6_V_7     => VMSME_L3PHIC23n1_nentries_VVV_dout(6)(7),
+      inputStubData_nentries_7_V_0     => VMSME_L3PHIC23n1_nentries_VVV_dout(7)(0),
+      inputStubData_nentries_7_V_1     => VMSME_L3PHIC23n1_nentries_VVV_dout(7)(1),
+      inputStubData_nentries_7_V_2     => VMSME_L3PHIC23n1_nentries_VVV_dout(7)(2),
+      inputStubData_nentries_7_V_3     => VMSME_L3PHIC23n1_nentries_VVV_dout(7)(3),
+      inputStubData_nentries_7_V_4     => VMSME_L3PHIC23n1_nentries_VVV_dout(7)(4),
+      inputStubData_nentries_7_V_5     => VMSME_L3PHIC23n1_nentries_VVV_dout(7)(5),
+      inputStubData_nentries_7_V_6     => VMSME_L3PHIC23n1_nentries_VVV_dout(7)(6),
+      inputStubData_nentries_7_V_7     => VMSME_L3PHIC23n1_nentries_VVV_dout(7)(7),
+      inputProjectionData_dataarray_data_V_ce0       => VMPROJ_L3PHIC23_dataarray_data_V_enb,
+      inputProjectionData_dataarray_data_V_address0  => VMPROJ_L3PHIC23_dataarray_data_V_readaddr,
+      inputProjectionData_dataarray_data_V_q0        => VMPROJ_L3PHIC23_dataarray_data_V_dout,
+      inputProjectionData_nentries_0_V               => VMPROJ_L3PHIC23_nentries_VV_dout(0),
+      inputProjectionData_nentries_1_V               => VMPROJ_L3PHIC23_nentries_VV_dout(1),
+      outputCandidateMatch_dataarray_data_V_ce0       => open,
+      outputCandidateMatch_dataarray_data_V_we0       => CM_L3PHIC23_dataarray_data_V_wea,
+      outputCandidateMatch_dataarray_data_V_address0  => CM_L3PHIC23_dataarray_data_V_writeaddr,
+      outputCandidateMatch_dataarray_data_V_d0        => CM_L3PHIC23_dataarray_data_V_din
   );
 
 
@@ -2216,82 +1882,82 @@ architecture rtl of SectorProcessor is
       ap_ready => open,
       ap_done  => open,
       bx_V          => bx_out_ProjectionRouter,
-      inputStubData_dataarray_data_V_ce0         => VMSME_L3PHIC24n1_dataarray_data_V_enb,
-      inputStubData_dataarray_data_V_address0    => VMSME_L3PHIC24n1_dataarray_data_V_readaddr,
-      inputStubData_dataarray_data_V_q0            => VMSME_L3PHIC24n1_dataarray_data_V_dout,
-      inputStubData_nentries_0_V_0        => VMSME_L3PHIC24n1_nentries_0_VV_dout(0),
-      inputStubData_nentries_0_V_1        => VMSME_L3PHIC24n1_nentries_0_VV_dout(1),
-      inputStubData_nentries_0_V_2        => VMSME_L3PHIC24n1_nentries_0_VV_dout(2),
-      inputStubData_nentries_0_V_3        => VMSME_L3PHIC24n1_nentries_0_VV_dout(3),
-      inputStubData_nentries_0_V_4        => VMSME_L3PHIC24n1_nentries_0_VV_dout(4),
-      inputStubData_nentries_0_V_5        => VMSME_L3PHIC24n1_nentries_0_VV_dout(5),
-      inputStubData_nentries_0_V_6        => VMSME_L3PHIC24n1_nentries_0_VV_dout(6),
-      inputStubData_nentries_0_V_7        => VMSME_L3PHIC24n1_nentries_0_VV_dout(7),
-      inputStubData_nentries_1_V_0        => VMSME_L3PHIC24n1_nentries_1_VV_dout(0),
-      inputStubData_nentries_1_V_1        => VMSME_L3PHIC24n1_nentries_1_VV_dout(1),
-      inputStubData_nentries_1_V_2        => VMSME_L3PHIC24n1_nentries_1_VV_dout(2),
-      inputStubData_nentries_1_V_3        => VMSME_L3PHIC24n1_nentries_1_VV_dout(3),
-      inputStubData_nentries_1_V_4        => VMSME_L3PHIC24n1_nentries_1_VV_dout(4),
-      inputStubData_nentries_1_V_5        => VMSME_L3PHIC24n1_nentries_1_VV_dout(5),
-      inputStubData_nentries_1_V_6        => VMSME_L3PHIC24n1_nentries_1_VV_dout(6),
-      inputStubData_nentries_1_V_7        => VMSME_L3PHIC24n1_nentries_1_VV_dout(7),
-      inputStubData_nentries_2_V_0        => VMSME_L3PHIC24n1_nentries_2_VV_dout(0),
-      inputStubData_nentries_2_V_1        => VMSME_L3PHIC24n1_nentries_2_VV_dout(1),
-      inputStubData_nentries_2_V_2        => VMSME_L3PHIC24n1_nentries_2_VV_dout(2),
-      inputStubData_nentries_2_V_3        => VMSME_L3PHIC24n1_nentries_2_VV_dout(3),
-      inputStubData_nentries_2_V_4        => VMSME_L3PHIC24n1_nentries_2_VV_dout(4),
-      inputStubData_nentries_2_V_5        => VMSME_L3PHIC24n1_nentries_2_VV_dout(5),
-      inputStubData_nentries_2_V_6        => VMSME_L3PHIC24n1_nentries_2_VV_dout(6),
-      inputStubData_nentries_2_V_7        => VMSME_L3PHIC24n1_nentries_2_VV_dout(7),
-      inputStubData_nentries_3_V_0        => VMSME_L3PHIC24n1_nentries_3_VV_dout(0),
-      inputStubData_nentries_3_V_1        => VMSME_L3PHIC24n1_nentries_3_VV_dout(1),
-      inputStubData_nentries_3_V_2        => VMSME_L3PHIC24n1_nentries_3_VV_dout(2),
-      inputStubData_nentries_3_V_3        => VMSME_L3PHIC24n1_nentries_3_VV_dout(3),
-      inputStubData_nentries_3_V_4        => VMSME_L3PHIC24n1_nentries_3_VV_dout(4),
-      inputStubData_nentries_3_V_5        => VMSME_L3PHIC24n1_nentries_3_VV_dout(5),
-      inputStubData_nentries_3_V_6        => VMSME_L3PHIC24n1_nentries_3_VV_dout(6),
-      inputStubData_nentries_3_V_7        => VMSME_L3PHIC24n1_nentries_3_VV_dout(7),
-      inputStubData_nentries_4_V_0        => VMSME_L3PHIC24n1_nentries_4_VV_dout(0),
-      inputStubData_nentries_4_V_1        => VMSME_L3PHIC24n1_nentries_4_VV_dout(1),
-      inputStubData_nentries_4_V_2        => VMSME_L3PHIC24n1_nentries_4_VV_dout(2),
-      inputStubData_nentries_4_V_3        => VMSME_L3PHIC24n1_nentries_4_VV_dout(3),
-      inputStubData_nentries_4_V_4        => VMSME_L3PHIC24n1_nentries_4_VV_dout(4),
-      inputStubData_nentries_4_V_5        => VMSME_L3PHIC24n1_nentries_4_VV_dout(5),
-      inputStubData_nentries_4_V_6        => VMSME_L3PHIC24n1_nentries_4_VV_dout(6),
-      inputStubData_nentries_4_V_7        => VMSME_L3PHIC24n1_nentries_4_VV_dout(7),
-      inputStubData_nentries_5_V_0        => VMSME_L3PHIC24n1_nentries_5_VV_dout(0),
-      inputStubData_nentries_5_V_1        => VMSME_L3PHIC24n1_nentries_5_VV_dout(1),
-      inputStubData_nentries_5_V_2        => VMSME_L3PHIC24n1_nentries_5_VV_dout(2),
-      inputStubData_nentries_5_V_3        => VMSME_L3PHIC24n1_nentries_5_VV_dout(3),
-      inputStubData_nentries_5_V_4        => VMSME_L3PHIC24n1_nentries_5_VV_dout(4),
-      inputStubData_nentries_5_V_5        => VMSME_L3PHIC24n1_nentries_5_VV_dout(5),
-      inputStubData_nentries_5_V_6        => VMSME_L3PHIC24n1_nentries_5_VV_dout(6),
-      inputStubData_nentries_5_V_7        => VMSME_L3PHIC24n1_nentries_5_VV_dout(7),
-      inputStubData_nentries_6_V_0        => VMSME_L3PHIC24n1_nentries_6_VV_dout(0),
-      inputStubData_nentries_6_V_1        => VMSME_L3PHIC24n1_nentries_6_VV_dout(1),
-      inputStubData_nentries_6_V_2        => VMSME_L3PHIC24n1_nentries_6_VV_dout(2),
-      inputStubData_nentries_6_V_3        => VMSME_L3PHIC24n1_nentries_6_VV_dout(3),
-      inputStubData_nentries_6_V_4        => VMSME_L3PHIC24n1_nentries_6_VV_dout(4),
-      inputStubData_nentries_6_V_5        => VMSME_L3PHIC24n1_nentries_6_VV_dout(5),
-      inputStubData_nentries_6_V_6        => VMSME_L3PHIC24n1_nentries_6_VV_dout(6),
-      inputStubData_nentries_6_V_7        => VMSME_L3PHIC24n1_nentries_6_VV_dout(7),
-      inputStubData_nentries_7_V_0        => VMSME_L3PHIC24n1_nentries_7_VV_dout(0),
-      inputStubData_nentries_7_V_1        => VMSME_L3PHIC24n1_nentries_7_VV_dout(1),
-      inputStubData_nentries_7_V_2        => VMSME_L3PHIC24n1_nentries_7_VV_dout(2),
-      inputStubData_nentries_7_V_3        => VMSME_L3PHIC24n1_nentries_7_VV_dout(3),
-      inputStubData_nentries_7_V_4        => VMSME_L3PHIC24n1_nentries_7_VV_dout(4),
-      inputStubData_nentries_7_V_5        => VMSME_L3PHIC24n1_nentries_7_VV_dout(5),
-      inputStubData_nentries_7_V_6        => VMSME_L3PHIC24n1_nentries_7_VV_dout(6),
-      inputStubData_nentries_7_V_7        => VMSME_L3PHIC24n1_nentries_7_VV_dout(7),
-      inputProjectionData_dataarray_data_V_ce0         => VMPROJ_L3PHIC24_dataarray_data_V_enb,
-      inputProjectionData_dataarray_data_V_address0    => VMPROJ_L3PHIC24_dataarray_data_V_readaddr,
-      inputProjectionData_dataarray_data_V_q0            => VMPROJ_L3PHIC24_dataarray_data_V_dout,
-      inputProjectionData_nentries_0_V        => VMPROJ_L3PHIC24_nentries_0_V_dout,
-      inputProjectionData_nentries_1_V        => VMPROJ_L3PHIC24_nentries_1_V_dout,
-      outputCandidateMatch_dataarray_data_V_ce0         => open,
-      outputCandidateMatch_dataarray_data_V_we0         => CM_L3PHIC24_dataarray_data_V_wea,
-      outputCandidateMatch_dataarray_data_V_address0    => CM_L3PHIC24_dataarray_data_V_writeaddr,
-      outputCandidateMatch_dataarray_data_V_d0          => CM_L3PHIC24_dataarray_data_V_din
+      inputStubData_dataarray_data_V_ce0       => VMSME_L3PHIC24n1_dataarray_data_V_enb,
+      inputStubData_dataarray_data_V_address0  => VMSME_L3PHIC24n1_dataarray_data_V_readaddr,
+      inputStubData_dataarray_data_V_q0        => VMSME_L3PHIC24n1_dataarray_data_V_dout,
+      inputStubData_nentries_0_V_0     => VMSME_L3PHIC24n1_nentries_VVV_dout(0)(0),
+      inputStubData_nentries_0_V_1     => VMSME_L3PHIC24n1_nentries_VVV_dout(0)(1),
+      inputStubData_nentries_0_V_2     => VMSME_L3PHIC24n1_nentries_VVV_dout(0)(2),
+      inputStubData_nentries_0_V_3     => VMSME_L3PHIC24n1_nentries_VVV_dout(0)(3),
+      inputStubData_nentries_0_V_4     => VMSME_L3PHIC24n1_nentries_VVV_dout(0)(4),
+      inputStubData_nentries_0_V_5     => VMSME_L3PHIC24n1_nentries_VVV_dout(0)(5),
+      inputStubData_nentries_0_V_6     => VMSME_L3PHIC24n1_nentries_VVV_dout(0)(6),
+      inputStubData_nentries_0_V_7     => VMSME_L3PHIC24n1_nentries_VVV_dout(0)(7),
+      inputStubData_nentries_1_V_0     => VMSME_L3PHIC24n1_nentries_VVV_dout(1)(0),
+      inputStubData_nentries_1_V_1     => VMSME_L3PHIC24n1_nentries_VVV_dout(1)(1),
+      inputStubData_nentries_1_V_2     => VMSME_L3PHIC24n1_nentries_VVV_dout(1)(2),
+      inputStubData_nentries_1_V_3     => VMSME_L3PHIC24n1_nentries_VVV_dout(1)(3),
+      inputStubData_nentries_1_V_4     => VMSME_L3PHIC24n1_nentries_VVV_dout(1)(4),
+      inputStubData_nentries_1_V_5     => VMSME_L3PHIC24n1_nentries_VVV_dout(1)(5),
+      inputStubData_nentries_1_V_6     => VMSME_L3PHIC24n1_nentries_VVV_dout(1)(6),
+      inputStubData_nentries_1_V_7     => VMSME_L3PHIC24n1_nentries_VVV_dout(1)(7),
+      inputStubData_nentries_2_V_0     => VMSME_L3PHIC24n1_nentries_VVV_dout(2)(0),
+      inputStubData_nentries_2_V_1     => VMSME_L3PHIC24n1_nentries_VVV_dout(2)(1),
+      inputStubData_nentries_2_V_2     => VMSME_L3PHIC24n1_nentries_VVV_dout(2)(2),
+      inputStubData_nentries_2_V_3     => VMSME_L3PHIC24n1_nentries_VVV_dout(2)(3),
+      inputStubData_nentries_2_V_4     => VMSME_L3PHIC24n1_nentries_VVV_dout(2)(4),
+      inputStubData_nentries_2_V_5     => VMSME_L3PHIC24n1_nentries_VVV_dout(2)(5),
+      inputStubData_nentries_2_V_6     => VMSME_L3PHIC24n1_nentries_VVV_dout(2)(6),
+      inputStubData_nentries_2_V_7     => VMSME_L3PHIC24n1_nentries_VVV_dout(2)(7),
+      inputStubData_nentries_3_V_0     => VMSME_L3PHIC24n1_nentries_VVV_dout(3)(0),
+      inputStubData_nentries_3_V_1     => VMSME_L3PHIC24n1_nentries_VVV_dout(3)(1),
+      inputStubData_nentries_3_V_2     => VMSME_L3PHIC24n1_nentries_VVV_dout(3)(2),
+      inputStubData_nentries_3_V_3     => VMSME_L3PHIC24n1_nentries_VVV_dout(3)(3),
+      inputStubData_nentries_3_V_4     => VMSME_L3PHIC24n1_nentries_VVV_dout(3)(4),
+      inputStubData_nentries_3_V_5     => VMSME_L3PHIC24n1_nentries_VVV_dout(3)(5),
+      inputStubData_nentries_3_V_6     => VMSME_L3PHIC24n1_nentries_VVV_dout(3)(6),
+      inputStubData_nentries_3_V_7     => VMSME_L3PHIC24n1_nentries_VVV_dout(3)(7),
+      inputStubData_nentries_4_V_0     => VMSME_L3PHIC24n1_nentries_VVV_dout(4)(0),
+      inputStubData_nentries_4_V_1     => VMSME_L3PHIC24n1_nentries_VVV_dout(4)(1),
+      inputStubData_nentries_4_V_2     => VMSME_L3PHIC24n1_nentries_VVV_dout(4)(2),
+      inputStubData_nentries_4_V_3     => VMSME_L3PHIC24n1_nentries_VVV_dout(4)(3),
+      inputStubData_nentries_4_V_4     => VMSME_L3PHIC24n1_nentries_VVV_dout(4)(4),
+      inputStubData_nentries_4_V_5     => VMSME_L3PHIC24n1_nentries_VVV_dout(4)(5),
+      inputStubData_nentries_4_V_6     => VMSME_L3PHIC24n1_nentries_VVV_dout(4)(6),
+      inputStubData_nentries_4_V_7     => VMSME_L3PHIC24n1_nentries_VVV_dout(4)(7),
+      inputStubData_nentries_5_V_0     => VMSME_L3PHIC24n1_nentries_VVV_dout(5)(0),
+      inputStubData_nentries_5_V_1     => VMSME_L3PHIC24n1_nentries_VVV_dout(5)(1),
+      inputStubData_nentries_5_V_2     => VMSME_L3PHIC24n1_nentries_VVV_dout(5)(2),
+      inputStubData_nentries_5_V_3     => VMSME_L3PHIC24n1_nentries_VVV_dout(5)(3),
+      inputStubData_nentries_5_V_4     => VMSME_L3PHIC24n1_nentries_VVV_dout(5)(4),
+      inputStubData_nentries_5_V_5     => VMSME_L3PHIC24n1_nentries_VVV_dout(5)(5),
+      inputStubData_nentries_5_V_6     => VMSME_L3PHIC24n1_nentries_VVV_dout(5)(6),
+      inputStubData_nentries_5_V_7     => VMSME_L3PHIC24n1_nentries_VVV_dout(5)(7),
+      inputStubData_nentries_6_V_0     => VMSME_L3PHIC24n1_nentries_VVV_dout(6)(0),
+      inputStubData_nentries_6_V_1     => VMSME_L3PHIC24n1_nentries_VVV_dout(6)(1),
+      inputStubData_nentries_6_V_2     => VMSME_L3PHIC24n1_nentries_VVV_dout(6)(2),
+      inputStubData_nentries_6_V_3     => VMSME_L3PHIC24n1_nentries_VVV_dout(6)(3),
+      inputStubData_nentries_6_V_4     => VMSME_L3PHIC24n1_nentries_VVV_dout(6)(4),
+      inputStubData_nentries_6_V_5     => VMSME_L3PHIC24n1_nentries_VVV_dout(6)(5),
+      inputStubData_nentries_6_V_6     => VMSME_L3PHIC24n1_nentries_VVV_dout(6)(6),
+      inputStubData_nentries_6_V_7     => VMSME_L3PHIC24n1_nentries_VVV_dout(6)(7),
+      inputStubData_nentries_7_V_0     => VMSME_L3PHIC24n1_nentries_VVV_dout(7)(0),
+      inputStubData_nentries_7_V_1     => VMSME_L3PHIC24n1_nentries_VVV_dout(7)(1),
+      inputStubData_nentries_7_V_2     => VMSME_L3PHIC24n1_nentries_VVV_dout(7)(2),
+      inputStubData_nentries_7_V_3     => VMSME_L3PHIC24n1_nentries_VVV_dout(7)(3),
+      inputStubData_nentries_7_V_4     => VMSME_L3PHIC24n1_nentries_VVV_dout(7)(4),
+      inputStubData_nentries_7_V_5     => VMSME_L3PHIC24n1_nentries_VVV_dout(7)(5),
+      inputStubData_nentries_7_V_6     => VMSME_L3PHIC24n1_nentries_VVV_dout(7)(6),
+      inputStubData_nentries_7_V_7     => VMSME_L3PHIC24n1_nentries_VVV_dout(7)(7),
+      inputProjectionData_dataarray_data_V_ce0       => VMPROJ_L3PHIC24_dataarray_data_V_enb,
+      inputProjectionData_dataarray_data_V_address0  => VMPROJ_L3PHIC24_dataarray_data_V_readaddr,
+      inputProjectionData_dataarray_data_V_q0        => VMPROJ_L3PHIC24_dataarray_data_V_dout,
+      inputProjectionData_nentries_0_V               => VMPROJ_L3PHIC24_nentries_VV_dout(0),
+      inputProjectionData_nentries_1_V               => VMPROJ_L3PHIC24_nentries_VV_dout(1),
+      outputCandidateMatch_dataarray_data_V_ce0       => open,
+      outputCandidateMatch_dataarray_data_V_we0       => CM_L3PHIC24_dataarray_data_V_wea,
+      outputCandidateMatch_dataarray_data_V_address0  => CM_L3PHIC24_dataarray_data_V_writeaddr,
+      outputCandidateMatch_dataarray_data_V_d0        => CM_L3PHIC24_dataarray_data_V_din
   );
 
 
@@ -2306,60 +1972,60 @@ architecture rtl of SectorProcessor is
       bx_V          => bx_out_MatchEngine,
       bx_o_V        => bx_out_MatchCalculator,
       bx_o_V_ap_vld => bx_out_MatchCalculator_vld,
-      match_0_dataarray_data_V_ce0         => CM_L3PHIC17_dataarray_data_V_enb,
-      match_0_dataarray_data_V_address0    => CM_L3PHIC17_dataarray_data_V_readaddr,
-      match_0_dataarray_data_V_q0            => CM_L3PHIC17_dataarray_data_V_dout,
-      match_0_nentries_0_V        => CM_L3PHIC17_nentries_0_V_dout,
-      match_0_nentries_1_V        => CM_L3PHIC17_nentries_1_V_dout,
-      match_1_dataarray_data_V_ce0         => CM_L3PHIC18_dataarray_data_V_enb,
-      match_1_dataarray_data_V_address0    => CM_L3PHIC18_dataarray_data_V_readaddr,
-      match_1_dataarray_data_V_q0            => CM_L3PHIC18_dataarray_data_V_dout,
-      match_1_nentries_0_V        => CM_L3PHIC18_nentries_0_V_dout,
-      match_1_nentries_1_V        => CM_L3PHIC18_nentries_1_V_dout,
-      match_2_dataarray_data_V_ce0         => CM_L3PHIC19_dataarray_data_V_enb,
-      match_2_dataarray_data_V_address0    => CM_L3PHIC19_dataarray_data_V_readaddr,
-      match_2_dataarray_data_V_q0            => CM_L3PHIC19_dataarray_data_V_dout,
-      match_2_nentries_0_V        => CM_L3PHIC19_nentries_0_V_dout,
-      match_2_nentries_1_V        => CM_L3PHIC19_nentries_1_V_dout,
-      match_3_dataarray_data_V_ce0         => CM_L3PHIC20_dataarray_data_V_enb,
-      match_3_dataarray_data_V_address0    => CM_L3PHIC20_dataarray_data_V_readaddr,
-      match_3_dataarray_data_V_q0            => CM_L3PHIC20_dataarray_data_V_dout,
-      match_3_nentries_0_V        => CM_L3PHIC20_nentries_0_V_dout,
-      match_3_nentries_1_V        => CM_L3PHIC20_nentries_1_V_dout,
-      match_4_dataarray_data_V_ce0         => CM_L3PHIC21_dataarray_data_V_enb,
-      match_4_dataarray_data_V_address0    => CM_L3PHIC21_dataarray_data_V_readaddr,
-      match_4_dataarray_data_V_q0            => CM_L3PHIC21_dataarray_data_V_dout,
-      match_4_nentries_0_V        => CM_L3PHIC21_nentries_0_V_dout,
-      match_4_nentries_1_V        => CM_L3PHIC21_nentries_1_V_dout,
-      match_5_dataarray_data_V_ce0         => CM_L3PHIC22_dataarray_data_V_enb,
-      match_5_dataarray_data_V_address0    => CM_L3PHIC22_dataarray_data_V_readaddr,
-      match_5_dataarray_data_V_q0            => CM_L3PHIC22_dataarray_data_V_dout,
-      match_5_nentries_0_V        => CM_L3PHIC22_nentries_0_V_dout,
-      match_5_nentries_1_V        => CM_L3PHIC22_nentries_1_V_dout,
-      match_6_dataarray_data_V_ce0         => CM_L3PHIC23_dataarray_data_V_enb,
-      match_6_dataarray_data_V_address0    => CM_L3PHIC23_dataarray_data_V_readaddr,
-      match_6_dataarray_data_V_q0            => CM_L3PHIC23_dataarray_data_V_dout,
-      match_6_nentries_0_V        => CM_L3PHIC23_nentries_0_V_dout,
-      match_6_nentries_1_V        => CM_L3PHIC23_nentries_1_V_dout,
-      match_7_dataarray_data_V_ce0         => CM_L3PHIC24_dataarray_data_V_enb,
-      match_7_dataarray_data_V_address0    => CM_L3PHIC24_dataarray_data_V_readaddr,
-      match_7_dataarray_data_V_q0            => CM_L3PHIC24_dataarray_data_V_dout,
-      match_7_nentries_0_V        => CM_L3PHIC24_nentries_0_V_dout,
-      match_7_nentries_1_V        => CM_L3PHIC24_nentries_1_V_dout,
-      allstub_dataarray_data_V_ce0         => AS_L3PHICn6_dataarray_data_V_enb,
-      allstub_dataarray_data_V_address0    => AS_L3PHICn6_dataarray_data_V_readaddr,
-      allstub_dataarray_data_V_q0            => AS_L3PHICn6_dataarray_data_V_dout,
-      allproj_dataarray_data_V_ce0         => AP_L3PHIC_dataarray_data_V_enb,
-      allproj_dataarray_data_V_address0    => AP_L3PHIC_dataarray_data_V_readaddr,
-      allproj_dataarray_data_V_q0            => AP_L3PHIC_dataarray_data_V_dout,
-      fullmatch_0_dataarray_data_V_ce0         => open,
-      fullmatch_0_dataarray_data_V_we0         => FM_L1L2_L3PHIC_dataarray_data_V_wea,
-      fullmatch_0_dataarray_data_V_address0    => FM_L1L2_L3PHIC_dataarray_data_V_writeaddr,
-      fullmatch_0_dataarray_data_V_d0          => FM_L1L2_L3PHIC_dataarray_data_V_din,
-      fullmatch_3_dataarray_data_V_ce0         => open,
-      fullmatch_3_dataarray_data_V_we0         => FM_L5L6_L3PHIC_dataarray_data_V_wea,
-      fullmatch_3_dataarray_data_V_address0    => FM_L5L6_L3PHIC_dataarray_data_V_writeaddr,
-      fullmatch_3_dataarray_data_V_d0          => FM_L5L6_L3PHIC_dataarray_data_V_din
+      match_0_dataarray_data_V_ce0       => CM_L3PHIC17_dataarray_data_V_enb,
+      match_0_dataarray_data_V_address0  => CM_L3PHIC17_dataarray_data_V_readaddr,
+      match_0_dataarray_data_V_q0        => CM_L3PHIC17_dataarray_data_V_dout,
+      match_0_nentries_0_V               => CM_L3PHIC17_nentries_VV_dout(0),
+      match_0_nentries_1_V               => CM_L3PHIC17_nentries_VV_dout(1),
+      match_1_dataarray_data_V_ce0       => CM_L3PHIC18_dataarray_data_V_enb,
+      match_1_dataarray_data_V_address0  => CM_L3PHIC18_dataarray_data_V_readaddr,
+      match_1_dataarray_data_V_q0        => CM_L3PHIC18_dataarray_data_V_dout,
+      match_1_nentries_0_V               => CM_L3PHIC18_nentries_VV_dout(0),
+      match_1_nentries_1_V               => CM_L3PHIC18_nentries_VV_dout(1),
+      match_2_dataarray_data_V_ce0       => CM_L3PHIC19_dataarray_data_V_enb,
+      match_2_dataarray_data_V_address0  => CM_L3PHIC19_dataarray_data_V_readaddr,
+      match_2_dataarray_data_V_q0        => CM_L3PHIC19_dataarray_data_V_dout,
+      match_2_nentries_0_V               => CM_L3PHIC19_nentries_VV_dout(0),
+      match_2_nentries_1_V               => CM_L3PHIC19_nentries_VV_dout(1),
+      match_3_dataarray_data_V_ce0       => CM_L3PHIC20_dataarray_data_V_enb,
+      match_3_dataarray_data_V_address0  => CM_L3PHIC20_dataarray_data_V_readaddr,
+      match_3_dataarray_data_V_q0        => CM_L3PHIC20_dataarray_data_V_dout,
+      match_3_nentries_0_V               => CM_L3PHIC20_nentries_VV_dout(0),
+      match_3_nentries_1_V               => CM_L3PHIC20_nentries_VV_dout(1),
+      match_4_dataarray_data_V_ce0       => CM_L3PHIC21_dataarray_data_V_enb,
+      match_4_dataarray_data_V_address0  => CM_L3PHIC21_dataarray_data_V_readaddr,
+      match_4_dataarray_data_V_q0        => CM_L3PHIC21_dataarray_data_V_dout,
+      match_4_nentries_0_V               => CM_L3PHIC21_nentries_VV_dout(0),
+      match_4_nentries_1_V               => CM_L3PHIC21_nentries_VV_dout(1),
+      match_5_dataarray_data_V_ce0       => CM_L3PHIC22_dataarray_data_V_enb,
+      match_5_dataarray_data_V_address0  => CM_L3PHIC22_dataarray_data_V_readaddr,
+      match_5_dataarray_data_V_q0        => CM_L3PHIC22_dataarray_data_V_dout,
+      match_5_nentries_0_V               => CM_L3PHIC22_nentries_VV_dout(0),
+      match_5_nentries_1_V               => CM_L3PHIC22_nentries_VV_dout(1),
+      match_6_dataarray_data_V_ce0       => CM_L3PHIC23_dataarray_data_V_enb,
+      match_6_dataarray_data_V_address0  => CM_L3PHIC23_dataarray_data_V_readaddr,
+      match_6_dataarray_data_V_q0        => CM_L3PHIC23_dataarray_data_V_dout,
+      match_6_nentries_0_V               => CM_L3PHIC23_nentries_VV_dout(0),
+      match_6_nentries_1_V               => CM_L3PHIC23_nentries_VV_dout(1),
+      match_7_dataarray_data_V_ce0       => CM_L3PHIC24_dataarray_data_V_enb,
+      match_7_dataarray_data_V_address0  => CM_L3PHIC24_dataarray_data_V_readaddr,
+      match_7_dataarray_data_V_q0        => CM_L3PHIC24_dataarray_data_V_dout,
+      match_7_nentries_0_V               => CM_L3PHIC24_nentries_VV_dout(0),
+      match_7_nentries_1_V               => CM_L3PHIC24_nentries_VV_dout(1),
+      allstub_dataarray_data_V_ce0       => AS_L3PHICn6_dataarray_data_V_enb,
+      allstub_dataarray_data_V_address0  => AS_L3PHICn6_dataarray_data_V_readaddr,
+      allstub_dataarray_data_V_q0        => AS_L3PHICn6_dataarray_data_V_dout,
+      allproj_dataarray_data_V_ce0       => AP_L3PHIC_dataarray_data_V_enb,
+      allproj_dataarray_data_V_address0  => AP_L3PHIC_dataarray_data_V_readaddr,
+      allproj_dataarray_data_V_q0        => AP_L3PHIC_dataarray_data_V_dout,
+      fullmatch_0_dataarray_data_V_ce0       => open,
+      fullmatch_0_dataarray_data_V_we0       => FM_L1L2_L3PHIC_dataarray_data_V_wea,
+      fullmatch_0_dataarray_data_V_address0  => FM_L1L2_L3PHIC_dataarray_data_V_writeaddr,
+      fullmatch_0_dataarray_data_V_d0        => FM_L1L2_L3PHIC_dataarray_data_V_din,
+      fullmatch_3_dataarray_data_V_ce0       => open,
+      fullmatch_3_dataarray_data_V_we0       => FM_L5L6_L3PHIC_dataarray_data_V_wea,
+      fullmatch_3_dataarray_data_V_address0  => FM_L5L6_L3PHIC_dataarray_data_V_writeaddr,
+      fullmatch_3_dataarray_data_V_d0        => FM_L5L6_L3PHIC_dataarray_data_V_din
   );
 
 

--- a/IntegrationTests/PRMEMC/hdl/tf_top.vhd
+++ b/IntegrationTests/PRMEMC/hdl/tf_top.vhd
@@ -66,7 +66,7 @@ architecture rtl of tf_top is
   signal TPROJ_L3PHIC_dataarray_data_V_enb      : t_arr8_1b;
   signal TPROJ_L3PHIC_dataarray_data_V_readaddr : t_arr8_8b;
   signal TPROJ_L3PHIC_dataarray_data_V_dout     : t_arr8_60b;
-  signal TPROJ_L3PHIC_nentries_V_dout : t_arr2_8_7b;
+  signal TPROJ_L3PHIC_nentries_V_dout : t_arr8_2_7b;
 
   -- ProjectionRouter signals
   signal PR_done       : std_logic := '0';
@@ -87,13 +87,13 @@ architecture rtl of tf_top is
   signal VMPROJ_L3PHIC17to24_dataarray_data_V_enb      : t_arr8_1b;
   signal VMPROJ_L3PHIC17to24_dataarray_data_V_readaddr : t_arr8_8b;
   signal VMPROJ_L3PHIC17to24_dataarray_data_V_dout     : t_arr8_21b;
-  signal VMPROJ_L3PHIC17to24_nentries_V_dout : t_arr2_8_7b;
+  signal VMPROJ_L3PHIC17to24_nentries_V_dout : t_arr8_2_7b;
 
   -- connecting VMStubME memories to MatchEngine input
   signal VMSME_L3PHIC17to24n1_dataarray_data_V_enb      : t_arr8_1b;
   signal VMSME_L3PHIC17to24n1_dataarray_data_V_readaddr : t_arr8_10b;
   signal VMSME_L3PHIC17to24n1_dataarray_data_V_dout     : t_arr8_13b;
-  signal VMSME_L3PHIC17to24n1_nentries_V_dout           : t_arr8_8_8_5b := (others => (others => (others => (others => '0')))); -- (#page, #bin, #mem); set MSbit to zero
+  signal VMSME_L3PHIC17to24n1_nentries_V_dout           : t_arr8_8_8_5b := (others => (others => (others => (others => '0')))); -- (#mem, #page, #bin); set MSbit to zero
 
   -- Note: entity work.tf_mem_bin class allocates 4-bits for nentries in each bin, while
   -- MatchEngine ports are expecting 5-bits. Leaving the 5th bit unconnected seems
@@ -132,7 +132,7 @@ architecture rtl of tf_top is
   signal CM_L3PHIC17to24_dataarray_data_V_enb      : t_arr8_1b;
   signal CM_L3PHIC17to24_dataarray_data_V_readaddr : t_arr8_8b;
   signal CM_L3PHIC17to24_dataarray_data_V_dout     : t_arr8_14b;
-  signal CM_L3PHIC17to24_nentries_V_dout : t_arr2_8_7b;
+  signal CM_L3PHIC17to24_nentries_V_dout : t_arr8_2_7b;
 
   -- MatchCalculator signals
   signal MC_start : std_logic := '0';

--- a/IntegrationTests/PRMEMC/hdl/tf_top_full.vhd
+++ b/IntegrationTests/PRMEMC/hdl/tf_top_full.vhd
@@ -86,19 +86,19 @@ architecture rtl of tf_top_full is
   signal TPROJ_L3PHIC_dataarray_data_V_enb      : t_arr8_1b;
   signal TPROJ_L3PHIC_dataarray_data_V_readaddr : t_arr8_8b;
   signal TPROJ_L3PHIC_dataarray_data_V_dout     : t_arr8_60b;
-  signal TPROJ_L3PHIC_nentries_V_dout           : t_arr2_8_7b;
+  signal TPROJ_L3PHIC_nentries_V_dout           : t_arr8_2_7b;
 
   -- connecting VMProjections memories to MatchEngine input
   signal VMPROJ_L3PHIC17to24_dataarray_data_V_enb      : t_arr8_1b;
   signal VMPROJ_L3PHIC17to24_dataarray_data_V_readaddr : t_arr8_8b;
   signal VMPROJ_L3PHIC17to24_dataarray_data_V_dout     : t_arr8_21b;
-  signal VMPROJ_L3PHIC17to24_nentries_V_dout           : t_arr2_8_7b;
+  signal VMPROJ_L3PHIC17to24_nentries_V_dout           : t_arr8_2_7b;
 
   -- connecting VMStubME memories to MatchEngine input
   signal VMSME_L3PHIC17to24n1_dataarray_data_V_enb      : t_arr8_1b;
   signal VMSME_L3PHIC17to24n1_dataarray_data_V_readaddr : t_arr8_10b;
   signal VMSME_L3PHIC17to24n1_dataarray_data_V_dout     : t_arr8_13b;
-  signal VMSME_L3PHIC17to24n1_nentries_V_dout           : t_arr8_8_8_5b := (others => (others => (others => (others => '0')))); -- (#page, #bin, #mem); set MSbit to zero
+  signal VMSME_L3PHIC17to24n1_nentries_V_dout           : t_arr8_8_8_5b := (others => (others => (others => (others => '0')))); -- (#mem, #page, #bin); set MSbit to zero
 
   -- MatchEngine signals
   signal ME_start : std_logic := '0';
@@ -122,7 +122,7 @@ architecture rtl of tf_top_full is
   signal CM_L3PHIC17to24_dataarray_data_V_enb      : t_arr8_1b;
   signal CM_L3PHIC17to24_dataarray_data_V_readaddr : t_arr8_8b;
   signal CM_L3PHIC17to24_dataarray_data_V_dout     : t_arr8_14b;
-  signal CM_L3PHIC17to24_nentries_V_dout           : t_arr2_8_7b;
+  signal CM_L3PHIC17to24_nentries_V_dout           : t_arr8_2_7b;
 
   -- MatchCalculator signals
   signal MC_start : std_logic := '0';
@@ -170,7 +170,7 @@ begin
     TPROJ_L3PHIC : entity work.tf_mem
       generic map (
         RAM_WIDTH       => RAM_WIDTH_TPROJ,
-        RAM_DEPTH       => 256,
+        NUM_PAGES       => 2,
         INIT_FILE       => "",
         INIT_HEX        => true,
         RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -187,14 +187,7 @@ begin
         addrb      => TPROJ_L3PHIC_dataarray_data_V_readaddr(tpidx),
         doutb      => TPROJ_L3PHIC_dataarray_data_V_dout(tpidx),
         sync_nent  => PR_start,
-        nent_o0    => TPROJ_L3PHIC_nentries_V_dout(0)(tpidx),
-        nent_o1    => TPROJ_L3PHIC_nentries_V_dout(1)(tpidx),
-        nent_o2    => open,
-        nent_o3    => open,
-        nent_o4    => open,
-        nent_o5    => open,
-        nent_o6    => open,
-        nent_o7    => open
+        nent_o     => TPROJ_L3PHIC_nentries_V_dout(tpidx)
         );
   end generate gen_TPROJ_L3PHIC;
 
@@ -215,42 +208,42 @@ begin
       projin_0_dataarray_data_V_ce0      => TPROJ_L3PHIC_dataarray_data_V_enb(0),
       projin_0_dataarray_data_V_q0       => TPROJ_L3PHIC_dataarray_data_V_dout(0),
       projin_0_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(0)(0),
-      projin_0_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(1)(0),
+      projin_0_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(0)(1),
       projin_1_dataarray_data_V_address0 => TPROJ_L3PHIC_dataarray_data_V_readaddr(1),
       projin_1_dataarray_data_V_ce0      => TPROJ_L3PHIC_dataarray_data_V_enb(1),
       projin_1_dataarray_data_V_q0       => TPROJ_L3PHIC_dataarray_data_V_dout(1),
-      projin_1_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(0)(1),
+      projin_1_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(1)(0),
       projin_1_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(1)(1),
       projin_2_dataarray_data_V_address0 => TPROJ_L3PHIC_dataarray_data_V_readaddr(2),
       projin_2_dataarray_data_V_ce0      => TPROJ_L3PHIC_dataarray_data_V_enb(2),
       projin_2_dataarray_data_V_q0       => TPROJ_L3PHIC_dataarray_data_V_dout(2),
-      projin_2_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(0)(2),
-      projin_2_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(1)(2),
+      projin_2_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(2)(0),
+      projin_2_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(2)(1),
       projin_3_dataarray_data_V_address0 => TPROJ_L3PHIC_dataarray_data_V_readaddr(3),
       projin_3_dataarray_data_V_ce0      => TPROJ_L3PHIC_dataarray_data_V_enb(3),
       projin_3_dataarray_data_V_q0       => TPROJ_L3PHIC_dataarray_data_V_dout(3),
-      projin_3_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(0)(3),
-      projin_3_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(1)(3),
+      projin_3_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(3)(0),
+      projin_3_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(3)(1),
       projin_4_dataarray_data_V_address0 => TPROJ_L3PHIC_dataarray_data_V_readaddr(4),
       projin_4_dataarray_data_V_ce0      => TPROJ_L3PHIC_dataarray_data_V_enb(4),
       projin_4_dataarray_data_V_q0       => TPROJ_L3PHIC_dataarray_data_V_dout(4),
-      projin_4_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(0)(4),
-      projin_4_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(1)(4),
+      projin_4_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(4)(0),
+      projin_4_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(4)(1),
       projin_5_dataarray_data_V_address0 => TPROJ_L3PHIC_dataarray_data_V_readaddr(5),
       projin_5_dataarray_data_V_ce0      => TPROJ_L3PHIC_dataarray_data_V_enb(5),
       projin_5_dataarray_data_V_q0       => TPROJ_L3PHIC_dataarray_data_V_dout(5),
-      projin_5_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(0)(5),
-      projin_5_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(1)(5),
+      projin_5_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(5)(0),
+      projin_5_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(5)(1),
       projin_6_dataarray_data_V_address0 => TPROJ_L3PHIC_dataarray_data_V_readaddr(6),
       projin_6_dataarray_data_V_ce0      => TPROJ_L3PHIC_dataarray_data_V_enb(6),
       projin_6_dataarray_data_V_q0       => TPROJ_L3PHIC_dataarray_data_V_dout(6),
-      projin_6_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(0)(6),
-      projin_6_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(1)(6),
+      projin_6_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(6)(0),
+      projin_6_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(6)(1),
       projin_7_dataarray_data_V_address0 => TPROJ_L3PHIC_dataarray_data_V_readaddr(7),
       projin_7_dataarray_data_V_ce0      => TPROJ_L3PHIC_dataarray_data_V_enb(7),
       projin_7_dataarray_data_V_q0       => TPROJ_L3PHIC_dataarray_data_V_dout(7),
-      projin_7_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(0)(7),
-      projin_7_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(1)(7),
+      projin_7_nentries_0_V              => TPROJ_L3PHIC_nentries_V_dout(7)(0),
+      projin_7_nentries_1_V              => TPROJ_L3PHIC_nentries_V_dout(7)(1),
       bx_o_V        => PR_bx_out,
       bx_o_V_ap_vld => PR_bx_out_vld,
       allprojout_dataarray_data_V_address0 => AP_L3PHIC_dataarray_data_V_writeaddr,
@@ -298,7 +291,7 @@ begin
   AP_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => RAM_WIDTH_AP,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -315,14 +308,7 @@ begin
       addrb      => AP_L3PHIC_dataarray_data_V_readaddr,
       doutb      => AP_L3PHIC_dataarray_data_V_dout,
       sync_nent  => MC_start,
-      nent_o0    => AP_L3PHIC_nentries_V_dout(0),
-      nent_o1    => AP_L3PHIC_nentries_V_dout(1),
-      nent_o2    => AP_L3PHIC_nentries_V_dout(2),
-      nent_o3    => AP_L3PHIC_nentries_V_dout(3),
-      nent_o4    => AP_L3PHIC_nentries_V_dout(4),
-      nent_o5    => AP_L3PHIC_nentries_V_dout(5),
-      nent_o6    => AP_L3PHIC_nentries_V_dout(6),
-      nent_o7    => AP_L3PHIC_nentries_V_dout(7)
+      nent_o     => AP_L3PHIC_nentries_V_dout
       );
 
 
@@ -334,7 +320,7 @@ begin
     VMPROJ_L3PHIC17to24 : entity work.tf_mem
       generic map (
         RAM_WIDTH       => 21,
-        RAM_DEPTH       => 256,
+        NUM_PAGES       => 2,
         INIT_FILE       => "",
         INIT_HEX        => true,
         RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -351,14 +337,7 @@ begin
         addrb      => VMPROJ_L3PHIC17to24_dataarray_data_V_readaddr(vmpidx),
         doutb      => VMPROJ_L3PHIC17to24_dataarray_data_V_dout(vmpidx),
         sync_nent  => ME_start,
-        nent_o0    => VMPROJ_L3PHIC17to24_nentries_V_dout(0)(vmpidx),
-        nent_o1    => VMPROJ_L3PHIC17to24_nentries_V_dout(1)(vmpidx),
-        nent_o2    => open,
-        nent_o3    => open,
-        nent_o4    => open,
-        nent_o5    => open,
-        nent_o6    => open,
-        nent_o7    => open
+        nent_o     => VMPROJ_L3PHIC17to24_nentries_V_dout(vmpidx)
         );
 
   end generate gen_VMPROJ_L3PHIC17to24;
@@ -372,7 +351,7 @@ begin
     VMSME_L3PHIC17to24n1 : entity work.tf_mem_bin
       generic map (
         RAM_WIDTH       => 13,
-        RAM_DEPTH       => 1024,
+        NUM_PAGES       => 8,
         INIT_FILE       => "",
         INIT_HEX        => true,
         RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -389,78 +368,7 @@ begin
         addrb      => VMSME_L3PHIC17to24n1_dataarray_data_V_readaddr(vmsidx),
         doutb      => VMSME_L3PHIC17to24n1_dataarray_data_V_dout(vmsidx),
         sync_nent  => ME_start,
-        --nent_o0   => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(0 to 7)(vmsidx), -- Try replacing the following lines: It results in a lot of errors
-        --nent_o1   => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(0 to 7)(vmsidx), -- Try replacing the following lines: It results in a lot of errors
-        --nent_o2   => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(0 to 7)(vmsidx), -- Try replacing the following lines: It results in a lot of errors
-        --nent_o3   => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(0 to 7)(vmsidx), -- Try replacing the following lines: It results in a lot of errors
-        --nent_o4   => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(0 to 7)(vmsidx), -- Try replacing the following lines: It results in a lot of errors
-        --nent_o5   => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(0 to 7)(vmsidx), -- Try replacing the following lines: It results in a lot of errors
-        --nent_o6   => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(0 to 7)(vmsidx), -- Try replacing the following lines: It results in a lot of errors
-        --nent_o7   => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(0 to 7)(vmsidx)  -- Try replacing the following lines: It results in a lot of errors
-        nent_o0(0) => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(0)(vmsidx),
-        nent_o0(1) => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(1)(vmsidx),
-        nent_o0(2) => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(2)(vmsidx),
-        nent_o0(3) => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(3)(vmsidx),
-        nent_o0(4) => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(4)(vmsidx),
-        nent_o0(5) => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(5)(vmsidx),
-        nent_o0(6) => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(6)(vmsidx),
-        nent_o0(7) => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(7)(vmsidx),
-        nent_o1(0) => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(0)(vmsidx),
-        nent_o1(1) => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(1)(vmsidx),
-        nent_o1(2) => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(2)(vmsidx),
-        nent_o1(3) => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(3)(vmsidx),
-        nent_o1(4) => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(4)(vmsidx),
-        nent_o1(5) => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(5)(vmsidx),
-        nent_o1(6) => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(6)(vmsidx),
-        nent_o1(7) => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(7)(vmsidx),
-        nent_o2(0) => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(0)(vmsidx),
-        nent_o2(1) => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(1)(vmsidx),
-        nent_o2(2) => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(2)(vmsidx),
-        nent_o2(3) => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(3)(vmsidx),
-        nent_o2(4) => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(4)(vmsidx),
-        nent_o2(5) => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(5)(vmsidx),
-        nent_o2(6) => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(6)(vmsidx),
-        nent_o2(7) => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(7)(vmsidx),
-        nent_o3(0) => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(0)(vmsidx),
-        nent_o3(1) => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(1)(vmsidx),
-        nent_o3(2) => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(2)(vmsidx),
-        nent_o3(3) => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(3)(vmsidx),
-        nent_o3(4) => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(4)(vmsidx),
-        nent_o3(5) => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(5)(vmsidx),
-        nent_o3(6) => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(6)(vmsidx),
-        nent_o3(7) => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(7)(vmsidx),
-        nent_o4(0) => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(0)(vmsidx),
-        nent_o4(1) => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(1)(vmsidx),
-        nent_o4(2) => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(2)(vmsidx),
-        nent_o4(3) => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(3)(vmsidx),
-        nent_o4(4) => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(4)(vmsidx),
-        nent_o4(5) => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(5)(vmsidx),
-        nent_o4(6) => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(6)(vmsidx),
-        nent_o4(7) => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(7)(vmsidx),
-        nent_o5(0) => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(0)(vmsidx),
-        nent_o5(1) => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(1)(vmsidx),
-        nent_o5(2) => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(2)(vmsidx),
-        nent_o5(3) => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(3)(vmsidx),
-        nent_o5(4) => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(4)(vmsidx),
-        nent_o5(5) => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(5)(vmsidx),
-        nent_o5(6) => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(6)(vmsidx),
-        nent_o5(7) => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(7)(vmsidx),
-        nent_o6(0) => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(0)(vmsidx),
-        nent_o6(1) => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(1)(vmsidx),
-        nent_o6(2) => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(2)(vmsidx),
-        nent_o6(3) => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(3)(vmsidx),
-        nent_o6(4) => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(4)(vmsidx),
-        nent_o6(5) => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(5)(vmsidx),
-        nent_o6(6) => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(6)(vmsidx),
-        nent_o6(7) => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(7)(vmsidx),
-        nent_o7(0) => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(0)(vmsidx),
-        nent_o7(1) => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(1)(vmsidx),
-        nent_o7(2) => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(2)(vmsidx),
-        nent_o7(3) => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(3)(vmsidx),
-        nent_o7(4) => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(4)(vmsidx),
-        nent_o7(5) => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(5)(vmsidx),
-        nent_o7(6) => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(6)(vmsidx),
-        nent_o7(7) => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(7)(vmsidx)
+        nent_o     => VMSME_L3PHIC17to24n1_nentries_V_dout(vmsidx)
         );
 
   end generate gen_VMSME_L3PHIC17to24n1;
@@ -485,75 +393,75 @@ begin
         inputStubData_dataarray_data_V_address0 => VMSME_L3PHIC17to24n1_dataarray_data_V_readaddr(meidx),
         inputStubData_dataarray_data_V_ce0      => VMSME_L3PHIC17to24n1_dataarray_data_V_enb(meidx),
         inputStubData_dataarray_data_V_q0       => VMSME_L3PHIC17to24n1_dataarray_data_V_dout(meidx),
-        inputStubData_nentries_0_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(0)(meidx),
-        inputStubData_nentries_0_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(1)(meidx),
-        inputStubData_nentries_0_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(2)(meidx),
-        inputStubData_nentries_0_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(3)(meidx),
-        inputStubData_nentries_0_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(4)(meidx),
-        inputStubData_nentries_0_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(5)(meidx),
-        inputStubData_nentries_0_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(6)(meidx),
-        inputStubData_nentries_0_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(0)(7)(meidx),
-        inputStubData_nentries_1_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(0)(meidx),
-        inputStubData_nentries_1_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(1)(meidx),
-        inputStubData_nentries_1_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(2)(meidx),
-        inputStubData_nentries_1_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(3)(meidx),
-        inputStubData_nentries_1_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(4)(meidx),
-        inputStubData_nentries_1_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(5)(meidx),
-        inputStubData_nentries_1_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(6)(meidx),
-        inputStubData_nentries_1_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(1)(7)(meidx),
-        inputStubData_nentries_2_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(0)(meidx),
-        inputStubData_nentries_2_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(1)(meidx),
-        inputStubData_nentries_2_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(2)(meidx),
-        inputStubData_nentries_2_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(3)(meidx),
-        inputStubData_nentries_2_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(4)(meidx),
-        inputStubData_nentries_2_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(5)(meidx),
-        inputStubData_nentries_2_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(6)(meidx),
-        inputStubData_nentries_2_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(2)(7)(meidx),
-        inputStubData_nentries_3_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(0)(meidx),
-        inputStubData_nentries_3_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(1)(meidx),
-        inputStubData_nentries_3_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(2)(meidx),
-        inputStubData_nentries_3_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(3)(meidx),
-        inputStubData_nentries_3_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(4)(meidx),
-        inputStubData_nentries_3_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(5)(meidx),
-        inputStubData_nentries_3_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(6)(meidx),
-        inputStubData_nentries_3_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(3)(7)(meidx),
-        inputStubData_nentries_4_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(0)(meidx),
-        inputStubData_nentries_4_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(1)(meidx),
-        inputStubData_nentries_4_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(2)(meidx),
-        inputStubData_nentries_4_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(3)(meidx),
-        inputStubData_nentries_4_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(4)(meidx),
-        inputStubData_nentries_4_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(5)(meidx),
-        inputStubData_nentries_4_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(6)(meidx),
-        inputStubData_nentries_4_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(4)(7)(meidx),
-        inputStubData_nentries_5_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(0)(meidx),
-        inputStubData_nentries_5_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(1)(meidx),
-        inputStubData_nentries_5_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(2)(meidx),
-        inputStubData_nentries_5_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(3)(meidx),
-        inputStubData_nentries_5_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(4)(meidx),
-        inputStubData_nentries_5_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(5)(meidx),
-        inputStubData_nentries_5_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(6)(meidx),
-        inputStubData_nentries_5_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(5)(7)(meidx),
-        inputStubData_nentries_6_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(0)(meidx),
-        inputStubData_nentries_6_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(1)(meidx),
-        inputStubData_nentries_6_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(2)(meidx),
-        inputStubData_nentries_6_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(3)(meidx),
-        inputStubData_nentries_6_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(4)(meidx),
-        inputStubData_nentries_6_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(5)(meidx),
-        inputStubData_nentries_6_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(6)(meidx),
-        inputStubData_nentries_6_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(6)(7)(meidx),
-        inputStubData_nentries_7_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(0)(meidx),
-        inputStubData_nentries_7_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(1)(meidx),
-        inputStubData_nentries_7_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(2)(meidx),
-        inputStubData_nentries_7_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(3)(meidx),
-        inputStubData_nentries_7_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(4)(meidx),
-        inputStubData_nentries_7_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(5)(meidx),
-        inputStubData_nentries_7_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(6)(meidx),
-        inputStubData_nentries_7_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(7)(7)(meidx),
+        inputStubData_nentries_0_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(0)(0),
+        inputStubData_nentries_0_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(0)(1),
+        inputStubData_nentries_0_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(0)(2),
+        inputStubData_nentries_0_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(0)(3),
+        inputStubData_nentries_0_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(0)(4),
+        inputStubData_nentries_0_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(0)(5),
+        inputStubData_nentries_0_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(0)(6),
+        inputStubData_nentries_0_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(0)(7),
+        inputStubData_nentries_1_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(1)(0),
+        inputStubData_nentries_1_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(1)(1),
+        inputStubData_nentries_1_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(1)(2),
+        inputStubData_nentries_1_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(1)(3),
+        inputStubData_nentries_1_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(1)(4),
+        inputStubData_nentries_1_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(1)(5),
+        inputStubData_nentries_1_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(1)(6),
+        inputStubData_nentries_1_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(1)(7),
+        inputStubData_nentries_2_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(2)(0),
+        inputStubData_nentries_2_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(2)(1),
+        inputStubData_nentries_2_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(2)(2),
+        inputStubData_nentries_2_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(2)(3),
+        inputStubData_nentries_2_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(2)(4),
+        inputStubData_nentries_2_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(2)(5),
+        inputStubData_nentries_2_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(2)(6),
+        inputStubData_nentries_2_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(2)(7),
+        inputStubData_nentries_3_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(3)(0),
+        inputStubData_nentries_3_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(3)(1),
+        inputStubData_nentries_3_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(3)(2),
+        inputStubData_nentries_3_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(3)(3),
+        inputStubData_nentries_3_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(3)(4),
+        inputStubData_nentries_3_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(3)(5),
+        inputStubData_nentries_3_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(3)(6),
+        inputStubData_nentries_3_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(3)(7),
+        inputStubData_nentries_4_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(4)(0),
+        inputStubData_nentries_4_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(4)(1),
+        inputStubData_nentries_4_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(4)(2),
+        inputStubData_nentries_4_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(4)(3),
+        inputStubData_nentries_4_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(4)(4),
+        inputStubData_nentries_4_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(4)(5),
+        inputStubData_nentries_4_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(4)(6),
+        inputStubData_nentries_4_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(4)(7),
+        inputStubData_nentries_5_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(5)(0),
+        inputStubData_nentries_5_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(5)(1),
+        inputStubData_nentries_5_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(5)(2),
+        inputStubData_nentries_5_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(5)(3),
+        inputStubData_nentries_5_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(5)(4),
+        inputStubData_nentries_5_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(5)(5),
+        inputStubData_nentries_5_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(5)(6),
+        inputStubData_nentries_5_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(5)(7),
+        inputStubData_nentries_6_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(6)(0),
+        inputStubData_nentries_6_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(6)(1),
+        inputStubData_nentries_6_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(6)(2),
+        inputStubData_nentries_6_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(6)(3),
+        inputStubData_nentries_6_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(6)(4),
+        inputStubData_nentries_6_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(6)(5),
+        inputStubData_nentries_6_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(6)(6),
+        inputStubData_nentries_6_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(6)(7),
+        inputStubData_nentries_7_V_0 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(7)(0),
+        inputStubData_nentries_7_V_1 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(7)(1),
+        inputStubData_nentries_7_V_2 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(7)(2),
+        inputStubData_nentries_7_V_3 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(7)(3),
+        inputStubData_nentries_7_V_4 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(7)(4),
+        inputStubData_nentries_7_V_5 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(7)(5),
+        inputStubData_nentries_7_V_6 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(7)(6),
+        inputStubData_nentries_7_V_7 => VMSME_L3PHIC17to24n1_nentries_V_dout(meidx)(7)(7),
         inputProjectionData_dataarray_data_V_address0 => VMPROJ_L3PHIC17to24_dataarray_data_V_readaddr(meidx),
         inputProjectionData_dataarray_data_V_ce0      => VMPROJ_L3PHIC17to24_dataarray_data_V_enb(meidx),
         inputProjectionData_dataarray_data_V_q0       => VMPROJ_L3PHIC17to24_dataarray_data_V_dout(meidx),
-        inputProjectionData_nentries_0_V => VMPROJ_L3PHIC17to24_nentries_V_dout(0)(meidx),
-        inputProjectionData_nentries_1_V => VMPROJ_L3PHIC17to24_nentries_V_dout(1)(meidx),
+        inputProjectionData_nentries_0_V => VMPROJ_L3PHIC17to24_nentries_V_dout(meidx)(0),
+        inputProjectionData_nentries_1_V => VMPROJ_L3PHIC17to24_nentries_V_dout(meidx)(1),
         outputCandidateMatch_dataarray_data_V_address0 => CM_L3PHIC17to24_dataarray_data_V_writeaddr(meidx),
         outputCandidateMatch_dataarray_data_V_ce0      => open,
         outputCandidateMatch_dataarray_data_V_we0      => CM_L3PHIC17to24_dataarray_data_V_wea(meidx),
@@ -568,7 +476,7 @@ begin
   AS_L3PHICn4 : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 36,
-      RAM_DEPTH       => 1024,
+      NUM_PAGES       => 8,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -585,14 +493,7 @@ begin
       addrb      => AS_L3PHICn4_dataarray_data_V_readaddr,
       doutb      => AS_L3PHICn4_dataarray_data_V_dout,
       sync_nent  => MC_start,
-      nent_o0    => AS_L3PHICn4_nentries_V_dout(0),
-      nent_o1    => AS_L3PHICn4_nentries_V_dout(1),
-      nent_o2    => AS_L3PHICn4_nentries_V_dout(2),
-      nent_o3    => AS_L3PHICn4_nentries_V_dout(3),
-      nent_o4    => AS_L3PHICn4_nentries_V_dout(4),
-      nent_o5    => AS_L3PHICn4_nentries_V_dout(5),
-      nent_o6    => AS_L3PHICn4_nentries_V_dout(6),
-      nent_o7    => AS_L3PHICn4_nentries_V_dout(7)
+      nent_o     => AS_L3PHICn4_nentries_V_dout
       );
 
 
@@ -604,7 +505,7 @@ begin
     CM_L3PHIC17to24 : entity work.tf_mem
       generic map (
         RAM_WIDTH       => 14,
-        RAM_DEPTH       => 256,
+        NUM_PAGES       => 2,
         INIT_FILE       => "",
         INIT_HEX        => true,
         RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -621,14 +522,7 @@ begin
         addrb      => CM_L3PHIC17to24_dataarray_data_V_readaddr(cmidx),
         doutb      => CM_L3PHIC17to24_dataarray_data_V_dout(cmidx),
         sync_nent  => MC_start,
-        nent_o0    => CM_L3PHIC17to24_nentries_V_dout(0)(cmidx),
-        nent_o1    => CM_L3PHIC17to24_nentries_V_dout(1)(cmidx),
-        nent_o2    => open,
-        nent_o3    => open,
-        nent_o4    => open,
-        nent_o5    => open,
-        nent_o6    => open,
-        nent_o7    => open
+        nent_o     => CM_L3PHIC17to24_nentries_V_dout(cmidx)
         );
 
   end generate gen_CM_L3PHIC17to24;
@@ -650,42 +544,42 @@ begin
       match_0_dataarray_data_V_ce0      => CM_L3PHIC17to24_dataarray_data_V_enb(0),
       match_0_dataarray_data_V_q0       => CM_L3PHIC17to24_dataarray_data_V_dout(0),
       match_0_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(0)(0),
-      match_0_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(1)(0),
+      match_0_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(0)(1),
       match_1_dataarray_data_V_address0 => CM_L3PHIC17to24_dataarray_data_V_readaddr(1),
       match_1_dataarray_data_V_ce0      => CM_L3PHIC17to24_dataarray_data_V_enb(1),
       match_1_dataarray_data_V_q0       => CM_L3PHIC17to24_dataarray_data_V_dout(1),
-      match_1_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(0)(1),
+      match_1_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(1)(0),
       match_1_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(1)(1),
       match_2_dataarray_data_V_address0 => CM_L3PHIC17to24_dataarray_data_V_readaddr(2),
       match_2_dataarray_data_V_ce0      => CM_L3PHIC17to24_dataarray_data_V_enb(2),
       match_2_dataarray_data_V_q0       => CM_L3PHIC17to24_dataarray_data_V_dout(2),
-      match_2_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(0)(2),
-      match_2_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(1)(2),
+      match_2_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(2)(0),
+      match_2_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(2)(1),
       match_3_dataarray_data_V_address0 => CM_L3PHIC17to24_dataarray_data_V_readaddr(3),
       match_3_dataarray_data_V_ce0      => CM_L3PHIC17to24_dataarray_data_V_enb(3),
       match_3_dataarray_data_V_q0       => CM_L3PHIC17to24_dataarray_data_V_dout(3),
-      match_3_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(0)(3),
-      match_3_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(1)(3),
+      match_3_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(3)(0),
+      match_3_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(3)(1),
       match_4_dataarray_data_V_address0 => CM_L3PHIC17to24_dataarray_data_V_readaddr(4),
       match_4_dataarray_data_V_ce0      => CM_L3PHIC17to24_dataarray_data_V_enb(4),
       match_4_dataarray_data_V_q0       => CM_L3PHIC17to24_dataarray_data_V_dout(4),
-      match_4_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(0)(4),
-      match_4_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(1)(4),
+      match_4_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(4)(0),
+      match_4_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(4)(1),
       match_5_dataarray_data_V_address0 => CM_L3PHIC17to24_dataarray_data_V_readaddr(5),
       match_5_dataarray_data_V_ce0      => CM_L3PHIC17to24_dataarray_data_V_enb(5),
       match_5_dataarray_data_V_q0       => CM_L3PHIC17to24_dataarray_data_V_dout(5),
-      match_5_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(0)(5),
-      match_5_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(1)(5),
+      match_5_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(5)(0),
+      match_5_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(5)(1),
       match_6_dataarray_data_V_address0 => CM_L3PHIC17to24_dataarray_data_V_readaddr(6),
       match_6_dataarray_data_V_ce0      => CM_L3PHIC17to24_dataarray_data_V_enb(6),
       match_6_dataarray_data_V_q0       => CM_L3PHIC17to24_dataarray_data_V_dout(6),
-      match_6_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(0)(6),
-      match_6_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(1)(6),
+      match_6_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(6)(0),
+      match_6_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(6)(1),
       match_7_dataarray_data_V_address0 => CM_L3PHIC17to24_dataarray_data_V_readaddr(7),
       match_7_dataarray_data_V_ce0      => CM_L3PHIC17to24_dataarray_data_V_enb(7),
       match_7_dataarray_data_V_q0       => CM_L3PHIC17to24_dataarray_data_V_dout(7),
-      match_7_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(0)(7),
-      match_7_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(1)(7),
+      match_7_nentries_0_V              => CM_L3PHIC17to24_nentries_V_dout(7)(0),
+      match_7_nentries_1_V              => CM_L3PHIC17to24_nentries_V_dout(7)(1),
       allstub_dataarray_data_V_address0 => AS_L3PHICn4_dataarray_data_V_readaddr,
       allstub_dataarray_data_V_ce0      => AS_L3PHICn4_dataarray_data_V_enb,
       allstub_dataarray_data_V_q0       => AS_L3PHICn4_dataarray_data_V_dout,
@@ -711,7 +605,7 @@ begin
   FM_L1L2_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 45,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -728,20 +622,13 @@ begin
       addrb      => FM_L1L2_L3PHIC_dataarray_data_V_readaddr,
       doutb      => FM_L1L2_L3PHIC_dataarray_data_V_dout,
       sync_nent  => MC_done,
-      nent_o0    => FM_L1L2_L3PHIC_nentries_V_dout(0),
-      nent_o1    => FM_L1L2_L3PHIC_nentries_V_dout(1),
-      nent_o2    => open,
-      nent_o3    => open,
-      nent_o4    => open,
-      nent_o5    => open,
-      nent_o6    => open,
-      nent_o7    => open
+      nent_o     => FM_L1L2_L3PHIC_nentries_V_dout
       );
 
   FM_L5L6_L3PHIC : entity work.tf_mem
     generic map (
       RAM_WIDTH       => 45,
-      RAM_DEPTH       => 256,
+      NUM_PAGES       => 2,
       INIT_FILE       => "",
       INIT_HEX        => true,
       RAM_PERFORMANCE => "HIGH_PERFORMANCE"
@@ -758,14 +645,7 @@ begin
       addrb      => FM_L5L6_L3PHIC_dataarray_data_V_readaddr,
       doutb      => FM_L5L6_L3PHIC_dataarray_data_V_dout,
       sync_nent  => MC_done,
-      nent_o0    => FM_L5L6_L3PHIC_nentries_V_dout(0),
-      nent_o1    => FM_L5L6_L3PHIC_nentries_V_dout(1),
-      nent_o2    => open,
-      nent_o3    => open,
-      nent_o4    => open,
-      nent_o5    => open,
-      nent_o6    => open,
-      nent_o7    => open
+      nent_o     => FM_L5L6_L3PHIC_nentries_V_dout
       );
 
 end rtl;

--- a/IntegrationTests/PRMEMC/script/makeProject.tcl
+++ b/IntegrationTests/PRMEMC/script/makeProject.tcl
@@ -25,8 +25,8 @@ add_files -fileset sources_1 [glob ../hdl/*.vhd]
 add_files -fileset sim_1 [glob ../tb/*.vhd]
 
 # Provide name of top-level HDL (without .vhd extension).
-set topLevelHDL "SectorProcessor"
-#set topLevelHDL "tf_top_full"
+#set topLevelHDL "SectorProcessor"
+set topLevelHDL "tf_top_full"
 
 # Set 'sim_1' fileset properties
 set_property file_type {VHDL 2008} [get_files -filter {FILE_TYPE == VHDL}]

--- a/IntegrationTests/PRMEMC/tb/tb_tf_top.vhd
+++ b/IntegrationTests/PRMEMC/tb/tb_tf_top.vhd
@@ -671,13 +671,11 @@ begin
         FM_L1L2_L3PHIC_dataarray_data_V_enb      => FM_L1L2_L3PHIC_dataarray_data_V_enb,
         FM_L1L2_L3PHIC_dataarray_data_V_readaddr => FM_L1L2_L3PHIC_dataarray_data_V_readaddr,
         FM_L1L2_L3PHIC_dataarray_data_V_dout     => FM_L1L2_L3PHIC_dataarray_data_V_dout,
-        FM_L1L2_L3PHIC_nentries_0_V_dout         => FM_L1L2_L3PHIC_nentries_V_dout(0),
-        FM_L1L2_L3PHIC_nentries_1_V_dout         => FM_L1L2_L3PHIC_nentries_V_dout(1),
+        FM_L1L2_L3PHIC_nentries_VV_dout          => FM_L1L2_L3PHIC_nentries_V_dout,
         FM_L5L6_L3PHIC_dataarray_data_V_enb      => FM_L5L6_L3PHIC_dataarray_data_V_enb,
         FM_L5L6_L3PHIC_dataarray_data_V_readaddr => FM_L5L6_L3PHIC_dataarray_data_V_readaddr,
         FM_L5L6_L3PHIC_dataarray_data_V_dout     => FM_L5L6_L3PHIC_dataarray_data_V_dout,
-        FM_L5L6_L3PHIC_nentries_0_V_dout         => FM_L5L6_L3PHIC_nentries_V_dout(0),
-        FM_L5L6_L3PHIC_nentries_1_V_dout         => FM_L5L6_L3PHIC_nentries_V_dout(1)  );
+        FM_L5L6_L3PHIC_nentries_VV_dout          => FM_L5L6_L3PHIC_nentries_V_dout   );
   end generate;
 
 

--- a/IntegrationTests/common/hdl/tf_mem.vhd
+++ b/IntegrationTests/common/hdl/tf_mem.vhd
@@ -35,7 +35,7 @@ entity tf_mem is
     INIT_FILE       : string := "";                --! Specify name/location of RAM initialization file if using one (leave blank if not)
     INIT_HEX        : boolean := true;             --! Read init file in hex (default) or bin
     RAM_PERFORMANCE : string := "HIGH_PERFORMANCE" --! Select "HIGH_PERFORMANCE" (2 clk latency) or "LOW_LATENCY" (1 clk latency)
-    ); 
+    );
   port (
     clka      : in  std_logic;                                      --! Write clock
     clkb      : in  std_logic;                                      --! Read clock

--- a/IntegrationTests/common/hdl/tf_mem.vhd
+++ b/IntegrationTests/common/hdl/tf_mem.vhd
@@ -30,11 +30,12 @@ use work.tf_pkg.all;
 entity tf_mem is
   generic (
     RAM_WIDTH       : natural := 18;               --! Specify RAM data width
-    RAM_DEPTH       : natural := 1024;             --! Specify RAM depth (number of entries)
+    NUM_PAGES       : natural := 2;                --! Specify no. Pages in RAM memory
+    RAM_DEPTH       : natural := NUM_PAGES*PAGE_OFFSET; --! Leave at default. RAM depth (no. of entries)
     INIT_FILE       : string := "";                --! Specify name/location of RAM initialization file if using one (leave blank if not)
     INIT_HEX        : boolean := true;             --! Read init file in hex (default) or bin
     RAM_PERFORMANCE : string := "HIGH_PERFORMANCE" --! Select "HIGH_PERFORMANCE" (2 clk latency) or "LOW_LATENCY" (1 clk latency)
-    );
+    ); 
   port (
     clka      : in  std_logic;                                      --! Write clock
     clkb      : in  std_logic;                                      --! Read clock
@@ -47,14 +48,8 @@ entity tf_mem is
     addrb     : in  std_logic_vector(clogb2(RAM_DEPTH)-1 downto 0); --! Read address bus, width determined from RAM_DEPTH
     doutb     : out std_logic_vector(RAM_WIDTH-1 downto 0);         --! RAM output data
     sync_nent : in  std_logic;                                      --! Synchronize nent counter; Connect to start of reading module
-    nent_o0   : out std_logic_vector(clogb2(MAX_ENTRIES) downto 0) := (others => '0'); --! Num entries per page; No array to avoid partially associated port
-    nent_o1   : out std_logic_vector(clogb2(MAX_ENTRIES) downto 0) := (others => '0'); --! Num entries per page; No array to avoid partially associated port
-    nent_o2   : out std_logic_vector(clogb2(MAX_ENTRIES) downto 0) := (others => '0'); --! Num entries per page; No array to avoid partially associated port
-    nent_o3   : out std_logic_vector(clogb2(MAX_ENTRIES) downto 0) := (others => '0'); --! Num entries per page; No array to avoid partially associated port
-    nent_o4   : out std_logic_vector(clogb2(MAX_ENTRIES) downto 0) := (others => '0'); --! Num entries per page; No array to avoid partially associated port
-    nent_o5   : out std_logic_vector(clogb2(MAX_ENTRIES) downto 0) := (others => '0'); --! Num entries per page; No array to avoid partially associated port
-    nent_o6   : out std_logic_vector(clogb2(MAX_ENTRIES) downto 0) := (others => '0'); --! Num entries per page; No array to avoid partially associated port
-    nent_o7   : out std_logic_vector(clogb2(MAX_ENTRIES) downto 0) := (others => '0')  --! Num entries per page; No array to avoid partially associated port
+    --nent_o    : out t_arr_meb(0 to NUM_PAGES-1) := (others => (others => '0'))
+    nent_o    : out t_arr_7b(0 to NUM_PAGES-1) := (others => (others => '0')) --! entries per page
     );
 end tf_mem;
 
@@ -111,8 +106,10 @@ attribute ram_style of sa_RAM_data : signal is "block";
 begin
 
 process(clka)
-  variable vi_clk_cnt  : integer := -1; -- Clock counter
-  variable vi_page_cnt : integer := 0;  -- Page counter
+  variable vi_clk_cnt   : integer := -1; -- Clock counter
+  variable vi_page_cnt  : integer := 0;  -- Page counter
+  variable page         : integer := 0;
+  variable addr_in_page : integer := 0;
 begin
   if rising_edge(clka) then -- ######################################### Start counter initially
     if (sync_nent='1') and vi_clk_cnt=-1 then
@@ -122,27 +119,9 @@ begin
       vi_clk_cnt := vi_clk_cnt+1;
     elsif (vi_clk_cnt >= MAX_ENTRIES-1) then -- -1 not included
       vi_clk_cnt := 0;
-      case (vi_page_cnt) is -- Reset nent counter values
-        when 0 =>
-          nent_o0 <= (others => '0');
-        when 1 =>
-          nent_o1 <= (others => '0');
-        when 2 =>
-          nent_o2 <= (others => '0');
-        when 3 =>
-          nent_o3 <= (others => '0');
-        when 4 =>
-          nent_o4 <= (others => '0');
-        when 5 =>
-          nent_o5 <= (others => '0');
-        when 6 =>
-          nent_o6 <= (others => '0');
-        when 7 =>
-          nent_o7 <= (others => '0');
-        when others =>
-          assert (false) report "vi_page_cnt out of range" severity error;
-      end case;
-      if (vi_page_cnt < RAM_DEPTH/PAGE_OFFSET-1) then -- Assuming linear continuous page access
+      nent_o(vi_page_cnt) <= (others => '0');
+      assert (vi_page_cnt < NUM_PAGES) report "vi_page_cnt out of range" severity error;
+      if (vi_page_cnt < NUM_PAGES-1) then -- Assuming linear continuous page access
         vi_page_cnt := vi_page_cnt +1;
       else
         vi_page_cnt := 0;
@@ -151,58 +130,15 @@ begin
     if (wea='1') then
       sa_RAM_data(to_integer(unsigned(addra))) <= dina; -- Write data
       if ((addra = (addra'range => '0')) or (addra /= sv_addra_d1)) and (dina /= (dina'range => '0')) then -- ##### Count n_entries;
-        case (to_integer(unsigned(addra))) is
-          when 0*PAGE_OFFSET to 1*PAGE_OFFSET-1 =>
-            if (addra = std_logic_vector(to_unsigned(0*PAGE_OFFSET, addra'length))) then
-              nent_o0 <= std_logic_vector(to_unsigned(1, nent_o0'length)); -- <= 1 (slv)
-            else
-              nent_o0 <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o0)) + 1, nent_o0'length)); -- + 1 (slv)
-            end if;
-          when 1*PAGE_OFFSET to 2*PAGE_OFFSET-1 =>
-            if (addra = std_logic_vector(to_unsigned(1*PAGE_OFFSET, addra'length))) then
-              nent_o1 <= std_logic_vector(to_unsigned(1, nent_o1'length)); -- <= 1 (slv)
-            else
-              nent_o1 <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o1)) + 1, nent_o1'length)); -- + 1 (slv)
-            end if;
-          when 2*PAGE_OFFSET to 3*PAGE_OFFSET-1 =>
-            if (addra = std_logic_vector(to_unsigned(2*PAGE_OFFSET, addra'length))) then
-              nent_o2 <= std_logic_vector(to_unsigned(1, nent_o2'length)); -- <= 1 (slv)
-            else
-              nent_o2 <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o2)) + 1, nent_o2'length)); -- + 1 (slv)
-            end if;
-          when 3*PAGE_OFFSET to 4*PAGE_OFFSET-1 =>
-            if (addra = std_logic_vector(to_unsigned(3*PAGE_OFFSET, addra'length))) then
-              nent_o3 <= std_logic_vector(to_unsigned(1, nent_o3'length)); -- <= 1 (slv)
-            else
-              nent_o3 <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o3)) + 1, nent_o3'length)); -- + 1 (slv)
-            end if;
-          when 4*PAGE_OFFSET to 5*PAGE_OFFSET-1 =>
-            if (addra = std_logic_vector(to_unsigned(4*PAGE_OFFSET, addra'length))) then
-              nent_o4 <= std_logic_vector(to_unsigned(1, nent_o4'length)); -- <= 1 (slv)
-            else
-              nent_o4 <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o4)) + 1, nent_o5'length)); -- + 1 (slv)
-            end if;
-          when 5*PAGE_OFFSET to 6*PAGE_OFFSET-1 =>
-            if (addra = std_logic_vector(to_unsigned(5*PAGE_OFFSET, addra'length))) then
-              nent_o5 <= std_logic_vector(to_unsigned(1, nent_o5'length)); -- <= 1 (slv)
-            else
-              nent_o5 <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o5)) + 1, nent_o5'length)); -- + 1 (slv)
-            end if;
-          when 6*PAGE_OFFSET to 7*PAGE_OFFSET-1 =>
-            if (addra = std_logic_vector(to_unsigned(6*PAGE_OFFSET, addra'length))) then
-              nent_o6 <= std_logic_vector(to_unsigned(1, nent_o6'length)); -- <= 1 (slv)
-            else
-              nent_o6 <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o6)) + 1, nent_o6'length)); -- + 1 (slv)
-            end if;
-          when 7*PAGE_OFFSET to 8*PAGE_OFFSET-1 =>
-            if (addra = std_logic_vector(to_unsigned(7*PAGE_OFFSET, addra'length))) then
-              nent_o7 <= std_logic_vector(to_unsigned(1, nent_o7'length)); -- <= 1 (slv)
-            else
-              nent_o7 <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o7)) + 1, nent_o7'length)); -- + 1 (slv)
-            end if;
-          when others =>
-            assert (false) report "addra out of range" severity error;
-        end case;
+      
+        page := to_integer(unsigned(addra(clogb2(RAM_DEPTH)-1 downto clogb2(PAGE_OFFSET))));
+	addr_in_page := to_integer(unsigned(addra(clogb2(PAGE_OFFSET)-1 downto 0)));
+        assert (page < NUM_PAGES) report "page out of range" severity error;
+        if (addr_in_page = 0) then
+          nent_o(page) <= std_logic_vector(to_unsigned(1, nent_o(page)'length)); -- <= 1 (slv)
+        else
+          nent_o(page) <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o(page))) + 1, nent_o(page)'length)); -- + 1 (slv)
+        end if;	
       end if;
       sv_addra_d1 <= addra;
     end if; -- (wea='1')

--- a/IntegrationTests/common/hdl/tf_pkg.vhd
+++ b/IntegrationTests/common/hdl/tf_pkg.vhd
@@ -78,17 +78,19 @@ package tf_pkg is
   type t_arr_2d_int is array(natural range <>,natural range <>) of integer; --! 2D array of int
   type t_arr_2d_slv is array(natural range <>, natural range <>) of std_logic_vector(EMDATA_WIDTH-1 downto 0); --! 2D array of slv
 
-  -- clogb2(MAX_ENTRIES) = 6.
-  type t_arr_8_5b  is array(integer range<>) of t_arr8_5b;
+  -- Used for memories
   type t_arr_7b  is array(integer range<>) of std_logic_vector(6 downto 0);
-  type t_arr_meb is array(integer range<>) of std_logic_vector(clogb2(MAX_ENTRIES)-1 downto 0);
-  type t_arr8_2_meb is array(0 to 7) of t_arr_meb(0 to 1);
-
   subtype t_arr2_7b is t_arr_7b(0 to 1);
   subtype t_arr8_7b is t_arr_7b(0 to 7);
   type t_arr8_2_7b is array(0 to 7) of t_arr2_7b;
+
+  type t_arr_8_5b  is array(integer range<>) of t_arr8_5b;
   subtype t_arr8_8_5b is t_arr_8_5b(0 to 7);
   type t_arr8_8_8_5b is array(0 to 7) of t_arr8_8_5b;
+
+  -- Could be used in place of t_arr_7b. 
+  -- type t_arr_meb is array(integer range<>) of std_logic_vector(clogb2(MAX_ENTRIES)-1 downto 0);
+
 
   -- -- ########################### Procedures #######################
   procedure char2int (


### PR DESCRIPTION
Several changes to make our VHDL shorter:

1) Individual "nent_o*" ports (one for each page) inside tf_mem.vhd & tf_mem_bin.vhd replaced with single "nent_o" port, using an array, where the array length is equal to the number of pages in the memory, configurable via GENERIC parameter. This substantially shortens the VHDL inside tf_mem*.vhd, and allows it to work for an arbitrary number of pages.

2) tf_top*.vhd & SectorProcessor.vhd updated to make use of modified tf_mem*.vhd from (1). They can now do the port assignment for "nent_o" in a single line of VHDL per memory, so are much shorter. To make this possible, the multidimensional "nentries" arrays needed changing, such that their first index now represents the ID of the memory (whereas this used to be in the last index). This means that all lines involving "*nentries*" have changed.

N.B. The new version of SectorProcessor.vhd is written by the updated python scripts in https://github.com/cms-L1TK/project_generation_scripts/tree/ian_MemNentArr , for which a separate PR will be made. 

3) A new implementation of clogb2(int N) added to tf_pkg.vhd. This now returns the number of bits needed to address an array with N elements. Comments in this function explain how this differs from the old version of this function (which I've temporarily renamed to clogb2_old()). The old & new functions give identical results if N is an exact power of two (unless N=2), which means that most of the code using this function didn't need changing.

4) Half a dozen new "type"'s added to tf_pkg.vhd to support the above changes. (For the moment, I've grouped these together after the other types, to make it easier to see them. We should move them to a more aesthetically pleasing position later).  The "nent_o" port inside tf_mem.vhd is based on type t_arr_7b, which hard-wires assumption that 7b are enough to encode "nent_o". We could alternatively switch to type t_arr_meb, which derives the number of bits from log2(max_nent).

5) Small change to tb_tf_top.vhd, modifying interface of its call to SectorProcessor.vhd, since the latters nentries port is now an array.

Validation: I've checked that the output of CompareMemPrintsFW.py is unchanged when run on the output of the Vivado simulation. And that the code still synthesises. Check done for both tf_top_full.vhd & SectorProcessor.vhd.