### PR TITLE
TPAR BX bits

### DIFF
--- a/TrackletAlgorithm/TrackletParameterMemory.h
+++ b/TrackletAlgorithm/TrackletParameterMemory.h
@@ -124,6 +124,6 @@ private:
 };
 
 // Memory definition
-typedef MemoryTemplate<TrackletParameters, 2, kNBits_MemAddr> TrackletParameterMemory;
+typedef MemoryTemplate<TrackletParameters, 3, kNBits_MemAddr> TrackletParameterMemory;
 
 #endif


### PR DESCRIPTION
This PR increases the number of bits used for the BX in TPAR memories to three. This is needed since these memories are filled by the TC, but are not read until the TrackBuilder/PurgeDuplicates.