### PR TITLE
Add FileWriter*.vhd utilities to simplify L1Trk chain test-benches

### DIFF
--- a/IntegrationTests/PRMEMC/tb/tb_tf_top.vhd
+++ b/IntegrationTests/PRMEMC/tb/tb_tf_top.vhd
@@ -6,7 +6,9 @@
 --! @brief Test bench for the track finding top using TextIO.
 --! @author Robert Glein
 --! @date 2020-05-18
---! @version v.1.0
+--! Simplified & cleaned up
+--! @author Ian Tomalin
+--! @date 2021-05-30
 --=============================================================================
 
 --! Standard library
@@ -69,14 +71,14 @@ architecture behavior of tb_tf_top is
   constant TPROJ_DELAY       : integer := 0;          --! Number of BX delays (can be written early 8 pages)
   constant VMSME_DELAY       : integer := 1;          --! Number of BX delays (can be written early 8 pages)
   constant AS_DELAY          : integer := 2;          --! Number of BX delays (can be written early 8 pages)
-  constant MEM_READ_DELAY    : integer := 2;          --! Number of memory read delay
+
   -- Paths of data files specified relative to Vivado project's xsim directory. 
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
   constant emDataDir  : string := "../../../../../../../../emData/MemPrints/";
   constant dataOutDir : string := "../../../../../dataOut/";
 
   -- Input files
-  constant FILE_IN_TPROJ : t_str_arr_TPROJ_60 := (
+  constant FILE_IN_TPROJ_60 : t_str_arr_TPROJ_60 := (
   emDataDir&"TrackletProjections/TrackletProjections_TPROJ_L1L2F_L3PHIC_04.dat",
   emDataDir&"TrackletProjections/TrackletProjections_TPROJ_L1L2G_L3PHIC_04.dat",
   emDataDir&"TrackletProjections/TrackletProjections_TPROJ_L1L2H_L3PHIC_04.dat",
@@ -86,7 +88,7 @@ architecture behavior of tb_tf_top is
   emDataDir&"TrackletProjections/TrackletProjections_TPROJ_L5L6C_L3PHIC_04.dat",  
   emDataDir&"TrackletProjections/TrackletProjections_TPROJ_L5L6D_L3PHIC_04.dat");    
   -- Input files
-  constant FILE_IN_VMSME : t_str_arr_VMSME_16 := (
+  constant FILE_IN_VMSME_16 : t_str_arr_VMSME_16 := (
   emDataDir&"VMStubsME/VMStubs_VMSME_L3PHIC17n1_04.dat",
   emDataDir&"VMStubsME/VMStubs_VMSME_L3PHIC18n1_04.dat",
   emDataDir&"VMStubsME/VMStubs_VMSME_L3PHIC19n1_04.dat",
@@ -97,11 +99,11 @@ architecture behavior of tb_tf_top is
   emDataDir&"VMStubsME/VMStubs_VMSME_L3PHIC24n1_04.dat");
 
   -- Input files (N.B. bizarre initialization method, due to VHDL issue with arrays of dim=1)
-  constant FILE_IN_AS : t_str_arr_AS_36 := (L3PHICn6 =>
+  constant FILE_IN_AS_36 : t_str_arr_AS_36 := (L3PHICn6 =>
   emDataDir&"Stubs/AllStubs_AS_L3PHICn6_04.dat");
 
   -- Output files
-  constant FILE_OUT_VMP : t_str_arr_VMP_24 := ( 
+  constant FILE_OUT_VMP_24 : t_str_arr_VMP_24 := ( 
   dataOutDir&"VMPROJ_L3PHIC17.txt",
   dataOutDir&"VMPROJ_L3PHIC18.txt",
   dataOutDir&"VMPROJ_L3PHIC19.txt",
@@ -111,10 +113,10 @@ architecture behavior of tb_tf_top is
   dataOutDir&"VMPROJ_L3PHIC23.txt",
   dataOutDir&"VMPROJ_L3PHIC24.txt");
   -- Output files (N.B. bizarre initialization method, due to VHDL issue with arrays of dim=1)
-  constant FILE_OUT_AP : t_str_arr_AP_60 := (L3PHIC =>
+  constant FILE_OUT_AP_60 : t_str_arr_AP_60 := (L3PHIC =>
   dataOutDir&"AP_L3PHIC.txt");
   -- Output files
-  constant FILE_OUT_CM  : t_str_arr_CM_14 :=  (
+  constant FILE_OUT_CM_14  : t_str_arr_CM_14 :=  (
   dataOutDir&"CM_L3PHIC17.txt",
   dataOutDir&"CM_L3PHIC18.txt",
   dataOutDir&"CM_L3PHIC19.txt",
@@ -124,7 +126,7 @@ architecture behavior of tb_tf_top is
   dataOutDir&"CM_L3PHIC23.txt",
   dataOutDir&"CM_L3PHIC24.txt");
   -- Output files
-  constant FILE_OUT_FM : t_str_arr_FM_52 :=  (
+  constant FILE_OUT_FM_52 : t_str_arr_FM_52 :=  (
   dataOutDir&"FM_L1L2_L3PHIC.txt", 
   dataOutDir&"FM_L5L6_L3PHIC.txt");
 
@@ -210,7 +212,7 @@ begin
   begin
     readTPROJ_60 : entity work.FileReader 
     generic map (
-      FILE_NAME  => FILE_IN_TPROJ(var),
+      FILE_NAME  => FILE_IN_TPROJ_60(var),
       DELAY      => TPROJ_DELAY*MAX_ENTRIES,
       RAM_WIDTH  => 60,
       NUM_PAGES  => 2,
@@ -235,7 +237,7 @@ begin
   begin
     readVMSME_16 : entity work.FileReader 
     generic map (
-      FILE_NAME  => FILE_IN_VMSME(var),
+      FILE_NAME  => FILE_IN_VMSME_16(var),
       DELAY      => VMSME_DELAY*MAX_ENTRIES,
       RAM_WIDTH  => 16,
       NUM_PAGES  => 8,
@@ -256,7 +258,7 @@ begin
   begin
     readAS_36 : entity work.FileReader 
     generic map (
-      FILE_NAME  => FILE_IN_AS(var),
+      FILE_NAME  => FILE_IN_AS_36(var),
       DELAY      => AS_DELAY*MAX_ENTRIES,
       RAM_WIDTH  => 36,
       NUM_PAGES  => 8,
@@ -384,206 +386,88 @@ begin
   end generate sectorProcFull;
 
 
-  --! @brief TextIO process for writing the FM output ---------------------------------------
-  --! @details Read memory outputs (from last HLS module in the chain) and write it to files including headers.
-  -- TODO: Replace with write procedures (e.g. like CM) but take MEM_READ_DELAY into account because it is the read port
-  write_result_FM : process
-    file     file_out_L1L2 : text open WRITE_MODE is FILE_OUT_FM(L1L2_L3PHIC); -- Text - a file of character strings
-    file     file_out_L5L6 : text open WRITE_MODE is FILE_OUT_FM(L5L6_L3PHIC); -- Text - a file of character strings
-    variable v_line   : line;                                        -- Line - one string from a text
-    variable v_FM_L1L2_L3PHIC_dataarray_data_V_enb_d : std_logic_vector(MEM_READ_DELAY-1 downto 0) := (others => '0'); -- Delay vector
-    variable v_FM_L5L6_L3PHIC_dataarray_data_V_enb_d : std_logic_vector(MEM_READ_DELAY-1 downto 0) := (others => '0'); -- Delay vector
+  -- Write signals to output .txt files
+
+  writeIntermediateRAMs : if INST_TOP_TF = 1 generate
   begin
-    -- Write file header
-    write(v_line, string'("time"), right, 20); write(v_line, string'("BX#"), right, 4);
-    write(v_line, string'("reset"), right, 6);
-    write(v_line, string'("n_ent_p0"), right, 9); write(v_line, string'("n_ent_p1"), right, 9); write(v_line, string'("enb"), right, 4);
-    write(v_line, string'("readaddr"), right, 9);  write(v_line, string'("FM_L1L2_L3PHIC_dataarray_data_V_dout"), right, 37);
-    write(v_line, string'("MC_done"), right, 9);  write(v_line, string'("MC_bx_out_vld"), right, 14); write(v_line, string'("MC_bx_out"), right, 10);
-    writeline (file_out_L1L2, v_line); -- Write line
-    write(v_line, string'("time"), right, 20); write(v_line, string'("BX#"), right, 4);
-    write(v_line, string'("reset"), right, 6);
-    write(v_line, string'("n_ent_p0"), right, 9); write(v_line, string'("n_ent_p1"), right, 9); write(v_line, string'("enb"), right, 4);
-    write(v_line, string'("readaddr"), right, 9);  write(v_line, string'("FM_L5L6_L3PHIC_dataarray_data_V_dout"), right, 37);
-    write(v_line, string'("MC_done"), right, 9);  write(v_line, string'("MC_bx_out_vld"), right, 14); write(v_line, string'("MC_bx_out"), right, 10);
-    writeline (file_out_L5L6, v_line); -- Write line
 
-    wait until rising_edge(clk) and MC_done = '1'; -- Wait for first result
-    l_BX : for v_bx_cnt in 0 to MAX_EVENTS-1 loop -- 0 to 99
-      -- FIX: This is buggy. As mem read takes 2 clks, it will lose last 2 samples
-      --      per event.
-      l_addr : for addr in 0 to MAX_ENTRIES-1 loop 
-        if (addr <= MAX_ENTRIES-1) then -- w/o MEM_READ_DELAY
-          if (v_bx_cnt mod 2)=0 then -- 1. page
-            if (addr < (to_integer(unsigned(FM_52_mem_AAV_dout_nent(L1L2_L3PHIC)(0))))) then -- Only read number of entries: Switch off in complete read out mode
-              FM_52_mem_A_enb(L1L2_L3PHIC) <= '1';
-            else
-              FM_52_mem_A_enb(L1L2_L3PHIC) <= '0';
-            end if;
-            if (addr < (to_integer(unsigned(FM_52_mem_AAV_dout_nent(L5L6_L3PHIC)(0))))) then -- Only read number of entries: Switch off in complete read out mode
-              FM_52_mem_A_enb(L5L6_L3PHIC) <= '1';
-            else
-              FM_52_mem_A_enb(L5L6_L3PHIC) <= '0';
-            end if;
-          else                       -- 2. page
-            if (addr < (to_integer(unsigned(FM_52_mem_AAV_dout_nent(L1L2_L3PHIC)(1))))) then -- Only read number of entries: Switch off in complete read out mode
-              FM_52_mem_A_enb(L1L2_L3PHIC) <= '1';
-            else
-              FM_52_mem_A_enb(L1L2_L3PHIC) <= '0';
-            end if;
-            if (addr < (to_integer(unsigned(FM_52_mem_AAV_dout_nent(L5L6_L3PHIC)(1))))) then -- Only read number of entries: Switch off in complete read out mode
-              FM_52_mem_A_enb(L5L6_L3PHIC) <= '1';
-            else
-              FM_52_mem_A_enb(L5L6_L3PHIC) <= '0';
-            end if;
-          end if;
-        end if;
-        FM_52_mem_AV_readaddr(L1L2_L3PHIC) <= std_logic_vector(to_unsigned(addr+(PAGE_LENGTH*(v_bx_cnt mod 2)), FM_52_mem_AV_readaddr(L1L2_L3PHIC)'length));
-         FM_52_mem_AV_readaddr(L5L6_L3PHIC) <= std_logic_vector(to_unsigned(addr+(PAGE_LENGTH*(v_bx_cnt mod 2)), FM_52_mem_AV_readaddr(L5L6_L3PHIC)'length));
+    -- This writes signals going to intermediate memories in chain.
 
-        v_FM_L1L2_L3PHIC_dataarray_data_V_enb_d :=  v_FM_L1L2_L3PHIC_dataarray_data_V_enb_d(MEM_READ_DELAY-2 downto 0) & FM_52_mem_A_enb(L1L2_L3PHIC); -- Required delay
-        v_FM_L5L6_L3PHIC_dataarray_data_V_enb_d :=  v_FM_L5L6_L3PHIC_dataarray_data_V_enb_d(MEM_READ_DELAY-2 downto 0) & FM_52_mem_A_enb(L5L6_L3PHIC); -- Required delay
-
-        -- Repeat this multiple times to go through all simulation delta-times.
-        wait for 0 ns; -- Update signals
-        wait for 0 ns; -- Update signals
-        wait for 0 ns; -- Update signals
-        wait for 0 ns; -- Update signals
-        wait for 0 ns; -- Update signals
-        -- Other writes ---------------------------------------
-        if (addr >= MEM_READ_DELAY) then -- Take read delay into account
-          write(v_line, NOW, right, 20); -- NOW = current simulation time
-          write(v_line, v_bx_cnt, right, 4);
-          --write(v_line, string'("0x"), right, 4); hwrite(v_line, std_logic_vector(to_unsigned(addr,10)), right, 3);
-          write(v_line, string'("0b"), right, 5);   write(v_line, reset, right, 1);
-          write(v_line, string'("0x"), right, 7);  hwrite(v_line, FM_52_mem_AAV_dout_nent(L1L2_L3PHIC)(0), right, 2);
-          write(v_line, string'("0x"), right, 7);  hwrite(v_line, FM_52_mem_AAV_dout_nent(L1L2_L3PHIC)(1), right, 2);
-          write(v_line, string'("0b"), right, 3);   write(v_line, v_FM_L1L2_L3PHIC_dataarray_data_V_enb_d(MEM_READ_DELAY-1), right, 1);
-          write(v_line, string'("0x"), right, 7);  hwrite(v_line, std_logic_vector(unsigned( FM_52_mem_AV_readaddr(L1L2_L3PHIC))-to_unsigned(MEM_READ_DELAY,FM_52_mem_AV_readaddr(L1L2_L3PHIC)'length)), right, 2);
-          if (v_FM_L1L2_L3PHIC_dataarray_data_V_enb_d(MEM_READ_DELAY-1)='1') then -- Only write if enable (delayed): Switch off in complete read out mode
-            write(v_line, string'("0x"), right, 25); hwrite(v_line, FM_52_mem_AV_dout(L1L2_L3PHIC), right, 12);
-          else
-            write(v_line, string'("0x"), right, 25);  write(v_line, string'("000000000000"), right, 12);
-          end if;
-          write(v_line, string'("0b"), right, 8);   write(v_line, MC_done, right, 1);
-          write(v_line, string'("0b"), right, 13);  write(v_line, MC_bx_out_vld, right, 1);
-          write(v_line, string'("0x"), right, 9);  hwrite(v_line, MC_bx_out, right, 1);
-          writeline (file_out_L1L2, v_line); -- Write line
-          write(v_line, NOW, right, 20); -- NOW = current simulation time
-          write(v_line, v_bx_cnt, right, 4);
-          --write(v_line, string'("0x"), right, 4); hwrite(v_line, std_logic_vector(to_unsigned(addr,10)), right, 3);
-          write(v_line, string'("0b"), right, 5);   write(v_line, reset, right, 1);
-          write(v_line, string'("0x"), right, 7);  hwrite(v_line, FM_52_mem_AAV_dout_nent(L5L6_L3PHIC)(0), right, 2);
-          write(v_line, string'("0x"), right, 7);  hwrite(v_line, FM_52_mem_AAV_dout_nent(L5L6_L3PHIC)(1), right, 2);
-          write(v_line, string'("0b"), right, 3);   write(v_line, v_FM_L5L6_L3PHIC_dataarray_data_V_enb_d(MEM_READ_DELAY-1), right, 1);
-          write(v_line, string'("0x"), right, 7);  hwrite(v_line, std_logic_vector(unsigned( FM_52_mem_AV_readaddr(L5L6_L3PHIC))-to_unsigned(MEM_READ_DELAY, FM_52_mem_AV_readaddr(L5L6_L3PHIC)'length)), right, 2);
-          if (v_FM_L5L6_L3PHIC_dataarray_data_V_enb_d(MEM_READ_DELAY-1)='1') then -- Only write if enable (delayed): Switch off in complete read out mode
-            write(v_line, string'("0x"), right, 27); hwrite(v_line,  FM_52_mem_AV_dout(L5L6_L3PHIC), right, 12);
-          else
-            write(v_line, string'("0x"), right, 27);  write(v_line, string'("000000000000"), right, 12);
-          end if;
-          write(v_line, string'("0b"), right, 8);   write(v_line, MC_done, right, 1);
-          write(v_line, string'("0b"), right, 13);  write(v_line, MC_bx_out_vld, right, 1);
-          write(v_line, string'("0x"), right, 9);  hwrite(v_line, MC_bx_out, right, 1);
-          writeline (file_out_L5L6, v_line); -- Write line
-        end if;
-        if (DEBUG=true and v_bx_cnt<=5 and addr<=10) then write(v_line, string'("v_bx_cnt: ")); write(v_line, v_bx_cnt); write(v_line, string'("   FM_L1L2_L3PHIC readaddr: ")); hwrite(v_line, FM_52_mem_AV_readaddr(L1L2_L3PHIC)); write(v_line, string'(", dout: ")); hwrite(v_line, FM_52_mem_AV_dout(L1L2_L3PHIC)); writeline(output, v_line); end if;
-        wait until rising_edge(clk); -- Main time control
-      end loop l_addr;
-    end loop l_BX;
-    file_close(file_out_L1L2);
-    file_close(file_out_L5L6);
-    -- Normal termination of simulation. All done.
-    assert false report "Simulation finished!" severity FAILURE;
-  end process write_result_FM;
-
-
-  fileOutput : if INST_TOP_TF = 1 generate
-    --! @brief TextIO process for writing the output of intermediate memories in chain ---------------------------------------
-    --! @details Read input signals to intermediate memories in chain,
-    --!          and write them to file using processes.
-    write_result_AP : process
-      variable v_bx_cnt      : integer       := -1; --! BX counter
+    VMPROJ_24_loop : for var in enum_VMPROJ_24 generate
     begin
-      wait until PR_start = '1'; -- Wait to start
-      write_header_line(FILE_OUT_AP(L3PHIC), "AP_L3PHIC_dataarray_data_V_din", 8);
-      -- Loops over all events and all valid entries within each event.
-      l_BX : while v_bx_cnt <= MAX_EVENTS-1 loop
-        if (AP_60_mem_AV_writeaddr(L3PHIC)(6 downto 0) = b"000_0000") and
-           (AP_60_mem_A_wea(L3PHIC) = '1') then -- Start new event assuming all addr behave the same
-          v_bx_cnt := v_bx_cnt + 1;
-        end if;
-        if (AP_60_mem_A_wea(L3PHIC)='1') then -- Only write valid data
-          write_emData_line_8p(reset, v_bx_cnt, PR_done, PR_bx_out, PR_bx_out_vld, FILE_OUT_AP(L3PHIC), "AP_L3PHIC_dataarray_data_V_din",
-                               AP_60_mem_AV_din(L3PHIC), AP_60_mem_A_wea(L3PHIC), AP_60_mem_AV_writeaddr(L3PHIC),
-                               (others => (others => '0')), (others => '0') );
-        end if;
-        wait for CLK_PERIOD; -- Main time control
-      end loop l_BX;
-      wait;
-    end process write_result_AP;
+      writeVMPROJ_24 : entity work.FileWriter 
+      generic map (
+        FILE_NAME  => FILE_OUT_VMP_24(var),
+        RAM_WIDTH  => 24,
+        NUM_PAGES  => 2
+      )
+      port map (
+        CLK => CLK,
+        ADDR => VMPROJ_24_mem_AV_writeaddr(var),
+        DATA => VMPROJ_24_mem_AV_din(var),
+        WRITE_EN => VMPROJ_24_mem_A_wea(var),
+        START => PR_START,
+        DONE => PR_DONE
+      );
+    end generate VMPROJ_24_loop;
 
-    --! @brief TextIO process for writting the output ---------------------------------------
-    write_result_VMP : process
-      variable v_bx_cnt      : integer       := -1; --! BX counter
-      constant myarray2_8b   : t_arr2_8b := (others => (others => '0')); -- Temporary array to avoid sim error
-      constant myarray2_1b   : t_arr2_1b := (others => '0'); -- Temporary array to avoid sim error
-      variable v_addr_d1     : t_arr_VMPROJ_24_ADDR := (others => (others => '0')); -- Delayed address
+    AP_60_loop : for var in enum_AP_60 generate
     begin
-      wait until PR_start = '1'; -- Wait to start
-      l_copies_header : for cp in enum_VMPROJ_24 loop
-        write_header_line(FILE_OUT_VMP(cp), "VMPROJ_L3PHIC17to24_dataarray_data_V_din", 2);
-      end loop l_copies_header;
-      -- Loops over all events and all valid entries within each event.
-      l_BX : while v_bx_cnt <= MAX_EVENTS-1 loop
-        if (VMPROJ_24_mem_AV_writeaddr(enum_VMPROJ_24'val(0))(6 downto 0) = b"000_0000") and
-           v_addr_d1(enum_VMPROJ_24'val(0))(7) /= VMPROJ_24_mem_AV_writeaddr(enum_VMPROJ_24'val(0))(7) then -- Start new event assuming all addr behave the same
-          v_bx_cnt := v_bx_cnt + 1;
-        end if;
-        l_copies : for cp in enum_VMPROJ_24 loop 
-          if (VMPROJ_24_mem_A_wea(cp)='1') then -- Only write valid data
-            write_emData_line_2p(reset, v_bx_cnt, PR_done, PR_bx_out, PR_bx_out_vld, FILE_OUT_VMP(cp), "VMPROJ_L3PHIC17to24_dataarray_data_V_din",
-                                 VMPROJ_24_mem_AV_din(cp), VMPROJ_24_mem_A_wea(cp), VMPROJ_24_mem_AV_writeaddr(cp),
-                                 myarray2_8b, myarray2_1b );
-          end if;
-        end loop l_copies;
-        v_addr_d1 := VMPROJ_24_mem_AV_writeaddr; -- Delay the address
-        wait for CLK_PERIOD; -- Main time control
-      end loop l_BX;
-      wait;
-    end process write_result_VMP;
+      writeAP_60 : entity work.FileWriter 
+      generic map (
+        FILE_NAME  => FILE_OUT_AP_60(var),
+        RAM_WIDTH  => 60,
+        NUM_PAGES  => 8
+      )
+      port map (
+        CLK => CLK,
+        ADDR => AP_60_mem_AV_writeaddr(var),
+        DATA => AP_60_mem_AV_din(var),
+        WRITE_EN => AP_60_mem_A_wea(var),
+        START => PR_START, 
+        DONE => PR_DONE
+      );
+    end generate AP_60_loop;
 
-    --! @brief TextIO process for writting the output ---------------------------------------
-    --! @details Read additional memory outputs (from intermediate HLS modules in the chain) and
-    --!         write it to files using procedures.
-    write_result_CM : process
-      variable v_bx_cnt    : integer       := -1; --! BX counter
-      constant myarray2_8b : t_arr2_8b := (others => (others => '0')); -- Temporary array to avoid sim error
-      constant myarray2_1b : t_arr2_1b := (others => '0'); -- Temporary array to avoid sim error
-      variable v_addr_d1   : t_arr_CM_14_ADDR := (others => (others => '0')); -- Delayed address
+    CM_14_loop : for var in enum_CM_14 generate
     begin
-      wait until PR_done = '1'; -- Wait to start = ME_start
-      l_copies_header : for cp in enum_CM_14 loop 
-        write_header_line(FILE_OUT_CM(cp), "CM_L3PHIC17to24_dataarray_data_V_din", 2);
-      end loop l_copies_header;
-      -- Loops over all events and all valid entries within each event.
-      l_BX : while v_bx_cnt <= MAX_EVENTS-1 loop
-        if (CM_14_mem_AV_writeaddr(enum_CM_14'val(0))(6 downto 0) = b"000_0000") and
-           v_addr_d1(enum_CM_14'val(0))(7) /= CM_14_mem_AV_writeaddr(enum_CM_14'val(0))(7) then -- Start new event assuming all addr behave the same
-          v_bx_cnt := v_bx_cnt + 1;
-        end if;
-        l_copies : for cp in enum_CM_14 loop
-          if (CM_14_mem_A_wea(cp)='1') then
-           write_emData_line_2p(reset, v_bx_cnt, ME_done, ME_bx_out, ME_bx_out_vld, FILE_OUT_CM(cp), "CM_L3PHIC17to24_dataarray_data_V_din",
-                                 CM_14_mem_AV_din(cp), CM_14_mem_A_wea(cp),  CM_14_mem_AV_writeaddr(cp),
-                                 myarray2_8b, myarray2_1b );
-          end if;
-        end loop l_copies;
-        v_addr_d1 :=  CM_14_mem_AV_writeaddr; -- Delay the address
-        wait for CLK_PERIOD; -- Main time control
-      end loop l_BX;
-      wait;
-    end process write_result_CM;
-  end generate fileOutput;
+      writeCM_14 : entity work.FileWriter 
+      generic map (
+        FILE_NAME  => FILE_OUT_CM_14(var),
+        RAM_WIDTH  => 14,
+        NUM_PAGES  => 2
+      )
+      port map (
+        CLK => CLK,
+        ADDR => CM_14_mem_AV_writeaddr(var),
+        DATA => CM_14_mem_AV_din(var),
+        WRITE_EN => CM_14_mem_A_wea(var),
+        START => PR_DONE,   --! = ME_START
+        DONE => ME_DONE
+      );
+    end generate CM_14_loop;
+
+  end generate writeIntermediateRAMs;
+
+
+-- Write memories from end of chain.
+
+  FM_52_loop : for var in enum_FM_52 generate
+  begin
+    writeFM_52 : entity work.FileWriterFromRAM 
+    generic map (
+      FILE_NAME  => FILE_OUT_FM_52(var),
+      RAM_WIDTH  => 52,
+      NUM_PAGES  => 2
+    )
+    port map (
+      CLK => CLK,
+      DONE => MC_DONE,
+      NENT_ARR => FM_52_mem_AAV_dout_nent(var),
+      ADDR => FM_52_mem_AV_readaddr(var),
+      DATA => FM_52_mem_AV_dout(var),
+      READ_EN => FM_52_mem_A_enb(var)
+    );
+  end generate FM_52_loop;
 
 end behavior;

--- a/IntegrationTests/common/hdl/FileReader.vhd
+++ b/IntegrationTests/common/hdl/FileReader.vhd
@@ -73,6 +73,11 @@ procFile : process(CLK)
 
 begin
 
+  -- Check user didn't change values of derived generics.
+  assert (RAM_DEPTH  = NUM_PAGES*PAGE_LENGTH) report "User changed RAM_DEPTH" severity FAILURE;
+  assert (ADDR_WIDTH = clogb2(RAM_DEPTH)) report "User changed ADDR_WIDTH" severity FAILURE;
+  assert (BIN_SIZE = PAGE_LENGTH/NUM_BINS) report "User changed BIN_SIZE" severity FAILURE;
+
   if rising_edge(CLK) then
   
     -- Open file

--- a/IntegrationTests/common/hdl/FileWriter.vhd
+++ b/IntegrationTests/common/hdl/FileWriter.vhd
@@ -1,0 +1,112 @@
+--! Using the IEEE Library
+library IEEE;
+--! Using STD_LOGIC
+use IEEE.STD_LOGIC_1164.all;
+--! Writing to and from files
+use IEEE.STD_LOGIC_TEXTIO.all;
+--! Using NUMERIC TYPES
+use IEEE.NUMERIC_STD.all;
+--! Writing to and from files
+use STD.TEXTIO.all;
+
+--! User packages
+use work.tf_pkg.all;
+
+-- ==================================================================
+--  Writes a .txt file with ADDR & DATA of the intermediate memories
+--  in the chain, whenever WRITE_EN is high.
+-- ==================================================================
+
+entity FileWriter is
+  generic (
+    FILE_NAME  : string;   --! Name of .txt file to be written
+    RAM_WIDTH  : natural := 18;    --! RAM data width
+    NUM_PAGES  : natural := 2;     --! Number of pages in RAM memory
+    -- Leave following parameters at their default values.
+    RAM_DEPTH  : natural := NUM_PAGES*PAGE_LENGTH; --! RAM depth (no. of entries)
+    ADDR_WIDTH : natural := clogb2(RAM_DEPTH)      --! RAM address
+  );
+  port (
+    CLK      : in  std_logic;
+    START    : in std_logic;  --! Start signal of previous proc. module.
+                              --! (or Done signal of previous, previous proc. module).
+    DONE     : in std_logic;  --! Done signal of previous proc. module.
+    ADDR     : in std_logic_vector(ADDR_WIDTH-1 downto 0); --! addr_in
+    DATA     : in std_logic_vector(RAM_WIDTH-1 downto 0);  --! din
+    WRITE_EN : in std_logic
+  );
+end FileWriter;
+
+
+architecture behavior of FileWriter is
+begin
+
+procFile : process(CLK)
+  variable START_LATCH : std_logic := '0';            
+  variable INIT        : boolean := false; --! File not yet open
+  variable FILE_STATUS : file_open_status;
+  file     FILE_OUT    : text;   
+  variable LINE_OUT    : line;                              
+  variable BX_CNT      : natural := 0;  --! Event counter
+  constant TXT_WIDTH   : natural := 11; --! Column width in output .txt file
+
+  function to_hexstring ( VAR : std_logic_vector) return string is
+  -- Convert to string, with "0x" prefix.
+  begin    
+    return "0x"&to_hstring(unsigned(var));
+  end;
+
+begin
+
+  -- Check user didn't change values of derived generics.
+  assert (RAM_DEPTH  = NUM_PAGES*PAGE_LENGTH) report "User changed RAM_DEPTH" severity FAILURE;
+  assert (ADDR_WIDTH = clogb2(RAM_DEPTH)) report "User changed ADDR_WIDTH" severity FAILURE;
+
+  if rising_edge(CLK) then
+
+    if (START = '1') then
+      START_LATCH := '1';
+    end if;
+
+    -- Open and initialize file
+
+    if (not INIT) then
+      INIT := true;
+      file_open(FILE_STATUS, FILE_OUT, FILE_NAME, write_mode); 
+      assert (FILE_STATUS = open_ok) report "Failed to open file "&FILE_NAME severity FAILURE;
+      -- Write column headings
+      write(LINE_OUT, string'("TIME (ns)"), right, TXT_WIDTH);
+      write(LINE_OUT, string'("BX")       , right, TXT_WIDTH);
+      write(LINE_OUT, string'("ADDR")     , right, TXT_WIDTH);
+      write(LINE_OUT, string'("DATA")     , right, 2*TXT_WIDTH);
+      writeline(FILE_OUT, LINE_OUT);      
+    end if;
+
+    -- Write data from events
+
+    if (START_LATCH = '1') then
+
+      if (WRITE_EN = '1') then 
+        -- Valid data, so write it to file.
+        write(LINE_OUT, NOW   , right, TXT_WIDTH); 
+        write(LINE_OUT, BX_CNT, right, TXT_WIDTH);
+        write(LINE_OUT, to_hexstring(ADDR), right, TXT_WIDTH);
+        write(LINE_OUT, to_hexstring(DATA), right, 2*TXT_WIDTH);
+        writeline(FILE_OUT, LINE_OUT);      
+      end if;
+
+      if (DONE = '1') then
+        -- Module has finished event, so increment event counter.
+        BX_CNT := BX_CNT + 1;
+
+        if (BX_CNT = MAX_EVENTS) then
+          -- All events processed, so close file.
+          file_close(FILE_OUT);
+        end if;
+      end if;
+    end if;
+  end if;
+
+end process procFile;
+
+end behavior;

--- a/IntegrationTests/common/hdl/FileWriterFromRAM.vhd
+++ b/IntegrationTests/common/hdl/FileWriterFromRAM.vhd
@@ -1,0 +1,142 @@
+--! Using the IEEE Library
+library IEEE;
+--! Using STD_LOGIC
+use IEEE.STD_LOGIC_1164.all;
+--! Writing to and from files
+use IEEE.STD_LOGIC_TEXTIO.all;
+--! Using NUMERIC TYPES
+use IEEE.NUMERIC_STD.all;
+--! Writing to and from files
+use STD.TEXTIO.all;
+
+--! User packages
+use work.tf_pkg.all;
+
+-- ==================================================================
+--  Writes a .txt file with the ADDR & DATA of all valid entries in
+--  the final memories in the chain.
+--
+--  N.B. This version assumes the memories are unbinned.
+-- ==================================================================
+
+entity FileWriterFromRAM is
+  generic (
+    FILE_NAME  : string;   --! Name of .txt file to be written
+    RAM_WIDTH  : natural := 18;    --! RAM data width
+    NUM_PAGES  : natural := 2;     --! Number of pages in RAM memory
+    -- Leave following parameters at their default values.
+    RAM_DEPTH  : natural := NUM_PAGES*PAGE_LENGTH; --! RAM depth (no. of entries)
+    ADDR_WIDTH : natural := clogb2(RAM_DEPTH)      --! RAM address
+  );
+  port (
+    CLK      : in  std_logic;
+    DONE     : in std_logic;   --! Done signal of final proc. module.
+    NENT_ARR : in t_arr_7b(0 to NUM_PAGES-1);
+    DATA     : in std_logic_vector(RAM_WIDTH-1 downto 0);    --! dout
+    ADDR     : out std_logic_vector(ADDR_WIDTH-1 downto 0);  --! read_addr
+    READ_EN  : out std_logic
+  );
+end FileWriterFromRAM;
+
+
+architecture behavior of FileWriterFromRAM is
+  -- Latches to allow for read latency of memory.
+  type t_arr_en_lat is array(0 to MEM_READ_LATENCY) of std_logic;
+  type t_arr_rd_lat is array(0 to MEM_READ_LATENCY) of std_logic_vector(ADDR_WIDTH-1 downto 0);
+  type t_arr_bx_lat is array(0 to MEM_READ_LATENCY) of integer;
+  signal READ_EN_LATCH : t_arr_en_lat := (others => '0');
+  signal ADDR_LATCH    : t_arr_rd_lat := (others => (others => '0'));
+  signal BX_CNT_LATCH  : t_arr_bx_lat := (others => 0);
+begin
+
+procFile : process(CLK)
+  variable INIT        : boolean := false; --! File not yet open
+  variable FILE_STATUS : file_open_status;
+  file     FILE_OUT    : text;   
+  variable LINE_OUT    : line;                              
+  variable BX_CNT      : integer := -1;  --! Event counter
+  variable PAGE        : natural := 0;
+  variable NENT        : natural := 0;
+  variable DATA_CNT    : natural := 0;   --! Counter of data within page
+  variable v_REN       : std_logic := '0';
+  variable v_ADDR      : std_logic_vector(ADDR_WIDTH-1 downto 0) := (others => '0');
+  constant zeroADDR    : std_logic_vector(ADDR_WIDTH-1 downto 0) := (others => '0');
+  constant TXT_WIDTH   : natural := 11;  --! Column width in output .txt file
+
+  function to_hexstring ( VAR : std_logic_vector) return string is
+  -- Convert to string, with "0x" prefix.
+  begin    
+    return "0x"&to_hstring(unsigned(var));
+  end;
+
+begin
+
+  -- Check user didn't change values of derived generics.
+  assert (RAM_DEPTH  = NUM_PAGES*PAGE_LENGTH) report "User changed RAM_DEPTH" severity FAILURE;
+  assert (ADDR_WIDTH = clogb2(RAM_DEPTH)) report "User changed ADDR_WIDTH" severity FAILURE;
+
+  if rising_edge(CLK) then
+
+    -- Open and initialize file
+
+    if (not INIT) then
+      INIT := true;
+      file_open(FILE_STATUS, FILE_OUT, FILE_NAME, write_mode); 
+      assert (FILE_STATUS = open_ok) report "Failed to open file "&FILE_NAME severity FAILURE;
+      -- Write column headings
+      write(LINE_OUT, string'("TIME (ns)"), right, TXT_WIDTH);
+      write(LINE_OUT, string'("BX")       , right, TXT_WIDTH);
+      write(LINE_OUT, string'("ADDR")     , right, TXT_WIDTH);
+      write(LINE_OUT, string'("DATA")     , right, 2*TXT_WIDTH);
+      writeline(FILE_OUT, LINE_OUT);      
+    end if;
+
+    -- Check if new event available in memory
+
+    if (DONE = '1') then   --! Signal present in single clk cycle when event first ready.
+      BX_CNT := BX_CNT + 1;
+      PAGE := BX_CNT mod NUM_PAGES;
+      NENT := to_integer(unsigned(NENT_ARR(PAGE)));
+      DATA_CNT :=0;
+
+      if (BX_CNT = MAX_EVENTS) then
+        -- All events processed, so close file.
+        file_close(FILE_OUT);
+      end if;
+    end if;
+
+    -- Launch memory read, if data remains to be read from current event.
+
+    if (BX_CNT >= 0 and BX_CNT < MAX_EVENTS and DATA_CNT < NENT) then
+      -- Data to read
+      v_REN  := '1';
+      v_ADDR := std_logic_vector(to_unsigned(DATA_CNT + PAGE_LENGTH*PAGE, ADDR_WIDTH));
+      DATA_CNT := DATA_CNT + 1;
+    else
+      -- No data to read.
+      v_REN  := '0';
+      v_ADDR := (others => '0');
+    end if;
+
+    READ_EN <= v_REN;
+    ADDR    <= v_ADDR;
+    -- As memory read takes 1-2 clks, store address and read-enable flags.
+    READ_EN_LATCH <= READ_EN_LATCH(1 to MEM_READ_LATENCY) & v_REN;
+    ADDR_LATCH    <= ADDR_LATCH   (1 to MEM_READ_LATENCY) & v_ADDR;
+    BX_CNT_LATCH  <= BX_CNT_LATCH (1 to MEM_READ_LATENCY) & BX_CNT;
+
+    -- Write to .txt file results of read from memory (if read took place).
+    -- (Delayed due to read latency of memory).
+    if (READ_EN_LATCH(0) = '1') then
+      -- Valid data, so write it to file.
+      write(LINE_OUT, NOW   , right, TXT_WIDTH); 
+      write(LINE_OUT, BX_CNT_LATCH(0), right, TXT_WIDTH);
+      write(LINE_OUT, to_hexstring(ADDR_LATCH(0)), right, TXT_WIDTH);
+      write(LINE_OUT, to_hexstring(DATA), right, 2*TXT_WIDTH);
+      writeline(FILE_OUT, LINE_OUT);      
+    end if;
+  end if;
+
+end process procFile;
+
+end behavior;

--- a/IntegrationTests/common/hdl/tf_pkg.vhd
+++ b/IntegrationTests/common/hdl/tf_pkg.vhd
@@ -38,6 +38,7 @@ package tf_pkg is
   constant N_MEM_BINS             : natural := 8;    --! Number of memory bins
   constant N_ENTRIES_PER_MEM_BINS : natural := 16;   --! Number of entries per memory bin
   constant PAGE_LENGTH            : natural := 128;  --! Page length of all memories
+  constant MEM_READ_LATENCY       : natural := 2;    --! Memory read latency.
   -- Memory width constants
   constant RAM_WIDTH_AS    : natural := 36; --! Width for memories
   constant RAM_WIDTH_TPROJ : natural := 60; --! Width for memories

--- a/IntegrationTests/common/script/CompareMemPrintsFW.py
+++ b/IntegrationTests/common/script/CompareMemPrintsFW.py
@@ -112,7 +112,8 @@ def compare(comparison_filename="", fail_on_error=False, file_location='./', pre
             raise IndexError("Unable to determine the reference file type from the file name")
         finally:
             reference_type = ReferenceType[reference_type_string]
-        print("Comparing " + reference_type.FullName() + " values ... ")
+
+        print("Comparing TB results to ref. file "+str(reference_filename)+" ... ")
 
         # Parse the reference data
         reference_data = parse_reference_file(file_location+"/"+reference_filename)

--- a/IntegrationTests/common/script/CompareMemPrintsFW.py
+++ b/IntegrationTests/common/script/CompareMemPrintsFW.py
@@ -74,16 +74,6 @@ def parse_reference_file(filename):
         events.append(values)
     return events
 
-def get_column_index(layers, df):
-    match = False
-    column_index = -1
-    for icol, column_header in enumerate(df.columns):
-        match = len(re.findall(layers,column_header))>0
-        if match:
-            column_index = icol
-            break
-    return icol
-
 def print_results(total_number_of_events, number_of_good_events, number_of_missing_events, number_of_event_length_mismatches, number_of_value_mismatches):
     print("\nResults\n"+(7*'='))
     print("Good events: "+str(number_of_good_events))
@@ -124,15 +114,6 @@ def compare(comparison_filename="", fail_on_error=False, file_location='./', pre
             reference_type = ReferenceType[reference_type_string]
         print("Comparing " + reference_type.FullName() + " values ... ")
 
-        # Find the layer names for the reference file
-        if reference_type == ReferenceType.FM:
-            layers = re.search("(L[0-9]L[0-9])",reference_filename).group(0)
-            print("Comparing the values for layers "+str(layers)+" to the reference file "+str(reference_filename)+" ... ")
-        elif reference_type in [ReferenceType.AP,ReferenceType.CM,ReferenceType.VMPROJ] :
-            layers = re.search("(L[0-9])",reference_filename).group(0)
-        else:
-            raise TypeError("Unknown type of the reference file (implemented options: FullMatches, CandidateMatches)")
-
         # Parse the reference data
         reference_data = parse_reference_file(file_location+"/"+reference_filename)
 
@@ -145,14 +126,7 @@ def compare(comparison_filename="", fail_on_error=False, file_location='./', pre
         data = pd.read_csv(file_location+"/"+comparison_filename,delim_whitespace=True,header=0,names=column_names,usecols=[i for i in column_names if any(select in i for select in column_selections)])
         if verbose: print(data) # Can also just do data.head()
 
-        # Get the column index for the correct columns of data
-        value_index = get_column_index(layers,data)
-        address_index = value_index-1
-        valid_index = value_index-2
-        selected_columns = data[['BX','ADDR','DATA']]
-
-        group_index = 0
-        group_sub_index = -1
+        selected_columns = data[column_selections]
 
         for ievent,event in enumerate(reference_data):
             print("Doing event "+str(ievent+1)+"/"+str(len(reference_data))+" ... ")


### PR DESCRIPTION
Simplified .txt file writing of results from VHDL test-bench by:
1) Adding new utility common/hdl/FileWriter.vhd to write to .txt file results from an intermediate BRAM memory in the L1Trk chain.
2) Adding new utility common/hdl/FileWriterFromRAM.vhd to write to .txt file results from an unbinned BRAM memory at the end of the L1Trk chain.
3) Small changes to CompareMemPrintsFW.py to handle simplified column headings in .txt files.
4) Resolves issue https://github.com/cms-L1TK/firmware-hls/issues/146

Validation: cmp.txt files produced by CompareMemPrintsFW.py are unchanged. And Vivado simulation running much faster.
