### PR TITLE
IR-VMR Chain updates

### DIFF
--- a/IntegrationTests/IRVMR/hdl/SectorProcessor.vhd
+++ b/IntegrationTests/IRVMR/hdl/SectorProcessor.vhd
@@ -1,0 +1,608 @@
+--! Standard libraries
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+--! User packages
+use work.tf_pkg.all;
+use work.memUtil_pkg.all;
+
+entity SectorProcessor is
+  port(
+    clk        : in std_logic;
+    reset      : in std_logic;
+    IR_start  : in std_logic;
+    IR_bx_in : in std_logic_vector(2 downto 0);
+    VMR_bx_out : out std_logic_vector(2 downto 0);
+    VMR_bx_out_vld : out std_logic;
+    VMR_done   : out std_logic;
+    DL_39_link_AV_dout       : in t_arr_DL_39_DATA;
+    DL_39_link_empty_neg     : in t_arr_DL_39_1b;
+    DL_39_link_read          : out t_arr_DL_39_1b;
+    AS_36_mem_A_enb          : in t_arr_AS_36_1b;
+    AS_36_mem_AV_readaddr    : in t_arr_AS_36_ADDR;
+    AS_36_mem_AV_dout        : out t_arr_AS_36_DATA;
+    VMSME_16_mem_A_enb          : in t_arr_VMSME_16_1b;
+    VMSME_16_mem_AV_readaddr    : in t_arr_VMSME_16_ADDR;
+    VMSME_16_mem_AV_dout        : out t_arr_VMSME_16_DATA;
+    VMSME_16_mem_AAAV_dout_nent : out t_arr_VMSME_16_NENT;
+    VMSTE_16_mem_A_enb          : in t_arr_VMSTE_16_1b;
+    VMSTE_16_mem_AV_readaddr    : in t_arr_VMSTE_16_ADDR;
+    VMSTE_16_mem_AV_dout        : out t_arr_VMSTE_16_DATA;
+    VMSTE_16_mem_AAAV_dout_nent : out t_arr_VMSTE_16_NENT;
+    VMSTE_22_mem_A_enb          : in t_arr_VMSTE_22_1b;
+    VMSTE_22_mem_AV_readaddr    : in t_arr_VMSTE_22_ADDR;
+    VMSTE_22_mem_AV_dout        : out t_arr_VMSTE_22_DATA;
+    VMSTE_22_mem_AAV_dout_nent  : out t_arr_VMSTE_22_NENT
+  );
+end SectorProcessor;
+
+architecture rtl of SectorProcessor is
+
+  signal IL_36_mem_A_wea          : t_arr_IL_36_1b;
+  signal IL_36_mem_AV_writeaddr   : t_arr_IL_36_ADDR;
+  signal IL_36_mem_AV_din         : t_arr_IL_36_DATA;
+  signal IL_36_mem_A_enb          : t_arr_IL_36_1b;
+  signal IL_36_mem_AV_readaddr    : t_arr_IL_36_ADDR;
+  signal IL_36_mem_AV_dout        : t_arr_IL_36_DATA;
+  signal IL_36_mem_AAV_dout_nent  : t_arr_IL_36_NENT; -- (#page)
+  signal AS_36_mem_A_wea          : t_arr_AS_36_1b;
+  signal AS_36_mem_AV_writeaddr   : t_arr_AS_36_ADDR;
+  signal AS_36_mem_AV_din         : t_arr_AS_36_DATA;
+  signal VMSME_16_mem_A_wea          : t_arr_VMSME_16_1b;
+  signal VMSME_16_mem_AV_writeaddr   : t_arr_VMSME_16_ADDR;
+  signal VMSME_16_mem_AV_din         : t_arr_VMSME_16_DATA;
+  signal VMSTE_16_mem_A_wea          : t_arr_VMSTE_16_1b;
+  signal VMSTE_16_mem_AV_writeaddr   : t_arr_VMSTE_16_ADDR;
+  signal VMSTE_16_mem_AV_din         : t_arr_VMSTE_16_DATA;
+  signal VMSTE_22_mem_A_wea          : t_arr_VMSTE_22_1b;
+  signal VMSTE_22_mem_AV_writeaddr   : t_arr_VMSTE_22_ADDR;
+  signal VMSTE_22_mem_AV_din         : t_arr_VMSTE_22_DATA;
+  signal IR_done : std_logic := '0';
+  signal IR_bx_out : std_logic_vector(2 downto 0);
+  signal IR_bx_out_vld : std_logic;
+  signal VMR_start : std_logic := '0';
+
+begin
+
+  IL_36_loop : for var in enum_IL_36 generate
+  begin
+
+    IL_36 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 36,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => IL_36_mem_A_wea(var),
+        addra     => IL_36_mem_AV_writeaddr(var),
+        dina      => IL_36_mem_AV_din(var),
+        clkb      => clk,
+        enb       => IL_36_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => IL_36_mem_AV_readaddr(var),
+        doutb     => IL_36_mem_AV_dout(var),
+        sync_nent => VMR_start,
+        nent_o    => IL_36_mem_AAV_dout_nent(var)
+      );
+
+  end generate IL_36_loop;
+
+
+  AS_36_loop : for var in enum_AS_36 generate
+  begin
+
+    AS_36 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 36,
+        NUM_PAGES       => 8,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => AS_36_mem_A_wea(var),
+        addra     => AS_36_mem_AV_writeaddr(var),
+        dina      => AS_36_mem_AV_din(var),
+        clkb      => clk,
+        enb       => AS_36_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => AS_36_mem_AV_readaddr(var),
+        doutb     => AS_36_mem_AV_dout(var),
+        sync_nent => VMR_done,
+        nent_o    => open
+      );
+
+  end generate AS_36_loop;
+
+
+  VMSME_16_loop : for var in enum_VMSME_16 generate
+  begin
+
+    VMSME_16 : entity work.tf_mem_bin
+      generic map (
+        RAM_WIDTH       => 16,
+        NUM_PAGES       => 8,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => VMSME_16_mem_A_wea(var),
+        addra     => VMSME_16_mem_AV_writeaddr(var),
+        dina      => VMSME_16_mem_AV_din(var),
+        clkb      => clk,
+        enb       => VMSME_16_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => VMSME_16_mem_AV_readaddr(var),
+        doutb     => VMSME_16_mem_AV_dout(var),
+        sync_nent => VMR_done,
+        nent_o    => VMSME_16_mem_AAAV_dout_nent(var)
+      );
+
+  end generate VMSME_16_loop;
+
+
+  VMSTE_16_loop : for var in enum_VMSTE_16 generate
+  begin
+
+    VMSTE_16 : entity work.tf_mem_bin
+      generic map (
+        RAM_WIDTH       => 16,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => VMSTE_16_mem_A_wea(var),
+        addra     => VMSTE_16_mem_AV_writeaddr(var),
+        dina      => VMSTE_16_mem_AV_din(var),
+        clkb      => clk,
+        enb       => VMSTE_16_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => VMSTE_16_mem_AV_readaddr(var),
+        doutb     => VMSTE_16_mem_AV_dout(var),
+        sync_nent => VMR_done,
+        nent_o    => VMSTE_16_mem_AAAV_dout_nent(var)
+      );
+
+  end generate VMSTE_16_loop;
+
+
+  VMSTE_22_loop : for var in enum_VMSTE_22 generate
+  begin
+
+    VMSTE_22 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 22,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => VMSTE_22_mem_A_wea(var),
+        addra     => VMSTE_22_mem_AV_writeaddr(var),
+        dina      => VMSTE_22_mem_AV_din(var),
+        clkb      => clk,
+        enb       => VMSTE_22_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => VMSTE_22_mem_AV_readaddr(var),
+        doutb     => VMSTE_22_mem_AV_dout(var),
+        sync_nent => VMR_done,
+        nent_o    => VMSTE_22_mem_AAV_dout_nent(var)
+      );
+
+  end generate VMSTE_22_loop;
+
+
+  VMR_start <= '1' when IR_done = '1';
+
+  IR_PS10G_3_A : entity work.IR_PS10G_3_A
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => IR_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => IR_done,
+      bx_V          => IR_bx_in,
+      bx_o_V        => IR_bx_out,
+      bx_o_V_ap_vld => IR_bx_out_vld,
+      hInputStubs_V_dout       => DL_39_link_AV_dout(PS10G_3_A),
+      hInputStubs_V_empty_n  => DL_39_link_empty_neg(PS10G_3_A),
+      hInputStubs_V_read        => DL_39_link_read(PS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_ce0       => open,
+      hOutputStubs_0_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIA_PS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIA_PS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIA_PS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_ce0       => open,
+      hOutputStubs_1_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIB_PS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIB_PS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIB_PS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_ce0       => open,
+      hOutputStubs_2_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIC_PS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIC_PS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIC_PS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_ce0       => open,
+      hOutputStubs_3_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIA_PS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIA_PS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIA_PS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_ce0       => open,
+      hOutputStubs_4_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIB_PS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIB_PS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIB_PS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_ce0       => open,
+      hOutputStubs_5_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIC_PS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIC_PS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIC_PS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_ce0       => open,
+      hOutputStubs_6_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHID_PS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHID_PS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHID_PS10G_3_A),
+      hLinkWord_V => "01000000000001000101",
+      hPhBnWord_V => "000000011010"
+  );
+
+  IR_negPS10G_3_A : entity work.IR_negPS10G_3_A
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => IR_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => IR_bx_in,
+      hInputStubs_V_dout       => DL_39_link_AV_dout(negPS10G_3_A),
+      hInputStubs_V_empty_n  => DL_39_link_empty_neg(negPS10G_3_A),
+      hInputStubs_V_read        => DL_39_link_read(negPS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_ce0       => open,
+      hOutputStubs_0_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIA_negPS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIA_negPS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIA_negPS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_ce0       => open,
+      hOutputStubs_1_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIB_negPS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIB_negPS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIB_negPS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_ce0       => open,
+      hOutputStubs_2_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIC_negPS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIC_negPS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIC_negPS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_ce0       => open,
+      hOutputStubs_3_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIA_negPS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIA_negPS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIA_negPS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_ce0       => open,
+      hOutputStubs_4_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIB_negPS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIB_negPS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIB_negPS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_ce0       => open,
+      hOutputStubs_5_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIC_negPS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIC_negPS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIC_negPS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_ce0       => open,
+      hOutputStubs_6_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHID_negPS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHID_negPS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHID_negPS10G_3_A),
+      hLinkWord_V => "01000000000001000101",
+      hPhBnWord_V => "000000011010"
+  );
+
+  VMR_L2PHIA : entity work.VMR_L2PHIA
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => VMR_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => VMR_done,
+      bx_V          => IR_bx_out,
+      bx_o_V        => VMR_bx_out,
+      bx_o_V_ap_vld => VMR_bx_out_vld,
+      inputStubs_0_dataarray_data_V_ce0       => IL_36_mem_A_enb(L2PHIA_PS10G_3_A),
+      inputStubs_0_dataarray_data_V_address0  => IL_36_mem_AV_readaddr(L2PHIA_PS10G_3_A),
+      inputStubs_0_dataarray_data_V_q0        => IL_36_mem_AV_dout(L2PHIA_PS10G_3_A),
+      inputStubs_0_nentries_0_V               => IL_36_mem_AAV_dout_nent(L2PHIA_PS10G_3_A)(0),
+      inputStubs_0_nentries_1_V               => IL_36_mem_AAV_dout_nent(L2PHIA_PS10G_3_A)(1),
+      inputStubs_1_dataarray_data_V_ce0       => IL_36_mem_A_enb(L2PHIA_negPS10G_3_A),
+      inputStubs_1_dataarray_data_V_address0  => IL_36_mem_AV_readaddr(L2PHIA_negPS10G_3_A),
+      inputStubs_1_dataarray_data_V_q0        => IL_36_mem_AV_dout(L2PHIA_negPS10G_3_A),
+      inputStubs_1_nentries_0_V               => IL_36_mem_AAV_dout_nent(L2PHIA_negPS10G_3_A)(0),
+      inputStubs_1_nentries_1_V               => IL_36_mem_AAV_dout_nent(L2PHIA_negPS10G_3_A)(1),
+      memoriesAS_0_dataarray_data_V_ce0       => open,
+      memoriesAS_0_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn1),
+      memoriesAS_0_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn1),
+      memoriesAS_0_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn1),
+      memoriesAS_1_dataarray_data_V_ce0       => open,
+      memoriesAS_1_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn2),
+      memoriesAS_1_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn2),
+      memoriesAS_1_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn2),
+      memoriesAS_2_dataarray_data_V_ce0       => open,
+      memoriesAS_2_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn3),
+      memoriesAS_2_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn3),
+      memoriesAS_2_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn3),
+      memoriesAS_3_dataarray_data_V_ce0       => open,
+      memoriesAS_3_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn4),
+      memoriesAS_3_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn4),
+      memoriesAS_3_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn4),
+      memoriesAS_4_dataarray_data_V_ce0       => open,
+      memoriesAS_4_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn5),
+      memoriesAS_4_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn5),
+      memoriesAS_4_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn5),
+      memoriesAS_5_dataarray_data_V_ce0       => open,
+      memoriesAS_5_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn6),
+      memoriesAS_5_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn6),
+      memoriesAS_5_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn6),
+      memoriesAS_6_dataarray_data_V_ce0       => open,
+      memoriesAS_6_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn7),
+      memoriesAS_6_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn7),
+      memoriesAS_6_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn7),
+      memoriesME_0_dataarray_data_V_ce0       => open,
+      memoriesME_0_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA1n1),
+      memoriesME_0_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA1n1),
+      memoriesME_0_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA1n1),
+      memoriesME_1_dataarray_data_V_ce0       => open,
+      memoriesME_1_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA2n1),
+      memoriesME_1_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA2n1),
+      memoriesME_1_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA2n1),
+      memoriesME_2_dataarray_data_V_ce0       => open,
+      memoriesME_2_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA3n1),
+      memoriesME_2_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA3n1),
+      memoriesME_2_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA3n1),
+      memoriesME_3_dataarray_data_V_ce0       => open,
+      memoriesME_3_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA4n1),
+      memoriesME_3_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA4n1),
+      memoriesME_3_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA4n1),
+      memoriesME_4_dataarray_data_V_ce0       => open,
+      memoriesME_4_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA5n1),
+      memoriesME_4_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA5n1),
+      memoriesME_4_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA5n1),
+      memoriesME_5_dataarray_data_V_ce0       => open,
+      memoriesME_5_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA6n1),
+      memoriesME_5_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA6n1),
+      memoriesME_5_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA6n1),
+      memoriesME_6_dataarray_data_V_ce0       => open,
+      memoriesME_6_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA7n1),
+      memoriesME_6_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA7n1),
+      memoriesME_6_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA7n1),
+      memoriesME_7_dataarray_data_V_ce0       => open,
+      memoriesME_7_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA8n1),
+      memoriesME_7_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA8n1),
+      memoriesME_7_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA8n1),
+      memoriesTEI_0_0_dataarray_data_V_ce0       => open,
+      memoriesTEI_0_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII1n1),
+      memoriesTEI_0_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII1n1),
+      memoriesTEI_0_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII1n1),
+      memoriesTEI_0_1_dataarray_data_V_ce0       => open,
+      memoriesTEI_0_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII1n2),
+      memoriesTEI_0_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII1n2),
+      memoriesTEI_0_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII1n2),
+      memoriesTEI_1_0_dataarray_data_V_ce0       => open,
+      memoriesTEI_1_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII2n1),
+      memoriesTEI_1_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII2n1),
+      memoriesTEI_1_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII2n1),
+      memoriesTEI_1_1_dataarray_data_V_ce0       => open,
+      memoriesTEI_1_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII2n2),
+      memoriesTEI_1_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII2n2),
+      memoriesTEI_1_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII2n2),
+      memoriesTEI_1_2_dataarray_data_V_ce0       => open,
+      memoriesTEI_1_2_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII2n3),
+      memoriesTEI_1_2_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII2n3),
+      memoriesTEI_1_2_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII2n3),
+      memoriesTEI_2_0_dataarray_data_V_ce0       => open,
+      memoriesTEI_2_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII3n1),
+      memoriesTEI_2_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII3n1),
+      memoriesTEI_2_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII3n1),
+      memoriesTEI_2_1_dataarray_data_V_ce0       => open,
+      memoriesTEI_2_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII3n2),
+      memoriesTEI_2_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII3n2),
+      memoriesTEI_2_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII3n2),
+      memoriesTEI_2_2_dataarray_data_V_ce0       => open,
+      memoriesTEI_2_2_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII3n3),
+      memoriesTEI_2_2_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII3n3),
+      memoriesTEI_2_2_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII3n3),
+      memoriesTEI_3_0_dataarray_data_V_ce0       => open,
+      memoriesTEI_3_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII4n1),
+      memoriesTEI_3_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII4n1),
+      memoriesTEI_3_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII4n1),
+      memoriesTEI_3_1_dataarray_data_V_ce0       => open,
+      memoriesTEI_3_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII4n2),
+      memoriesTEI_3_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII4n2),
+      memoriesTEI_3_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII4n2),
+      memoriesTEI_3_2_dataarray_data_V_ce0       => open,
+      memoriesTEI_3_2_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII4n3),
+      memoriesTEI_3_2_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII4n3),
+      memoriesTEI_3_2_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII4n3),
+      memoriesOL_0_0_dataarray_data_V_ce0       => open,
+      memoriesOL_0_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX1n5),
+      memoriesOL_0_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX1n5),
+      memoriesOL_0_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX1n5),
+      memoriesOL_0_1_dataarray_data_V_ce0       => open,
+      memoriesOL_0_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX1n6),
+      memoriesOL_0_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX1n6),
+      memoriesOL_0_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX1n6),
+      memoriesOL_0_2_dataarray_data_V_ce0       => open,
+      memoriesOL_0_2_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX1n7),
+      memoriesOL_0_2_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX1n7),
+      memoriesOL_0_2_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX1n7),
+      memoriesOL_1_0_dataarray_data_V_ce0       => open,
+      memoriesOL_1_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX2n5),
+      memoriesOL_1_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX2n5),
+      memoriesOL_1_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX2n5),
+      memoriesOL_1_1_dataarray_data_V_ce0       => open,
+      memoriesOL_1_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX2n6),
+      memoriesOL_1_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX2n6),
+      memoriesOL_1_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX2n6),
+      memoriesOL_1_2_dataarray_data_V_ce0       => open,
+      memoriesOL_1_2_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX2n7),
+      memoriesOL_1_2_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX2n7),
+      memoriesOL_1_2_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX2n7),
+      memoriesOL_1_3_dataarray_data_V_ce0       => open,
+      memoriesOL_1_3_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX2n8),
+      memoriesOL_1_3_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX2n8),
+      memoriesOL_1_3_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX2n8),
+      memoriesTEO_0_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_0_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA1n1),
+      memoriesTEO_0_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA1n1),
+      memoriesTEO_0_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA1n1),
+      memoriesTEO_0_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_0_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA1n2),
+      memoriesTEO_0_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA1n2),
+      memoriesTEO_0_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA1n2),
+      memoriesTEO_0_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_0_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA1n3),
+      memoriesTEO_0_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA1n3),
+      memoriesTEO_0_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA1n3),
+      memoriesTEO_1_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_1_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA2n1),
+      memoriesTEO_1_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA2n1),
+      memoriesTEO_1_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA2n1),
+      memoriesTEO_1_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_1_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA2n2),
+      memoriesTEO_1_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA2n2),
+      memoriesTEO_1_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA2n2),
+      memoriesTEO_1_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_1_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA2n3),
+      memoriesTEO_1_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA2n3),
+      memoriesTEO_1_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA2n3),
+      memoriesTEO_1_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_1_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA2n4),
+      memoriesTEO_1_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA2n4),
+      memoriesTEO_1_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA2n4),
+      memoriesTEO_2_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_2_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA3n1),
+      memoriesTEO_2_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA3n1),
+      memoriesTEO_2_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA3n1),
+      memoriesTEO_2_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_2_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA3n2),
+      memoriesTEO_2_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA3n2),
+      memoriesTEO_2_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA3n2),
+      memoriesTEO_2_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_2_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA3n3),
+      memoriesTEO_2_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA3n3),
+      memoriesTEO_2_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA3n3),
+      memoriesTEO_2_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_2_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA3n4),
+      memoriesTEO_2_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA3n4),
+      memoriesTEO_2_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA3n4),
+      memoriesTEO_2_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_2_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA3n5),
+      memoriesTEO_2_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA3n5),
+      memoriesTEO_2_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA3n5),
+      memoriesTEO_3_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_3_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA4n1),
+      memoriesTEO_3_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA4n1),
+      memoriesTEO_3_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA4n1),
+      memoriesTEO_3_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_3_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA4n2),
+      memoriesTEO_3_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA4n2),
+      memoriesTEO_3_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA4n2),
+      memoriesTEO_3_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_3_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA4n3),
+      memoriesTEO_3_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA4n3),
+      memoriesTEO_3_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA4n3),
+      memoriesTEO_3_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_3_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA4n4),
+      memoriesTEO_3_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA4n4),
+      memoriesTEO_3_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA4n4),
+      memoriesTEO_3_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_3_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA4n5),
+      memoriesTEO_3_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA4n5),
+      memoriesTEO_3_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA4n5),
+      memoriesTEO_4_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_4_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA5n1),
+      memoriesTEO_4_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA5n1),
+      memoriesTEO_4_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA5n1),
+      memoriesTEO_4_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_4_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA5n2),
+      memoriesTEO_4_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA5n2),
+      memoriesTEO_4_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA5n2),
+      memoriesTEO_4_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_4_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA5n3),
+      memoriesTEO_4_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA5n3),
+      memoriesTEO_4_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA5n3),
+      memoriesTEO_4_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_4_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA5n4),
+      memoriesTEO_4_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA5n4),
+      memoriesTEO_4_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA5n4),
+      memoriesTEO_4_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_4_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA5n5),
+      memoriesTEO_4_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA5n5),
+      memoriesTEO_4_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA5n5),
+      memoriesTEO_5_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_5_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA6n1),
+      memoriesTEO_5_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA6n1),
+      memoriesTEO_5_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA6n1),
+      memoriesTEO_5_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_5_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA6n2),
+      memoriesTEO_5_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA6n2),
+      memoriesTEO_5_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA6n2),
+      memoriesTEO_5_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_5_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA6n3),
+      memoriesTEO_5_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA6n3),
+      memoriesTEO_5_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA6n3),
+      memoriesTEO_5_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_5_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA6n4),
+      memoriesTEO_5_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA6n4),
+      memoriesTEO_5_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA6n4),
+      memoriesTEO_5_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_5_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA6n5),
+      memoriesTEO_5_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA6n5),
+      memoriesTEO_5_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA6n5),
+      memoriesTEO_6_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_6_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA7n1),
+      memoriesTEO_6_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA7n1),
+      memoriesTEO_6_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA7n1),
+      memoriesTEO_6_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_6_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA7n2),
+      memoriesTEO_6_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA7n2),
+      memoriesTEO_6_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA7n2),
+      memoriesTEO_6_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_6_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA7n3),
+      memoriesTEO_6_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA7n3),
+      memoriesTEO_6_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA7n3),
+      memoriesTEO_6_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_6_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA7n4),
+      memoriesTEO_6_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA7n4),
+      memoriesTEO_6_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA7n4),
+      memoriesTEO_6_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_6_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA7n5),
+      memoriesTEO_6_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA7n5),
+      memoriesTEO_6_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA7n5),
+      memoriesTEO_7_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_7_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA8n1),
+      memoriesTEO_7_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA8n1),
+      memoriesTEO_7_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA8n1),
+      memoriesTEO_7_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_7_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA8n2),
+      memoriesTEO_7_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA8n2),
+      memoriesTEO_7_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA8n2),
+      memoriesTEO_7_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_7_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA8n3),
+      memoriesTEO_7_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA8n3),
+      memoriesTEO_7_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA8n3),
+      memoriesTEO_7_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_7_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA8n4),
+      memoriesTEO_7_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA8n4),
+      memoriesTEO_7_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA8n4),
+      memoriesTEO_7_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_7_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA8n5),
+      memoriesTEO_7_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA8n5),
+      memoriesTEO_7_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA8n5)
+  );
+
+
+
+end rtl;

--- a/IntegrationTests/IRVMR/hdl/SectorProcessorFull.vhd
+++ b/IntegrationTests/IRVMR/hdl/SectorProcessorFull.vhd
@@ -1,0 +1,608 @@
+--! Standard libraries
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+--! User packages
+use work.tf_pkg.all;
+use work.memUtil_pkg.all;
+
+entity SectorProcessorFull is
+  port(
+    clk        : in std_logic;
+    reset      : in std_logic;
+    IR_start  : in std_logic;
+    IR_bx_in : in std_logic_vector(2 downto 0);
+    VMR_bx_out : out std_logic_vector(2 downto 0);
+    VMR_bx_out_vld : out std_logic;
+    VMR_done   : out std_logic;
+    IR_bx_out : out std_logic_vector(2 downto 0);
+    IR_bx_out_vld : out std_logic;
+    IR_done   : out std_logic;
+    DL_39_link_AV_dout       : in t_arr_DL_39_DATA;
+    DL_39_link_empty_neg     : in t_arr_DL_39_1b;
+    DL_39_link_read          : out t_arr_DL_39_1b;
+    IL_36_mem_A_wea        : out t_arr_IL_36_1b;
+    IL_36_mem_AV_writeaddr : out t_arr_IL_36_ADDR;
+    IL_36_mem_AV_din       : out t_arr_IL_36_DATA;
+    AS_36_mem_A_enb          : in t_arr_AS_36_1b;
+    AS_36_mem_AV_readaddr    : in t_arr_AS_36_ADDR;
+    AS_36_mem_AV_dout        : out t_arr_AS_36_DATA;
+    VMSME_16_mem_A_enb          : in t_arr_VMSME_16_1b;
+    VMSME_16_mem_AV_readaddr    : in t_arr_VMSME_16_ADDR;
+    VMSME_16_mem_AV_dout        : out t_arr_VMSME_16_DATA;
+    VMSME_16_mem_AAAV_dout_nent : out t_arr_VMSME_16_NENT;
+    VMSTE_16_mem_A_enb          : in t_arr_VMSTE_16_1b;
+    VMSTE_16_mem_AV_readaddr    : in t_arr_VMSTE_16_ADDR;
+    VMSTE_16_mem_AV_dout        : out t_arr_VMSTE_16_DATA;
+    VMSTE_16_mem_AAAV_dout_nent : out t_arr_VMSTE_16_NENT;
+    VMSTE_22_mem_A_enb          : in t_arr_VMSTE_22_1b;
+    VMSTE_22_mem_AV_readaddr    : in t_arr_VMSTE_22_ADDR;
+    VMSTE_22_mem_AV_dout        : out t_arr_VMSTE_22_DATA;
+    VMSTE_22_mem_AAV_dout_nent  : out t_arr_VMSTE_22_NENT
+  );
+end SectorProcessorFull;
+
+architecture rtl of SectorProcessorFull is
+
+  signal IL_36_mem_A_enb          : t_arr_IL_36_1b;
+  signal IL_36_mem_AV_readaddr    : t_arr_IL_36_ADDR;
+  signal IL_36_mem_AV_dout        : t_arr_IL_36_DATA;
+  signal IL_36_mem_AAV_dout_nent  : t_arr_IL_36_NENT; -- (#page)
+  signal AS_36_mem_A_wea          : t_arr_AS_36_1b;
+  signal AS_36_mem_AV_writeaddr   : t_arr_AS_36_ADDR;
+  signal AS_36_mem_AV_din         : t_arr_AS_36_DATA;
+  signal VMSME_16_mem_A_wea          : t_arr_VMSME_16_1b;
+  signal VMSME_16_mem_AV_writeaddr   : t_arr_VMSME_16_ADDR;
+  signal VMSME_16_mem_AV_din         : t_arr_VMSME_16_DATA;
+  signal VMSTE_16_mem_A_wea          : t_arr_VMSTE_16_1b;
+  signal VMSTE_16_mem_AV_writeaddr   : t_arr_VMSTE_16_ADDR;
+  signal VMSTE_16_mem_AV_din         : t_arr_VMSTE_16_DATA;
+  signal VMSTE_22_mem_A_wea          : t_arr_VMSTE_22_1b;
+  signal VMSTE_22_mem_AV_writeaddr   : t_arr_VMSTE_22_ADDR;
+  signal VMSTE_22_mem_AV_din         : t_arr_VMSTE_22_DATA;
+  signal VMR_start : std_logic := '0';
+
+begin
+
+  IL_36_loop : for var in enum_IL_36 generate
+  begin
+
+    IL_36 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 36,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => IL_36_mem_A_wea(var),
+        addra     => IL_36_mem_AV_writeaddr(var),
+        dina      => IL_36_mem_AV_din(var),
+        clkb      => clk,
+        enb       => IL_36_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => IL_36_mem_AV_readaddr(var),
+        doutb     => IL_36_mem_AV_dout(var),
+        sync_nent => VMR_start,
+        nent_o    => IL_36_mem_AAV_dout_nent(var)
+      );
+
+  end generate IL_36_loop;
+
+
+  AS_36_loop : for var in enum_AS_36 generate
+  begin
+
+    AS_36 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 36,
+        NUM_PAGES       => 8,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => AS_36_mem_A_wea(var),
+        addra     => AS_36_mem_AV_writeaddr(var),
+        dina      => AS_36_mem_AV_din(var),
+        clkb      => clk,
+        enb       => AS_36_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => AS_36_mem_AV_readaddr(var),
+        doutb     => AS_36_mem_AV_dout(var),
+        sync_nent => VMR_done,
+        nent_o    => open
+      );
+
+  end generate AS_36_loop;
+
+
+  VMSME_16_loop : for var in enum_VMSME_16 generate
+  begin
+
+    VMSME_16 : entity work.tf_mem_bin
+      generic map (
+        RAM_WIDTH       => 16,
+        NUM_PAGES       => 8,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => VMSME_16_mem_A_wea(var),
+        addra     => VMSME_16_mem_AV_writeaddr(var),
+        dina      => VMSME_16_mem_AV_din(var),
+        clkb      => clk,
+        enb       => VMSME_16_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => VMSME_16_mem_AV_readaddr(var),
+        doutb     => VMSME_16_mem_AV_dout(var),
+        sync_nent => VMR_done,
+        nent_o    => VMSME_16_mem_AAAV_dout_nent(var)
+      );
+
+  end generate VMSME_16_loop;
+
+
+  VMSTE_16_loop : for var in enum_VMSTE_16 generate
+  begin
+
+    VMSTE_16 : entity work.tf_mem_bin
+      generic map (
+        RAM_WIDTH       => 16,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => VMSTE_16_mem_A_wea(var),
+        addra     => VMSTE_16_mem_AV_writeaddr(var),
+        dina      => VMSTE_16_mem_AV_din(var),
+        clkb      => clk,
+        enb       => VMSTE_16_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => VMSTE_16_mem_AV_readaddr(var),
+        doutb     => VMSTE_16_mem_AV_dout(var),
+        sync_nent => VMR_done,
+        nent_o    => VMSTE_16_mem_AAAV_dout_nent(var)
+      );
+
+  end generate VMSTE_16_loop;
+
+
+  VMSTE_22_loop : for var in enum_VMSTE_22 generate
+  begin
+
+    VMSTE_22 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 22,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => VMSTE_22_mem_A_wea(var),
+        addra     => VMSTE_22_mem_AV_writeaddr(var),
+        dina      => VMSTE_22_mem_AV_din(var),
+        clkb      => clk,
+        enb       => VMSTE_22_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => VMSTE_22_mem_AV_readaddr(var),
+        doutb     => VMSTE_22_mem_AV_dout(var),
+        sync_nent => VMR_done,
+        nent_o    => VMSTE_22_mem_AAV_dout_nent(var)
+      );
+
+  end generate VMSTE_22_loop;
+
+
+  VMR_start <= '1' when IR_done = '1';
+
+  IR_PS10G_3_A : entity work.IR_PS10G_3_A
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => IR_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => IR_done,
+      bx_V          => IR_bx_in,
+      bx_o_V        => IR_bx_out,
+      bx_o_V_ap_vld => IR_bx_out_vld,
+      hInputStubs_V_dout       => DL_39_link_AV_dout(PS10G_3_A),
+      hInputStubs_V_empty_n  => DL_39_link_empty_neg(PS10G_3_A),
+      hInputStubs_V_read        => DL_39_link_read(PS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_ce0       => open,
+      hOutputStubs_0_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIA_PS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIA_PS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIA_PS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_ce0       => open,
+      hOutputStubs_1_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIB_PS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIB_PS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIB_PS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_ce0       => open,
+      hOutputStubs_2_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIC_PS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIC_PS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIC_PS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_ce0       => open,
+      hOutputStubs_3_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIA_PS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIA_PS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIA_PS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_ce0       => open,
+      hOutputStubs_4_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIB_PS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIB_PS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIB_PS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_ce0       => open,
+      hOutputStubs_5_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIC_PS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIC_PS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIC_PS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_ce0       => open,
+      hOutputStubs_6_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHID_PS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHID_PS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHID_PS10G_3_A),
+      hLinkWord_V => "01000000000001000101",
+      hPhBnWord_V => "000000011010"
+  );
+
+  IR_negPS10G_3_A : entity work.IR_negPS10G_3_A
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => IR_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => IR_bx_in,
+      hInputStubs_V_dout       => DL_39_link_AV_dout(negPS10G_3_A),
+      hInputStubs_V_empty_n  => DL_39_link_empty_neg(negPS10G_3_A),
+      hInputStubs_V_read        => DL_39_link_read(negPS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_ce0       => open,
+      hOutputStubs_0_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIA_negPS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIA_negPS10G_3_A),
+      hOutputStubs_0_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIA_negPS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_ce0       => open,
+      hOutputStubs_1_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIB_negPS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIB_negPS10G_3_A),
+      hOutputStubs_1_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIB_negPS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_ce0       => open,
+      hOutputStubs_2_dataarray_data_V_we0       => IL_36_mem_A_wea(L2PHIC_negPS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(L2PHIC_negPS10G_3_A),
+      hOutputStubs_2_dataarray_data_V_d0        => IL_36_mem_AV_din(L2PHIC_negPS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_ce0       => open,
+      hOutputStubs_3_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIA_negPS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIA_negPS10G_3_A),
+      hOutputStubs_3_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIA_negPS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_ce0       => open,
+      hOutputStubs_4_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIB_negPS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIB_negPS10G_3_A),
+      hOutputStubs_4_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIB_negPS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_ce0       => open,
+      hOutputStubs_5_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHIC_negPS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHIC_negPS10G_3_A),
+      hOutputStubs_5_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHIC_negPS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_ce0       => open,
+      hOutputStubs_6_dataarray_data_V_we0       => IL_36_mem_A_wea(D2PHID_negPS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_address0  => IL_36_mem_AV_writeaddr(D2PHID_negPS10G_3_A),
+      hOutputStubs_6_dataarray_data_V_d0        => IL_36_mem_AV_din(D2PHID_negPS10G_3_A),
+      hLinkWord_V => "01000000000001000101",
+      hPhBnWord_V => "000000011010"
+  );
+
+  VMR_L2PHIA : entity work.VMR_L2PHIA
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => VMR_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => VMR_done,
+      bx_V          => IR_bx_out,
+      bx_o_V        => VMR_bx_out,
+      bx_o_V_ap_vld => VMR_bx_out_vld,
+      inputStubs_0_dataarray_data_V_ce0       => IL_36_mem_A_enb(L2PHIA_PS10G_3_A),
+      inputStubs_0_dataarray_data_V_address0  => IL_36_mem_AV_readaddr(L2PHIA_PS10G_3_A),
+      inputStubs_0_dataarray_data_V_q0        => IL_36_mem_AV_dout(L2PHIA_PS10G_3_A),
+      inputStubs_0_nentries_0_V               => IL_36_mem_AAV_dout_nent(L2PHIA_PS10G_3_A)(0),
+      inputStubs_0_nentries_1_V               => IL_36_mem_AAV_dout_nent(L2PHIA_PS10G_3_A)(1),
+      inputStubs_1_dataarray_data_V_ce0       => IL_36_mem_A_enb(L2PHIA_negPS10G_3_A),
+      inputStubs_1_dataarray_data_V_address0  => IL_36_mem_AV_readaddr(L2PHIA_negPS10G_3_A),
+      inputStubs_1_dataarray_data_V_q0        => IL_36_mem_AV_dout(L2PHIA_negPS10G_3_A),
+      inputStubs_1_nentries_0_V               => IL_36_mem_AAV_dout_nent(L2PHIA_negPS10G_3_A)(0),
+      inputStubs_1_nentries_1_V               => IL_36_mem_AAV_dout_nent(L2PHIA_negPS10G_3_A)(1),
+      memoriesAS_0_dataarray_data_V_ce0       => open,
+      memoriesAS_0_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn1),
+      memoriesAS_0_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn1),
+      memoriesAS_0_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn1),
+      memoriesAS_1_dataarray_data_V_ce0       => open,
+      memoriesAS_1_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn2),
+      memoriesAS_1_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn2),
+      memoriesAS_1_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn2),
+      memoriesAS_2_dataarray_data_V_ce0       => open,
+      memoriesAS_2_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn3),
+      memoriesAS_2_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn3),
+      memoriesAS_2_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn3),
+      memoriesAS_3_dataarray_data_V_ce0       => open,
+      memoriesAS_3_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn4),
+      memoriesAS_3_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn4),
+      memoriesAS_3_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn4),
+      memoriesAS_4_dataarray_data_V_ce0       => open,
+      memoriesAS_4_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn5),
+      memoriesAS_4_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn5),
+      memoriesAS_4_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn5),
+      memoriesAS_5_dataarray_data_V_ce0       => open,
+      memoriesAS_5_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn6),
+      memoriesAS_5_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn6),
+      memoriesAS_5_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn6),
+      memoriesAS_6_dataarray_data_V_ce0       => open,
+      memoriesAS_6_dataarray_data_V_we0       => AS_36_mem_A_wea(L2PHIAn7),
+      memoriesAS_6_dataarray_data_V_address0  => AS_36_mem_AV_writeaddr(L2PHIAn7),
+      memoriesAS_6_dataarray_data_V_d0        => AS_36_mem_AV_din(L2PHIAn7),
+      memoriesME_0_dataarray_data_V_ce0       => open,
+      memoriesME_0_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA1n1),
+      memoriesME_0_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA1n1),
+      memoriesME_0_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA1n1),
+      memoriesME_1_dataarray_data_V_ce0       => open,
+      memoriesME_1_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA2n1),
+      memoriesME_1_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA2n1),
+      memoriesME_1_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA2n1),
+      memoriesME_2_dataarray_data_V_ce0       => open,
+      memoriesME_2_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA3n1),
+      memoriesME_2_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA3n1),
+      memoriesME_2_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA3n1),
+      memoriesME_3_dataarray_data_V_ce0       => open,
+      memoriesME_3_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA4n1),
+      memoriesME_3_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA4n1),
+      memoriesME_3_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA4n1),
+      memoriesME_4_dataarray_data_V_ce0       => open,
+      memoriesME_4_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA5n1),
+      memoriesME_4_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA5n1),
+      memoriesME_4_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA5n1),
+      memoriesME_5_dataarray_data_V_ce0       => open,
+      memoriesME_5_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA6n1),
+      memoriesME_5_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA6n1),
+      memoriesME_5_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA6n1),
+      memoriesME_6_dataarray_data_V_ce0       => open,
+      memoriesME_6_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA7n1),
+      memoriesME_6_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA7n1),
+      memoriesME_6_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA7n1),
+      memoriesME_7_dataarray_data_V_ce0       => open,
+      memoriesME_7_dataarray_data_V_we0       => VMSME_16_mem_A_wea(L2PHIA8n1),
+      memoriesME_7_dataarray_data_V_address0  => VMSME_16_mem_AV_writeaddr(L2PHIA8n1),
+      memoriesME_7_dataarray_data_V_d0        => VMSME_16_mem_AV_din(L2PHIA8n1),
+      memoriesTEI_0_0_dataarray_data_V_ce0       => open,
+      memoriesTEI_0_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII1n1),
+      memoriesTEI_0_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII1n1),
+      memoriesTEI_0_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII1n1),
+      memoriesTEI_0_1_dataarray_data_V_ce0       => open,
+      memoriesTEI_0_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII1n2),
+      memoriesTEI_0_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII1n2),
+      memoriesTEI_0_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII1n2),
+      memoriesTEI_1_0_dataarray_data_V_ce0       => open,
+      memoriesTEI_1_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII2n1),
+      memoriesTEI_1_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII2n1),
+      memoriesTEI_1_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII2n1),
+      memoriesTEI_1_1_dataarray_data_V_ce0       => open,
+      memoriesTEI_1_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII2n2),
+      memoriesTEI_1_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII2n2),
+      memoriesTEI_1_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII2n2),
+      memoriesTEI_1_2_dataarray_data_V_ce0       => open,
+      memoriesTEI_1_2_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII2n3),
+      memoriesTEI_1_2_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII2n3),
+      memoriesTEI_1_2_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII2n3),
+      memoriesTEI_2_0_dataarray_data_V_ce0       => open,
+      memoriesTEI_2_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII3n1),
+      memoriesTEI_2_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII3n1),
+      memoriesTEI_2_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII3n1),
+      memoriesTEI_2_1_dataarray_data_V_ce0       => open,
+      memoriesTEI_2_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII3n2),
+      memoriesTEI_2_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII3n2),
+      memoriesTEI_2_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII3n2),
+      memoriesTEI_2_2_dataarray_data_V_ce0       => open,
+      memoriesTEI_2_2_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII3n3),
+      memoriesTEI_2_2_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII3n3),
+      memoriesTEI_2_2_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII3n3),
+      memoriesTEI_3_0_dataarray_data_V_ce0       => open,
+      memoriesTEI_3_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII4n1),
+      memoriesTEI_3_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII4n1),
+      memoriesTEI_3_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII4n1),
+      memoriesTEI_3_1_dataarray_data_V_ce0       => open,
+      memoriesTEI_3_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII4n2),
+      memoriesTEI_3_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII4n2),
+      memoriesTEI_3_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII4n2),
+      memoriesTEI_3_2_dataarray_data_V_ce0       => open,
+      memoriesTEI_3_2_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHII4n3),
+      memoriesTEI_3_2_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHII4n3),
+      memoriesTEI_3_2_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHII4n3),
+      memoriesOL_0_0_dataarray_data_V_ce0       => open,
+      memoriesOL_0_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX1n5),
+      memoriesOL_0_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX1n5),
+      memoriesOL_0_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX1n5),
+      memoriesOL_0_1_dataarray_data_V_ce0       => open,
+      memoriesOL_0_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX1n6),
+      memoriesOL_0_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX1n6),
+      memoriesOL_0_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX1n6),
+      memoriesOL_0_2_dataarray_data_V_ce0       => open,
+      memoriesOL_0_2_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX1n7),
+      memoriesOL_0_2_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX1n7),
+      memoriesOL_0_2_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX1n7),
+      memoriesOL_1_0_dataarray_data_V_ce0       => open,
+      memoriesOL_1_0_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX2n5),
+      memoriesOL_1_0_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX2n5),
+      memoriesOL_1_0_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX2n5),
+      memoriesOL_1_1_dataarray_data_V_ce0       => open,
+      memoriesOL_1_1_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX2n6),
+      memoriesOL_1_1_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX2n6),
+      memoriesOL_1_1_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX2n6),
+      memoriesOL_1_2_dataarray_data_V_ce0       => open,
+      memoriesOL_1_2_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX2n7),
+      memoriesOL_1_2_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX2n7),
+      memoriesOL_1_2_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX2n7),
+      memoriesOL_1_3_dataarray_data_V_ce0       => open,
+      memoriesOL_1_3_dataarray_data_V_we0       => VMSTE_22_mem_A_wea(L2PHIX2n8),
+      memoriesOL_1_3_dataarray_data_V_address0  => VMSTE_22_mem_AV_writeaddr(L2PHIX2n8),
+      memoriesOL_1_3_dataarray_data_V_d0        => VMSTE_22_mem_AV_din(L2PHIX2n8),
+      memoriesTEO_0_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_0_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA1n1),
+      memoriesTEO_0_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA1n1),
+      memoriesTEO_0_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA1n1),
+      memoriesTEO_0_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_0_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA1n2),
+      memoriesTEO_0_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA1n2),
+      memoriesTEO_0_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA1n2),
+      memoriesTEO_0_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_0_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA1n3),
+      memoriesTEO_0_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA1n3),
+      memoriesTEO_0_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA1n3),
+      memoriesTEO_1_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_1_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA2n1),
+      memoriesTEO_1_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA2n1),
+      memoriesTEO_1_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA2n1),
+      memoriesTEO_1_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_1_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA2n2),
+      memoriesTEO_1_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA2n2),
+      memoriesTEO_1_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA2n2),
+      memoriesTEO_1_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_1_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA2n3),
+      memoriesTEO_1_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA2n3),
+      memoriesTEO_1_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA2n3),
+      memoriesTEO_1_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_1_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA2n4),
+      memoriesTEO_1_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA2n4),
+      memoriesTEO_1_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA2n4),
+      memoriesTEO_2_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_2_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA3n1),
+      memoriesTEO_2_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA3n1),
+      memoriesTEO_2_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA3n1),
+      memoriesTEO_2_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_2_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA3n2),
+      memoriesTEO_2_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA3n2),
+      memoriesTEO_2_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA3n2),
+      memoriesTEO_2_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_2_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA3n3),
+      memoriesTEO_2_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA3n3),
+      memoriesTEO_2_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA3n3),
+      memoriesTEO_2_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_2_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA3n4),
+      memoriesTEO_2_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA3n4),
+      memoriesTEO_2_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA3n4),
+      memoriesTEO_2_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_2_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA3n5),
+      memoriesTEO_2_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA3n5),
+      memoriesTEO_2_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA3n5),
+      memoriesTEO_3_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_3_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA4n1),
+      memoriesTEO_3_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA4n1),
+      memoriesTEO_3_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA4n1),
+      memoriesTEO_3_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_3_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA4n2),
+      memoriesTEO_3_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA4n2),
+      memoriesTEO_3_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA4n2),
+      memoriesTEO_3_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_3_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA4n3),
+      memoriesTEO_3_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA4n3),
+      memoriesTEO_3_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA4n3),
+      memoriesTEO_3_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_3_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA4n4),
+      memoriesTEO_3_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA4n4),
+      memoriesTEO_3_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA4n4),
+      memoriesTEO_3_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_3_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA4n5),
+      memoriesTEO_3_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA4n5),
+      memoriesTEO_3_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA4n5),
+      memoriesTEO_4_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_4_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA5n1),
+      memoriesTEO_4_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA5n1),
+      memoriesTEO_4_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA5n1),
+      memoriesTEO_4_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_4_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA5n2),
+      memoriesTEO_4_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA5n2),
+      memoriesTEO_4_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA5n2),
+      memoriesTEO_4_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_4_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA5n3),
+      memoriesTEO_4_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA5n3),
+      memoriesTEO_4_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA5n3),
+      memoriesTEO_4_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_4_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA5n4),
+      memoriesTEO_4_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA5n4),
+      memoriesTEO_4_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA5n4),
+      memoriesTEO_4_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_4_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA5n5),
+      memoriesTEO_4_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA5n5),
+      memoriesTEO_4_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA5n5),
+      memoriesTEO_5_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_5_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA6n1),
+      memoriesTEO_5_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA6n1),
+      memoriesTEO_5_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA6n1),
+      memoriesTEO_5_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_5_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA6n2),
+      memoriesTEO_5_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA6n2),
+      memoriesTEO_5_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA6n2),
+      memoriesTEO_5_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_5_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA6n3),
+      memoriesTEO_5_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA6n3),
+      memoriesTEO_5_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA6n3),
+      memoriesTEO_5_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_5_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA6n4),
+      memoriesTEO_5_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA6n4),
+      memoriesTEO_5_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA6n4),
+      memoriesTEO_5_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_5_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA6n5),
+      memoriesTEO_5_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA6n5),
+      memoriesTEO_5_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA6n5),
+      memoriesTEO_6_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_6_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA7n1),
+      memoriesTEO_6_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA7n1),
+      memoriesTEO_6_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA7n1),
+      memoriesTEO_6_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_6_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA7n2),
+      memoriesTEO_6_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA7n2),
+      memoriesTEO_6_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA7n2),
+      memoriesTEO_6_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_6_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA7n3),
+      memoriesTEO_6_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA7n3),
+      memoriesTEO_6_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA7n3),
+      memoriesTEO_6_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_6_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA7n4),
+      memoriesTEO_6_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA7n4),
+      memoriesTEO_6_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA7n4),
+      memoriesTEO_6_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_6_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA7n5),
+      memoriesTEO_6_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA7n5),
+      memoriesTEO_6_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA7n5),
+      memoriesTEO_7_0_dataarray_data_V_ce0       => open,
+      memoriesTEO_7_0_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA8n1),
+      memoriesTEO_7_0_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA8n1),
+      memoriesTEO_7_0_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA8n1),
+      memoriesTEO_7_1_dataarray_data_V_ce0       => open,
+      memoriesTEO_7_1_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA8n2),
+      memoriesTEO_7_1_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA8n2),
+      memoriesTEO_7_1_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA8n2),
+      memoriesTEO_7_2_dataarray_data_V_ce0       => open,
+      memoriesTEO_7_2_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA8n3),
+      memoriesTEO_7_2_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA8n3),
+      memoriesTEO_7_2_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA8n3),
+      memoriesTEO_7_3_dataarray_data_V_ce0       => open,
+      memoriesTEO_7_3_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA8n4),
+      memoriesTEO_7_3_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA8n4),
+      memoriesTEO_7_3_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA8n4),
+      memoriesTEO_7_4_dataarray_data_V_ce0       => open,
+      memoriesTEO_7_4_dataarray_data_V_we0       => VMSTE_16_mem_A_wea(L2PHIA8n5),
+      memoriesTEO_7_4_dataarray_data_V_address0  => VMSTE_16_mem_AV_writeaddr(L2PHIA8n5),
+      memoriesTEO_7_4_dataarray_data_V_d0        => VMSTE_16_mem_AV_din(L2PHIA8n5)
+  );
+
+
+
+end rtl;

--- a/IntegrationTests/IRVMR/hdl/memUtil_pkg.vhd
+++ b/IntegrationTests/IRVMR/hdl/memUtil_pkg.vhd
@@ -1,0 +1,43 @@
+--! Standard libraries
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+--! User packages
+use work.tf_pkg.all;
+
+package memUtil_pkg is
+
+  type enum_DL_39 is (PS10G_3_A,negPS10G_3_A);
+
+  type enum_IL_36 is (L2PHIB_PS10G_3_A,L2PHIC_PS10G_3_A,D2PHIA_PS10G_3_A,D2PHIB_PS10G_3_A,D2PHIC_PS10G_3_A,D2PHID_PS10G_3_A,L2PHIB_negPS10G_3_A,L2PHIC_negPS10G_3_A,D2PHIA_negPS10G_3_A,D2PHIB_negPS10G_3_A,D2PHIC_negPS10G_3_A,D2PHID_negPS10G_3_A,L2PHIA_PS10G_3_A,L2PHIA_negPS10G_3_A);
+
+  type enum_AS_36 is (L2PHIAn1,L2PHIAn2,L2PHIAn3,L2PHIAn4,L2PHIAn5,L2PHIAn6,L2PHIAn7);
+
+  type enum_VMSME_16 is (L2PHIA1n1,L2PHIA2n1,L2PHIA3n1,L2PHIA4n1,L2PHIA5n1,L2PHIA6n1,L2PHIA7n1,L2PHIA8n1);
+
+  type enum_VMSTE_16 is (L2PHIA1n1,L2PHIA1n2,L2PHIA1n3,L2PHIA2n1,L2PHIA2n2,L2PHIA2n3,L2PHIA2n4,L2PHIA3n1,L2PHIA3n2,L2PHIA3n3,L2PHIA3n4,L2PHIA3n5,L2PHIA4n1,L2PHIA4n2,L2PHIA4n3,L2PHIA4n4,L2PHIA4n5,L2PHIA5n1,L2PHIA5n2,L2PHIA5n3,L2PHIA5n4,L2PHIA5n5,L2PHIA6n1,L2PHIA6n2,L2PHIA6n3,L2PHIA6n4,L2PHIA6n5,L2PHIA7n1,L2PHIA7n2,L2PHIA7n3,L2PHIA7n4,L2PHIA7n5,L2PHIA8n1,L2PHIA8n2,L2PHIA8n3,L2PHIA8n4,L2PHIA8n5);
+
+  type enum_VMSTE_22 is (L2PHII1n1,L2PHII1n2,L2PHII2n1,L2PHII2n2,L2PHII2n3,L2PHII3n1,L2PHII3n2,L2PHII3n3,L2PHII4n1,L2PHII4n2,L2PHII4n3,L2PHIX1n5,L2PHIX1n6,L2PHIX1n7,L2PHIX2n5,L2PHIX2n6,L2PHIX2n7,L2PHIX2n8);
+
+  type t_arr_DL_39_1b is array(enum_DL_39) of std_logic;
+  type t_arr_DL_39_DATA is array(enum_DL_39) of std_logic_vector(38 downto 0);
+  type t_arr_IL_36_1b is array(enum_IL_36) of std_logic;
+  type t_arr_IL_36_ADDR is array(enum_IL_36) of std_logic_vector(7 downto 0);
+  type t_arr_IL_36_DATA is array(enum_IL_36) of std_logic_vector(35 downto 0);
+  type t_arr_IL_36_NENT is array(enum_IL_36) of t_arr2_7b;
+  type t_arr_AS_36_1b is array(enum_AS_36) of std_logic;
+  type t_arr_AS_36_ADDR is array(enum_AS_36) of std_logic_vector(9 downto 0);
+  type t_arr_AS_36_DATA is array(enum_AS_36) of std_logic_vector(35 downto 0);
+  type t_arr_AS_36_NENT is array(enum_AS_36) of t_arr8_7b;
+  type t_arr_VMSME_16_1b is array(enum_VMSME_16) of std_logic;
+  type t_arr_VMSME_16_ADDR is array(enum_VMSME_16) of std_logic_vector(9 downto 0);
+  type t_arr_VMSME_16_DATA is array(enum_VMSME_16) of std_logic_vector(15 downto 0);
+  type t_arr_VMSME_16_NENT is array(enum_VMSME_16) of t_arr8_8_5b;
+  type t_arr_VMSTE_16_1b is array(enum_VMSTE_16) of std_logic;
+  type t_arr_VMSTE_16_ADDR is array(enum_VMSTE_16) of std_logic_vector(7 downto 0);
+  type t_arr_VMSTE_16_DATA is array(enum_VMSTE_16) of std_logic_vector(15 downto 0);
+  type t_arr_VMSTE_16_NENT is array(enum_VMSTE_16) of t_arr2_8_5b;
+  type t_arr_VMSTE_22_1b is array(enum_VMSTE_22) of std_logic;
+  type t_arr_VMSTE_22_ADDR is array(enum_VMSTE_22) of std_logic_vector(7 downto 0);
+  type t_arr_VMSTE_22_DATA is array(enum_VMSTE_22) of std_logic_vector(21 downto 0);
+  type t_arr_VMSTE_22_NENT is array(enum_VMSTE_22) of t_arr2_7b;
+end package memUtil_pkg;

--- a/IntegrationTests/IRVMR/script/compileHLS.sh
+++ b/IntegrationTests/IRVMR/script/compileHLS.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Create HLS IP for IR & VMR.
+# Run this in IntegrationTests/xyz/script/ 
+
+pushd ../../../project
+
+vivado_hls -f script_IR.tcl
+vivado_hls -f script_VMR.tcl
+
+popd

--- a/IntegrationTests/IRVMR/script/makeProject.tcl
+++ b/IntegrationTests/IRVMR/script/makeProject.tcl
@@ -38,9 +38,6 @@ set_property xsim.simulate.runtime -value "50us" -objects  [get_filesets sim_1]
 
 update_compile_order -fileset sources_1 
 
-# set mode to out_of_context as the VMR has too many input/output ports
-set_property -name {STEPS.SYNTH_DESIGN.ARGS.MORE OPTIONS} -value {-mode out_of_context} -objects [get_runs synth_1]
-
 puts "INFO: Project created: ${projName}"
 
 exit

--- a/IntegrationTests/IRVMR/script/makeProject.tcl
+++ b/IntegrationTests/IRVMR/script/makeProject.tcl
@@ -30,6 +30,9 @@ add_files -fileset sources_1 [glob ../../common/hdl/*.vhd]
 # Add HDL for TB
 #add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]
 
+# Add constraints (clock etc.)
+add_files -fileset constrs_1 [glob ../../common/hdl/constraints.xdc]
+
 # Set 'sim_1' fileset properties
 set_property file_type {VHDL 2008} [get_files -filter {FILE_TYPE == VHDL}]
 set_property top -value ${topLevelHDL} -objects [get_filesets sources_1]

--- a/IntegrationTests/IRVMR/script/makeProject.tcl
+++ b/IntegrationTests/IRVMR/script/makeProject.tcl
@@ -1,0 +1,46 @@
+# Create Vivado project, with user HDL files & IP.
+# Run this in IntegrationTests/xyz/script/ 
+
+# Create project
+set projName "Work"
+set FPGA "xcvu7p-flvb2104-1-e"
+create_project -force ${projName} ./${projName} -part $FPGA
+set_property target_language VHDL [current_project]
+
+# Rebuild user HLS IP repos index before adding any source files
+set_property ip_repo_paths "../../../project/"  [get_filesets sources_1]
+update_ip_catalog -rebuild
+
+# Create .xci files for user HLS IP
+# Chain contains two IRs and one VMR
+# Note: currently uses the same IP core for the two IRs. OK for this minimal example but probably not in general.
+create_ip -name InputRouterTop -module_name IR_PS10G_3_A -vendor xilinx.com -library hls -version 1.0
+create_ip -name InputRouterTop -module_name IR_negPS10G_3_A -vendor xilinx.com -library hls -version 1.0
+create_ip -name VMRouterTop -module_name VMR_L2PHIA -vendor xilinx.com -library hls -version 1.0
+
+# Provide name of top-level HDL (without .vhd extension).
+#set topLevelHDL "SectorProcessor"
+set topLevelHDL "SectorProcessorFull"
+
+# Add HDL for algo
+add_files -fileset sources_1 [glob ../hdl/SectorProcessor*.vhd]
+add_files -fileset sources_1 [glob ../hdl/memUtil_pkg.vhd]
+add_files -fileset sources_1 [glob ../../common/hdl/*.vhd]
+
+# Add HDL for TB
+#add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]
+
+# Set 'sim_1' fileset properties
+set_property file_type {VHDL 2008} [get_files -filter {FILE_TYPE == VHDL}]
+set_property top -value ${topLevelHDL} -objects [get_filesets sources_1]
+#set_property top -value "tb_tf_top" -objects [get_filesets sim_1]
+set_property xsim.simulate.runtime -value "50us" -objects  [get_filesets sim_1]
+
+update_compile_order -fileset sources_1 
+
+# set mode to out_of_context as the VMR has too many input/output ports
+set_property -name {STEPS.SYNTH_DESIGN.ARGS.MORE OPTIONS} -value {-mode out_of_context} -objects [get_runs synth_1]
+
+puts "INFO: Project created: ${projName}"
+
+exit

--- a/IntegrationTests/common/hdl/tf_mem.vhd
+++ b/IntegrationTests/common/hdl/tf_mem.vhd
@@ -104,6 +104,9 @@ attribute ram_style of sa_RAM_data : signal is "block";
 
 begin
 
+-- Check user didn't change values of derived generics.
+assert (RAM_DEPTH  = NUM_PAGES*PAGE_LENGTH) report "User changed RAM_DEPTH" severity FAILURE;
+
 process(clka)
   variable vi_clk_cnt   : integer := -1; -- Clock counter
   variable vi_page_cnt  : integer := 0;  -- Page counter

--- a/IntegrationTests/common/hdl/tf_mem_bin.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_bin.vhd
@@ -33,7 +33,7 @@ entity tf_mem_bin is
     NUM_PAGES       : natural := 2;                --! Specify no. Pages in RAM memory
     RAM_DEPTH       : natural := NUM_PAGES*PAGE_LENGTH; --! Leave at default. RAM depth (no. of entries)
     NUM_MEM_BINS    : natural := 8;                --! Specify number of memory bins
-    NUM_ENTRIES_PER_MEM_BINS : natural := 16;      --! Specify number of entries per memory bin
+    NUM_ENTRIES_PER_MEM_BINS : natural := PAGE_LENGTH/NUM_MEM_BINS; --! Leave at default. Number of entries per memory bin
     INIT_FILE       : string := "";                --! Specify name/location of RAM initialization file if using one (leave blank if not)
     INIT_HEX        : boolean := true;             --! Read init file in hex (default) or bin
     RAM_PERFORMANCE : string := "HIGH_PERFORMANCE" --! Select "HIGH_PERFORMANCE" (2 clk latency) or "LOW_LATENCY" (1 clk latency)

--- a/IntegrationTests/common/hdl/tf_mem_bin.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_bin.vhd
@@ -105,6 +105,10 @@ attribute ram_style of sa_RAM_data : signal is "block";
 
 begin
 
+-- Check user didn't change values of derived generics.
+assert (RAM_DEPTH  = NUM_PAGES*PAGE_LENGTH) report "User changed RAM_DEPTH" severity FAILURE;
+assert (NUM_ENTRIES_PER_MEM_BINS = PAGE_LENGTH/NUM_MEM_BINS) report "User changed NUM_ENTRIES_PER_MEM_BINS" severity FAILURE;
+
 process(clka)
   variable vi_clk_cnt   : integer := -1; -- Clock counter
   variable vi_page_cnt  : integer := 0;  -- Page counter

--- a/IntegrationTests/common/hdl/tf_mem_bin.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_bin.vhd
@@ -32,6 +32,8 @@ entity tf_mem_bin is
     RAM_WIDTH       : natural := 14;               --! Specify RAM data width
     NUM_PAGES       : natural := 2;                --! Specify no. Pages in RAM memory
     RAM_DEPTH       : natural := NUM_PAGES*PAGE_LENGTH; --! Leave at default. RAM depth (no. of entries)
+    NUM_MEM_BINS    : natural := 8;                --! Specify number of memory bins
+    NUM_ENTRIES_PER_MEM_BINS : natural := 16;      --! Specify number of entries per memory bin
     INIT_FILE       : string := "";                --! Specify name/location of RAM initialization file if using one (leave blank if not)
     INIT_HEX        : boolean := true;             --! Read init file in hex (default) or bin
     RAM_PERFORMANCE : string := "HIGH_PERFORMANCE" --! Select "HIGH_PERFORMANCE" (2 clk latency) or "LOW_LATENCY" (1 clk latency)
@@ -130,7 +132,7 @@ begin
     if (wea='1') then
       sa_RAM_data(to_integer(unsigned(addra))) <= dina; -- Write data
       -- Count entries
-      vi_nent_idx := to_integer(shift_right(unsigned(addra), clogb2(N_ENTRIES_PER_MEM_BINS))) mod N_MEM_BINS; -- Calculate bin index
+      vi_nent_idx := to_integer(shift_right(unsigned(addra), clogb2(NUM_ENTRIES_PER_MEM_BINS))) mod NUM_MEM_BINS; -- Calculate bin index
       --if DEBUG=true then write(v_line_out, string'("vi_nent_idx: ")); write(v_line_out, vi_nent_idx); writeline(output, v_line_out); end if;
 
       page := to_integer(unsigned(addra(clogb2(RAM_DEPTH)-1 downto clogb2(PAGE_LENGTH))));

--- a/IntegrationTests/common/hdl/tf_pkg.vhd
+++ b/IntegrationTests/common/hdl/tf_pkg.vhd
@@ -110,11 +110,6 @@ package tf_pkg is
     data_arr      : out   t_arr_2d_slv(0 to MAX_EVENTS-1,0 to PAGE_LENGTH-1); --! Dataarray with read values
     n_entries_arr : inout t_arr_2d_int(0 to MAX_EVENTS-1,0 to N_MEM_BINS-1)     --! Number of entries per event
   );
-  procedure read_emData_bin_me_disk (
-    file_path     : in    string;  --! File path as string
-    data_arr      : out   t_arr_2d_slv(0 to MAX_EVENTS-1,0 to PAGE_LENGTH-1); --! Dataarray with read values
-    n_entries_arr : inout t_arr_2d_int(0 to MAX_EVENTS-1,0 to N_MEM_BINS_ME_DISK-1)     --! Number of entries per event
-  );
   procedure write_header_line (
     file_path       : in string;  --! File path as string
     signal_name     : in string;  --! Signal name that will be printed in output file
@@ -318,61 +313,6 @@ package body tf_pkg is
     end loop l_rd_row;
     file_close(file_in);
   end read_emData_bin;
-
-  -- read_emData_bin function for ME disks
-  procedure read_emData_bin_me_disk (
-    file_path     : in    string;  --! File path as string
-    data_arr      : out   t_arr_2d_slv(0 to MAX_EVENTS-1,0 to PAGE_LENGTH-1); --! Dataarray with read values
-    n_entries_arr : inout t_arr_2d_int(0 to MAX_EVENTS-1,0 to N_MEM_BINS_ME_DISK-1)     --! Number of entries per event per bin
-  ) is
-  constant N_X_CHAR        : integer :=1;                        --! Count of 'x' characters before actual value to read
-  file     file_in         : text open READ_MODE is file_path;   -- Text - a file of character strings
-  variable line_in         : line;                               -- Line - one string from a text file
-  variable bx_cnt          : integer;                            -- BX counter
-  variable i_bx_row        : integer;                            -- Read row index
-  variable i_rd_col        : integer;                            -- Read column index
-  variable cnt_x_char      : integer;                            -- Count of 'x' characters
-  variable char            : character;                          -- Character
-  variable mem_bin         : integer;                            -- Bin number of memory
-  variable n_entry_mem_bin : integer;                            -- Entry number of memory bin
-  begin
-    data_arr      := (others => (others => (others => '0'))); -- Init
-    n_entries_arr := (others => (others => 0));               -- Init
-    bx_cnt        := -1;                                      -- Init
-    l_rd_row : while not endfile(file_in) loop -- Read until EoF
-    --l_rd_row : for i in 0 to 5 loop -- Debug
-      readline (file_in, line_in);
-      if (line_in.all(1 to 2) = "BX" or line_in.all = "") then -- Identify event header line or empty line
-        i_bx_row := 0;       -- Init
-        bx_cnt   := bx_cnt +1;
-        --if DEBUG=true then writeline(output, line_in); end if;
-      elsif (bx_cnt >= 0) then
-        i_rd_col := 0;   -- Init
-        cnt_x_char := 0; -- Init
-        l_rd_col : while line_in'length>0 loop  -- Loop over the columns
-          read(line_in, char);                  -- Read chars ...
-            if (i_rd_col=0) then
-              char2int(char, mem_bin);
-            end if;
-            if (i_rd_col=2) then
-              char2int(char, n_entry_mem_bin);
-            end if;
-            if (char='x') then                   -- ... until the next x
-              cnt_x_char := cnt_x_char +1;
-              if (cnt_x_char >= N_X_CHAR) then -- Number of 'x' chars reached
-                hread(line_in, data_arr(bx_cnt,mem_bin*N_ENTRIES_PER_MEM_BINS_ME_DISK+n_entry_mem_bin)(line_in'length*4-1 downto 0)); -- Read value as hex slv (line_in'length in hex)
-              end if;
-              n_entries_arr(bx_cnt,mem_bin) := n_entries_arr(bx_cnt,mem_bin) +1;
-            end if;
-        i_rd_col := i_rd_col +1;
-        end loop l_rd_col;
-        i_bx_row := i_bx_row +1;
-      else
-        assert false report "No BX header before data in txt file" severity FAILURE;
-      end if;
-    end loop l_rd_row;
-    file_close(file_in);
-  end read_emData_bin_me_disk;
 
   --! @brief TextIO procedure to write emData for non-binned memories one line per clock cycle
   procedure write_header_line (

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This would create a project directory \<project> ("projrouter" in case of the ab
 3) vivado -mode batch -source makeProject.tcl (creates Vivado project).
 4) vivado -mode batch -source runSim.tcl (runs Vivado simulation,
    which writes data output from chain to dataOut/*.txt).
-5) python ../../common/script/CompareMemPrintsFW.py -p -s (compares .txt files in emData and dataOut/ writing comparison to dataOut/*_cmp.txt).
+5) python ../../common/script/CompareMemPrintsFW.py -p -s (compares .txt files in emData and dataOut/ writing comparison to dataOut/*_cmp.txt. Uses Python 3.).
 6) vivado -mode batch -source ../../common/script/synth.tcl (runs synthesis, writes utilization & timing reports to current directory).
 7) vivado -mode batch -source ../../common/script/impl.tcl (runs implementation, writes utilization & timing reports to current directory). N.B. This step is optional, and not required for code validation.
 

--- a/TestBenches/InputRouter_test.cpp
+++ b/TestBenches/InputRouter_test.cpp
@@ -189,6 +189,13 @@ std::string getDTCName( int pLinkId
 {
   auto cDtcMap = getCablingMap( pInputFile_Wires );
   auto cMapIter = *std::next(cDtcMap.begin(), pLinkId);
+
+  for(auto cMapItem : cDtcMap)
+  {
+    //auto cLyrs = cMapItem.second;
+    std::cout << "DTC " << cMapItem.first << endl;
+  }
+
   return cMapIter.first;
 }
 
@@ -403,7 +410,7 @@ void prepareInputStreams( ifstream * pInputStreams
 int main(int argc, char * argv[])
 {
   // default values for test bench 
-  int cLinkId = 6; 
+  int cLinkId = 8; 
   int cDTCsplit=0;
   int cNonant=4;
   // if cmd line args are passed 

--- a/TestBenches/InputRouter_test.cpp
+++ b/TestBenches/InputRouter_test.cpp
@@ -189,13 +189,6 @@ std::string getDTCName( int pLinkId
 {
   auto cDtcMap = getCablingMap( pInputFile_Wires );
   auto cMapIter = *std::next(cDtcMap.begin(), pLinkId);
-
-  for(auto cMapItem : cDtcMap)
-  {
-    //auto cLyrs = cMapItem.second;
-    std::cout << "DTC " << cMapItem.first << endl;
-  }
-
   return cMapIter.first;
 }
 

--- a/TestBenches/VMRouterCM_test.cpp
+++ b/TestBenches/VMRouterCM_test.cpp
@@ -74,7 +74,7 @@ int main() {
   static AllStubMemory<outputType> memoriesAS[numASCopies];
   static AllStubInnerMemory<outputType> memoriesASInner[numASInnerCopies];
   static VMStubMEMemoryCM<outputType, rzSizeME, phiRegSize, kNMatchEngines> memoryME;
-  static VMStubTEOuterMemoryCM<outputType,rzSizeTE,phiRegSize,numTEOCopies> memoryTEO;
+  static VMStubTEOuterMemoryCM<outputType, rzSizeTE, phiRegSize, kNTEUnits> memoriesTEO[numTEOCopies];
 
 
   ///////////////////////////
@@ -97,7 +97,10 @@ int main() {
     }
     memoryME.clear();
     if (nVMSTE) {
-      memoryTEO.clear();
+      for (int i=0; i<nVMSTE; ++i) {
+        memoriesTEO[i].clear();
+      }
+
     }
     
     // Read event and write to memories
@@ -123,7 +126,7 @@ int main() {
 #endif
         , &memoryME
 #if kLAYER == 2 || kLAYER == 3 || kLAYER == 4 || kLAYER == 6 || kDISK == 1 || kDISK == 2 || kDISK == 4
-        , &memoryTEO
+        , memoriesTEO
 #endif
       );
 
@@ -145,7 +148,9 @@ int main() {
     err += compareBinnedMemCMWithFile<VMStubMEMemoryCM<outputType, rzSizeME, phiRegSize, kNMatchEngines>>(memoryME, fout_vmstubme[0], ievt, "VMStubME", truncation);  
     //TE Outer memories
     if (nVMSTE) {
-      err += compareBinnedMemCMWithFile<VMStubTEOuterMemoryCM<outputType, rzSizeTE, phiRegSize, numTEOCopies>>(memoryTEO, fout_vmstubte[0], ievt, "VMStubTEOuter", truncation);
+      for (unsigned int i = 0; i < numTEOCopies; i++) {
+        err += compareBinnedMemCMWithFile<VMStubTEOuterMemoryCM<outputType, rzSizeTE, phiRegSize, kNTEUnits>>(memoriesTEO[i], fout_vmstubte[i], ievt, "VMStubTEOuter", truncation);
+      }
     }
   } // End of event loop
 

--- a/TrackletAlgorithm/DTCStubMemory.h
+++ b/TrackletAlgorithm/DTCStubMemory.h
@@ -55,6 +55,6 @@ private:
 };
 
 // Memory definition
-using DTCStubMemory = MemoryTemplate<DTCStub, 3, kNBits_MemAddr>;
+using DTCStubMemory = MemoryTemplate<DTCStub, 1, kNBits_MemAddr>;
 
 #endif

--- a/TrackletAlgorithm/InputRouter.h
+++ b/TrackletAlgorithm/InputRouter.h
@@ -226,8 +226,9 @@ void InputRouter( const BXType bx
 	
 	#pragma HLS inline
 	#pragma HLS interface register port = bx_o
-  
-  	ap_uint<1> hIs2S= hLinkWord.range(kLINKMAPwidth-4,kLINKMAPwidth-4);
+	#pragma HLS array_partition variable = hOutputStubs complete
+
+		ap_uint<1> hIs2S= hLinkWord.range(kLINKMAPwidth-4,kLINKMAPwidth-4);
 
 	// count memories 
 	unsigned int nMems=0;

--- a/TrackletAlgorithm/InputRouter.h
+++ b/TrackletAlgorithm/InputRouter.h
@@ -228,7 +228,7 @@ void InputRouter( const BXType bx
 	#pragma HLS interface register port = bx_o
 	#pragma HLS array_partition variable = hOutputStubs complete
 
-		ap_uint<1> hIs2S= hLinkWord.range(kLINKMAPwidth-4,kLINKMAPwidth-4);
+	ap_uint<1> hIs2S= hLinkWord.range(kLINKMAPwidth-4,kLINKMAPwidth-4);
 
 	// count memories 
 	unsigned int nMems=0;

--- a/TrackletAlgorithm/InputRouterTop.h
+++ b/TrackletAlgorithm/InputRouterTop.h
@@ -7,11 +7,11 @@
 // at the moment I'm changing this for each link 
 // is that really the only way to do this? 
 
-// only for PS10G_1_A for now 
+// only for PS10G_3_A for now 
 // other cases to be added 
 // when I have final link map
 //constexpr unsigned int cTest = (const)(std::atoi(getenv ("TEST")));
-constexpr unsigned int cNMemories = 17; 
+constexpr unsigned int cNMemories = 7;
 
 void InputRouterTop( const BXType bx
 	, const ap_uint<kLINKMAPwidth> kInputLink // input link LUT 

--- a/TrackletAlgorithm/VMRouterCM.h
+++ b/TrackletAlgorithm/VMRouterCM.h
@@ -182,13 +182,14 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 		// ME memories
 		VMStubMEMemoryCM<OutType, rzSizeME, phiRegSize, kNMatchEngines> *memoryME,
 		// TE Outer memories
-		VMStubTEOuterMemoryCM<OutType, rzSizeTE, phiRegSize, nTEOCopies> *memoryTEO) {
+		VMStubTEOuterMemoryCM<OutType, rzSizeTE, phiRegSize, kNTEUnits> memoriesTEO[nTEOCopies]) {
 
 #pragma HLS inline
 #pragma HLS array_partition variable=inputStubs complete dim=1
 #pragma HLS array_partition variable=inputStubsDisk2S complete dim=1
 #pragma HLS array_partition variable=memoriesAS complete dim=1
 #pragma HLS array_partition variable=memoriesASInner complete dim=1
+#pragma HLS array_partition variable=memoriesTEO complete dim=1
 
 	// Number of data in each input memory
 	typename InputStubMemory<InType>::NEntryT nInputs[nInputMems
@@ -410,8 +411,11 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 					createVMStub<VMStubTEOuter<OutType>, InType, OutType, Layer, Disk, false>(stub, i, negDisk, METable, phiCorrTable, slotTE) :
 					createVMStub<VMStubTEOuter<OutType>, InType, OutType, Layer, Disk, false>(stub, i, negDisk, TEDiskTable, phiCorrTable, slotTE);
 
-			// Write the TE Outer stub if bin isn't negative
-			memoryTEO->write_mem(bx, slotTE, stubTEO, addrCountTE[slotTE]);
+			// Write stub to all TE memory copies
+			for (int n = 0; n < nTEOCopies; n++) {
+#pragma HLS UNROLL
+				memoriesTEO[n].write_mem(bx, slotTE, stubTEO, addrCountTE[slotTE]);
+			}
 			addrCountTE[slotTE] += 1;
 
 // For debugging

--- a/TrackletAlgorithm/VMRouterCMTop.cc
+++ b/TrackletAlgorithm/VMRouterCMTop.cc
@@ -24,7 +24,7 @@ void VMRouterCMTop(const BXType bx, BXType& bx_o
 #endif
 	, VMStubMEMemoryCM<outputType, rzSizeME, phiRegSize, kNMatchEngines> *memoryME
 #if kLAYER == 2 || kLAYER == 3 || kLAYER == 4 || kLAYER == 6 || kDISK == 1 || kDISK == 2 || kDISK == 4
-	, VMStubTEOuterMemoryCM<outputType,rzSizeTE,phiRegSize,numTEOCopies> *memoryTEO
+	, VMStubTEOuterMemoryCM<outputType, rzSizeTE, phiRegSize, kNTEUnits> memoriesTEO[numTEOCopies]
 #endif
 	) {
 
@@ -152,7 +152,7 @@ void VMRouterCMTop(const BXType bx, BXType& bx_o
 
 		// TEOuter memories
 #if kLAYER == 2 || kLAYER == 3 || kLAYER == 4 || kLAYER == 6 || kDISK == 1 || kDISK == 2 || kDISK == 4
-		memoryTEO
+		memoriesTEO
 #else
 		nullptr
 #endif

--- a/TrackletAlgorithm/VMRouterCMTop.h
+++ b/TrackletAlgorithm/VMRouterCMTop.h
@@ -84,7 +84,7 @@ void VMRouterCMTop(const BXType bx, BXType& bx_o
 #endif
 	, VMStubMEMemoryCM<outputType, rzSizeME, phiRegSize, kNMatchEngines> *memoryME
 #if kLAYER == 2 || kLAYER == 3 || kLAYER == 4 || kLAYER == 6 || kDISK == 1 || kDISK == 2 || kDISK == 4
-	, VMStubTEOuterMemoryCM<outputType,rzSizeTE,phiRegSize,numTEOCopies> *memoryTEO
+	, VMStubTEOuterMemoryCM<outputType, rzSizeTE, phiRegSize, kNTEUnits> memoriesTEO[numTEOCopies]
 #endif
 	);
 

--- a/project/script_IR.tcl
+++ b/project/script_IR.tcl
@@ -27,10 +27,10 @@ create_clock -period 240MHz -name slow_clock
 create_clock -period 360MHz -name fast_clock
 
 set nProc [exec nproc]
-csim_design -mflags "-j$nProc" -argv "--link,6 --dtcSplit,0 --tkNonant,4"
+csim_design -mflags "-j$nProc" -argv "--link,8 --dtcSplit,0 --tkNonant,4"
 csynth_design 
-# possible options -trace_level all -rtl verilog -verbose 
-cosim_design  -argv "--link,6 --dtcSplit,0 --tkNonant,4"
-# possible options  -flow syn, -flow impl
+# # possible options -trace_level all -rtl verilog -verbose 
+cosim_design  -argv "--link,8 --dtcSplit,0 --tkNonant,4"
+# # possible options  -flow syn, -flow impl
 export_design -format ip_catalog 
 exit

--- a/project/script_IR.tcl
+++ b/project/script_IR.tcl
@@ -29,8 +29,8 @@ create_clock -period 360MHz -name fast_clock
 set nProc [exec nproc]
 csim_design -mflags "-j$nProc" -argv "--link,8 --dtcSplit,0 --tkNonant,4"
 csynth_design 
-# # possible options -trace_level all -rtl verilog -verbose 
+# possible options -trace_level all -rtl verilog -verbose 
 cosim_design  -argv "--link,8 --dtcSplit,0 --tkNonant,4"
-# # possible options  -flow syn, -flow impl
+# possible options  -flow syn, -flow impl
 export_design -format ip_catalog 
 exit

--- a/project/script_VMRCM.tcl
+++ b/project/script_VMRCM.tcl
@@ -21,7 +21,6 @@ open_solution "solution1"
 source settings_hls.tcl
 
 # data files
-add_files -tb ../emData/VMRCM/tables/
 add_files -tb ../emData/VMRCM/
 
 csim_design -mflags "-j8"


### PR DESCRIPTION
Added files for the simplest IR-VMR chain generated by the project generation script using the wiring downloaded from #151. Some minor edits to the IR and VMR to make it compatible with the generated top-level. It synthesises and implements in Vivado, although no testbench yet.

Changed the binned memories so they can handle different bin numbers (the ME disks uses more bins than the other binned memories).

I sneaked in a tiny bug fix for the the VMRCM as well... 