### PR TITLE
Set nentries when running in CMSSW

### DIFF
--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -98,10 +98,10 @@ public:
 	int nent = nentries_[ibx]; 
 	bool success = write_mem(ibx, data, nent);
 
-  #ifndef CMSSW_GIT_HASH
-  if (success) nentries_[ibx] ++;
-  #endif
-  return success;
+	#ifndef CMSSW_GIT_HASH
+	if (success) nentries_[ibx] ++;
+	#endif
+	return success;
   }
 
   bool write_mem(BunchXingT ibx, const std::string datastr, int base=16)
@@ -110,10 +110,10 @@ public:
 	int nent = nentries_[ibx];
 	bool success = write_mem(ibx, data, nent);
 
-  #ifndef CMSSW_GIT_HASH
-  if (success) nentries_[ibx] ++;
-  #endif
-  return success;
+	#ifndef CMSSW_GIT_HASH
+	if (success) nentries_[ibx] ++;
+	#endif
+	return success;
   }
 
   // print memory contents

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -60,6 +60,11 @@ public:
 #pragma HLS inline
     if (addr_index < (1<<NBIT_ADDR)) {
       dataarray_[ibx][addr_index] = data;
+      
+      #ifdef CMSSW_GIT_HASH
+        nentries_[ibx] = addr_index + 1;
+      #endif
+      
       return true;
     } else {
       return false;
@@ -92,7 +97,10 @@ public:
 	DataType data(datastr, base);
 	int nent = nentries_[ibx]; 
 	bool success = write_mem(ibx, data, nent);
+
+  #ifndef CMSSW_GIT_HASH
 	if (success) nentries_[ibx] ++;
+  #endif
         return success;
   }
 
@@ -101,7 +109,10 @@ public:
 	DataType data(datastr.c_str(), base);
 	int nent = nentries_[ibx];
 	bool success = write_mem(ibx, data, nent);
+
+  #ifndef CMSSW_GIT_HASH
 	if (success) nentries_[ibx] ++;
+  #endif
         return success;
   }
 
@@ -138,7 +149,15 @@ public:
   static constexpr int getWidth() {return DataType::getWidth();}
   
 #endif
-  
+
+// #ifdef CMSSW_GIT_HASH
+//   bool write_mem_CMSSW(BunchXingT ibx, DataType data, int addr_index)
+//   {
+//     bool success = write_mem(ibx, data, addr_index);
+//     if (success) nentries_[ibx] ++;
+//           return success;
+//   }
+// #endif
 };
 
 #endif

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -150,14 +150,6 @@ public:
   
 #endif
 
-// #ifdef CMSSW_GIT_HASH
-//   bool write_mem_CMSSW(BunchXingT ibx, DataType data, int addr_index)
-//   {
-//     bool success = write_mem(ibx, data, addr_index);
-//     if (success) nentries_[ibx] ++;
-//           return success;
-//   }
-// #endif
 };
 
 #endif

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -62,7 +62,7 @@ public:
       dataarray_[ibx][addr_index] = data;
       
       #ifdef CMSSW_GIT_HASH
-        nentries_[ibx] = addr_index + 1;
+      nentries_[ibx] = addr_index + 1;
       #endif
       
       return true;
@@ -101,7 +101,7 @@ public:
   #ifndef CMSSW_GIT_HASH
 	if (success) nentries_[ibx] ++;
   #endif
-        return success;
+  return success;
   }
 
   bool write_mem(BunchXingT ibx, const std::string datastr, int base=16)
@@ -113,7 +113,7 @@ public:
   #ifndef CMSSW_GIT_HASH
 	if (success) nentries_[ibx] ++;
   #endif
-        return success;
+  return success;
   }
 
   // print memory contents

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -99,7 +99,7 @@ public:
 	bool success = write_mem(ibx, data, nent);
 
   #ifndef CMSSW_GIT_HASH
-	if (success) nentries_[ibx] ++;
+  if (success) nentries_[ibx] ++;
   #endif
   return success;
   }
@@ -111,7 +111,7 @@ public:
 	bool success = write_mem(ibx, data, nent);
 
   #ifndef CMSSW_GIT_HASH
-	if (success) nentries_[ibx] ++;
+  if (success) nentries_[ibx] ++;
   #endif
   return success;
   }

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -66,6 +66,9 @@ public:
 	if (nentry_ibx < (1<<(kNBitDataAddr))) {
 	  // write address for slot: 1<<(kNBitDataAddr) * slot + nentry_ibx
 	  dataarray_[ibx][(1<<(kNBitDataAddr))*slot+nentry_ibx] = data;
+    #ifdef CMSSW_GIT_HASH
+    nentries_[ibx][slot]++;
+    #endif
 	  return true;
 	}
 	else {
@@ -125,7 +128,9 @@ public:
     DataType data(datastr.c_str(), base);
     int nent = nentries_[bx][slot];
     bool success = write_mem(bx, slot, data, nent);
+    #ifndef CMSSW_GIT_HASH
     if (success) nentries_[bx][slot] ++;
+    #endif
     return success;
   }
 

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -66,9 +66,9 @@ public:
 	if (nentry_ibx < (1<<(kNBitDataAddr))) {
 	  // write address for slot: 1<<(kNBitDataAddr) * slot + nentry_ibx
 	  dataarray_[ibx][(1<<(kNBitDataAddr))*slot+nentry_ibx] = data;
-    #ifdef CMSSW_GIT_HASH
-    nentries_[ibx][slot]++;
-    #endif
+	  #ifdef CMSSW_GIT_HASH
+	  nentries_[ibx][slot]++;
+	  #endif
 	  return true;
 	}
 	else {

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -174,10 +174,12 @@ class MemoryTemplateBinnedCM{
     DataType data(datastr.c_str(), base);
 
     bool success = write_mem(ibx, slot, data, nentry_ibx);
+    #ifndef CMSSW_GIT_HASH
     if (success) {
       nentries8_[ibx][ibin].range(ireg*4+3,ireg*4)=nentry_ibx+1;
       binmask8_[ibx][ibin].set_bit(ireg,true);
     }
+    #endif
 
     return success;
   }

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -105,6 +105,13 @@ class MemoryTemplateBinnedCM{
 	dataarray_[icopy][ibx][getNEntryPerBin()*slot+nentry_ibx] = data;
       }
 
+      #ifdef CMSSW_GIT_HASH
+      ap_uint<3> ibin,ireg;
+      (ireg,ibin)=slot;
+      nentries8_[ibx][ibin].range(ireg*4+3,ireg*4)=nentry_ibx+1;
+      binmask8_[ibx][ibin].set_bit(ireg,true);
+      #endif
+
       return true;
     }
     else {

--- a/TrackletAlgorithm/VMRouterCM.h
+++ b/TrackletAlgorithm/VMRouterCM.h
@@ -286,7 +286,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 		}
 
 // For debugging
-#ifndef __SYNTHESIS__
+#if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
 		std::cout << std::endl << "Stub index no. " << i << std::endl
 				<< "Out put stub: " << std::hex << allstub.raw() << std::dec
 				<< std::endl;
@@ -369,7 +369,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 				}
 
 // For debugging
-#ifndef __SYNTHESIS__
+#if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
 				std::cout << std::endl << "Allstub Inner: " << std::hex
 						<< allstubinner.raw() << std::dec << std::endl;
 #endif // DEBUG
@@ -392,7 +392,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 		addrCountME[slotME] += 1;
 
 // For debugging
-#ifndef __SYNTHESIS__
+#if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
 		std::cout << "ME stub " << std::hex << stubME.raw() << std::dec
 				<< "       to slot " << slotME << std::endl;
 #endif // DEBUG
@@ -415,7 +415,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 			addrCountTE[slotTE] += 1;
 
 // For debugging
-#ifndef __SYNTHESIS__
+#if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
 			std::cout << "TEOuter stub " << std::hex << stubTEO.raw()
 					<< std::dec << "       to slot " << slotTE << std::endl;
 #endif // DEBUG


### PR DESCRIPTION
We need the nentries variable to be set for the memories when running inside CMSSW. As we are also replicating the testbenches in CMSSW (using inputs from text files rather than from the CMSSW event), we have to avoid incrementing nentries twice when reading from a text file. Following a short email exchange with @aehart, using the CMSSW_GIT_HASH was suggested as the way to implement this.

I implemented the changes for MemoryTemplate.h and MemoryTemplateBinned.h so far. It wasn't obvious to me how to implement the same changes for MemoryTemplateBinnedCM.h (for both nentries 8 and binmask8), so I would appreciate some guidance there.

I also added a few preprocessor guards around the cout statements in the VMR code so they don't appear when running in CMSSW.