### PR TITLE
Future CMSSW changes for compilation with CMSSW_11_3

### DIFF
--- a/TrackletAlgorithm/AllStubMemory.h
+++ b/TrackletAlgorithm/AllStubMemory.h
@@ -187,20 +187,17 @@ public:
   }
 
   std::string getBitStr() {
-
-   std::string str = decodeToBits(getR(),AllStubBase<ASType>::kASRSize);
-   str += "|"+decodeToBits(getZ(),AllStubBase<ASType>::kASZSize);
-   str += "|"+decodeToBits(getPhi(),AllStubBase<ASType>::kASPhiSize);
-   // Different get method for DISKPS?  Where is it?     
-   //     str += "|"+decodeToBits(getAlpha(),AllStubBase<ASType>::kASAlphaSize);
-   str += "|"+decodeToBits(getBend(),AllStubBase<ASType>::kASBendSize);
-   return str;
+    std::string str = decodeToBits(getR(),AllStubBase<ASType>::kASRSize);
+    str += "|"+decodeToBits(getZ(),AllStubBase<ASType>::kASZSize);
+    str += "|"+decodeToBits(getPhi(),AllStubBase<ASType>::kASPhiSize);
+    // Different get method for DISKPS?  Where is it?     
+    //     str += "|"+decodeToBits(getAlpha(),AllStubBase<ASType>::kASAlphaSize);
+    str += "|"+decodeToBits(getBend(),AllStubBase<ASType>::kASBendSize);
+    return str;
   }
 
   // TO DO: This belongs in some sort of helper class.
-  std::string decodeToBits(unsigned int field, unsigned int size) const
-  {
-
+  std::string decodeToBits(unsigned int field, unsigned int size) const {
     unsigned int valtmp = field;
     std::string str = "";
     for(unsigned int i=0; i< size; i++) {

--- a/TrackletAlgorithm/AllStubMemory.h
+++ b/TrackletAlgorithm/AllStubMemory.h
@@ -186,6 +186,30 @@ public:
     data_.range(kASBendMSB,kASBendLSB) = bend;
   }
 
+  std::string getBitStr() {
+
+   std::string str = decodeToBits(getR(),AllStubBase<ASType>::kASRSize);
+   str += "|"+decodeToBits(getZ(),AllStubBase<ASType>::kASZSize);
+   str += "|"+decodeToBits(getPhi(),AllStubBase<ASType>::kASPhiSize);
+   // Different get method for DISKPS?  Where is it?     
+   //     str += "|"+decodeToBits(getAlpha(),AllStubBase<ASType>::kASAlphaSize);
+   str += "|"+decodeToBits(getBend(),AllStubBase<ASType>::kASBendSize);
+   return str;
+  }
+
+  // TO DO: This belongs in some sort of helper class.
+  std::string decodeToBits(unsigned int field, unsigned int size) const
+  {
+
+    unsigned int valtmp = field;
+    std::string str = "";
+    for(unsigned int i=0; i< size; i++) {
+      str = ((valtmp & 1) ? "1" : "0") + str;
+      valtmp >>= 1;
+    }
+    return str;
+  }
+
 private:
 
   AllStubData data_;

--- a/TrackletAlgorithm/Constants.h
+++ b/TrackletAlgorithm/Constants.h
@@ -3,6 +3,11 @@
 
 #include "ap_int.h"
 
+#ifdef CMSSW_GIT_HAS
+  #include "Settings.h"
+  using namespace trklet;
+#endif
+
 // Inline function to convert floating point values to integers, given a
 // digitization constant. The 1.0e-1 is a fudge factor needed to get the
 // floating point truncation to agree exactly with the emulation.
@@ -60,8 +65,10 @@ constexpr int TEBinsBits = 3;
 constexpr double c = 0.299792458; // m/ns
 
 // detector constants
-constexpr int N_LAYER = 6; // # of barrel layers assumed
-constexpr int N_DISK = 5; // # of endcap disks assumed
+#ifndef CMSSW_GIT_HASH
+  constexpr int N_LAYER = 6; // # of barrel layers assumed
+  constexpr int N_DISK = 5; // # of endcap disks assumed
+#endif
 constexpr double bfield = 3.8112; // T
 constexpr int rmean[N_LAYER + N_DISK] = { 851, 1269, 1784, 2347, 2936, 3697,   -1,   -1,   -1,   -1,   -1 }; // valid for layers
 constexpr int zmean[N_LAYER + N_DISK] = {  -1,   -1,   -1,   -1,   -1,   -1, 2239, 2645, 3163, 3782, 4523 }; // valid for disks

--- a/TrackletAlgorithm/FullMatchMemory.h
+++ b/TrackletAlgorithm/FullMatchMemory.h
@@ -247,19 +247,16 @@ public:
   }
 
   std::string getBitStr() {
-
-     std::string str = decodeToBits(getTCID(),FullMatchBase<FMType>::kFMTCIDSize);
-     str += "|"+decodeToBits(getTrackletIndex(),FullMatchBase<FMType>::kFMTrackletIndexSize);
-     str += "|"+decodeToBits(getStubIndex(),FullMatchBase<FMType>::kFMStubIndexSize);
-     str += "|"+decodeToBits(getPhiRes(),FullMatchBase<FMType>::kFMPhiResSize);
-     str += "|"+decodeToBits(getZRes(),FullMatchBase<FMType>::kFMZResSize);
-     return str;
+    std::string str = decodeToBits(getTCID(),FullMatchBase<FMType>::kFMTCIDSize);
+    str += "|"+decodeToBits(getTrackletIndex(),FullMatchBase<FMType>::kFMTrackletIndexSize);
+    str += "|"+decodeToBits(getStubIndex(),FullMatchBase<FMType>::kFMStubIndexSize);
+    str += "|"+decodeToBits(getPhiRes(),FullMatchBase<FMType>::kFMPhiResSize);
+    str += "|"+decodeToBits(getZRes(),FullMatchBase<FMType>::kFMZResSize);
+    return str;
   }
 
   // TO DO: This belongs in some sort of helper class.
-  std::string decodeToBits(unsigned int field, unsigned int size) const
-  {
-
+  std::string decodeToBits(unsigned int field, unsigned int size) const {
     unsigned int valtmp = field;
     std::string str = "";
     for(unsigned int i=0; i< size; i++) {

--- a/TrackletAlgorithm/FullMatchMemory.h
+++ b/TrackletAlgorithm/FullMatchMemory.h
@@ -246,6 +246,29 @@ public:
     data_.range(kFMZResMSB,kFMZResLSB) = zres;
   }
 
+  std::string getBitStr() {
+
+     std::string str = decodeToBits(getTCID(),FullMatchBase<FMType>::kFMTCIDSize);
+     str += "|"+decodeToBits(getTrackletIndex(),FullMatchBase<FMType>::kFMTrackletIndexSize);
+     str += "|"+decodeToBits(getStubIndex(),FullMatchBase<FMType>::kFMStubIndexSize);
+     str += "|"+decodeToBits(getPhiRes(),FullMatchBase<FMType>::kFMPhiResSize);
+     str += "|"+decodeToBits(getZRes(),FullMatchBase<FMType>::kFMZResSize);
+     return str;
+  }
+
+  // TO DO: This belongs in some sort of helper class.
+  std::string decodeToBits(unsigned int field, unsigned int size) const
+  {
+
+    unsigned int valtmp = field;
+    std::string str = "";
+    for(unsigned int i=0; i< size; i++) {
+      str = ((valtmp & 1) ? "1" : "0") + str;
+      valtmp >>= 1;
+    }
+    return str;
+  }
+
 private:
 
   FullMatchData data_;

--- a/TrackletAlgorithm/MatchEngine.h
+++ b/TrackletAlgorithm/MatchEngine.h
@@ -8,7 +8,9 @@
 #include "CandidateMatchMemory.h"
 
 // HLS Headers
-#include "hls_math.h"
+#ifndef CMSSW_GIT_HASH
+  #include "hls_math.h"
+#endif
 
 // STL Headers
 #include <iostream>

--- a/TrackletAlgorithm/MatchEngine.h
+++ b/TrackletAlgorithm/MatchEngine.h
@@ -8,7 +8,7 @@
 #include "CandidateMatchMemory.h"
 
 // HLS Headers
-#ifndef CMSSW_GIT_HASH
+#if __has_include
   #include "hls_math.h"
 #endif
 

--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -10,7 +10,11 @@
 #include "AllStubMemory.h"
 #include "AllProjectionMemory.h"
 #include "FullMatchMemory.h"
-#include "hls_math.h"
+
+#ifndef CMSSW_GIT_HASH
+  #include "hls_math.h"
+#endif
+
 #include <iostream>
 #include <fstream>
 #include <bitset>

--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -11,7 +11,7 @@
 #include "AllProjectionMemory.h"
 #include "FullMatchMemory.h"
 
-#ifndef CMSSW_GIT_HASH
+#if __has_include
   #include "hls_math.h"
 #endif
 

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -11,7 +11,11 @@
 #include "AllStubMemory.h"
 #include "FullMatchMemory.h"
 #include "MatchEngineUnit.h"
-#include "hls_math.h"
+
+#ifndef CMSSW_GIT_HASH
+  #include "hls_math.h"
+#endif
+
 #include <iostream>
 #include <fstream>
 #include <bitset>
@@ -517,7 +521,7 @@ void MatchProcessor(BXType bx,
   //Initialize table for bend-rinv consistency
   ap_uint<1> table[kNMatchEngines][(LAYER<TF::L4)?256:512]; //FIXME Need to figure out how to replace 256 with meaningful const.
 #pragma HLS ARRAY_PARTITION variable=table dim=0 complete
-  readtable: for(int iMEU = 0; iMEU < kNMatchEngines; ++iMEU) {
+  readtable: for(unsigned int iMEU = 0; iMEU < kNMatchEngines; ++iMEU) {
 #pragma HLS unroll
     readTable<LAYER>(table[iMEU]); 
   } 
@@ -598,7 +602,7 @@ void MatchProcessor(BXType bx,
      nvmstubs[izbin][3],nvmstubs[izbin][2],nvmstubs[izbin][1],nvmstubs[izbin][0]) = instubdata.getEntries8(bx, izbin);
   }
 
- PROC_LOOP: for (int istep = 0; istep < kMaxProc-LoopItersCut; ++istep) {
+ PROC_LOOP: for (unsigned int istep = 0; istep < kMaxProc-LoopItersCut; ++istep) {
 #pragma HLS PIPELINE II=1 //rewind
 
     auto readptr = projbufferarray.getReadPtr();
@@ -619,7 +623,7 @@ void MatchProcessor(BXType bx,
 
     bool anyidle = false;
 
-  MEU_get_trkids: for(int iMEU = 0; iMEU < kNMatchEngines; ++iMEU) {
+  MEU_get_trkids: for(unsigned int iMEU = 0; iMEU < kNMatchEngines; ++iMEU) {
 #pragma HLS unroll      
       matchengine[iMEU].set_empty();
       idles[iMEU] = matchengine[iMEU].idle();
@@ -631,9 +635,9 @@ void MatchProcessor(BXType bx,
     
     ap_uint<kNMatchEngines> smallest = ~emptys;
 #pragma HLS ARRAY_PARTITION variable=trkids complete dim=0
-  MEU_smallest1: for(int iMEU1 = 0; iMEU1 < kNMatchEngines-1; ++iMEU1) {
+  MEU_smallest1: for(unsigned int iMEU1 = 0; iMEU1 < kNMatchEngines-1; ++iMEU1) {
 #pragma HLS unroll
-  MEU_smallest2: for(int iMEU2 = iMEU1+1; iMEU2 < kNMatchEngines; ++iMEU2) {
+  MEU_smallest2: for(unsigned int iMEU2 = iMEU1+1; iMEU2 < kNMatchEngines; ++iMEU2) {
 #pragma HLS unroll
 	smallest[iMEU1] = smallest[iMEU1] & (trkids[iMEU1]<trkids[iMEU2]);
         smallest[iMEU2] = smallest[iMEU2] & (trkids[iMEU2]<trkids[iMEU1]);

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -12,7 +12,7 @@
 #include "FullMatchMemory.h"
 #include "MatchEngineUnit.h"
 
-#ifndef CMSSW_GIT_HASH
+#if __has_include
   #include "hls_math.h"
 #endif
 

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -130,7 +130,7 @@ public:
 
   void print_mem(BunchXingT bx) const
   {
-	for (int i = 0; i <  nentries_[bx]; ++i) {
+	for (unsigned int i = 0; i <  nentries_[bx]; ++i) {
 	  std::cout << bx << " " << i << " ";
 	  print_entry(bx,i);
 	}
@@ -138,8 +138,8 @@ public:
 
   void print_mem() const
   {
-	for (int ibx = 0; ibx < (1<<NBIT_BX); ++ibx) {
-	  for (int i = 0; i < nentries_[ibx]; ++i) {
+	for (unsigned int ibx = 0; ibx < (1<<NBIT_BX); ++ibx) {
+	  for (unsigned int i = 0; i < nentries_[ibx]; ++i) {
 		std::cout << ibx << " " << i << " ";
 		print_entry(ibx,i);
 	  }
@@ -147,7 +147,15 @@ public:
   }
 
   static constexpr int getWidth() {return DataType::getWidth();}
-  
+ 
+  std::string name_;
+  void setName(std::string name) { name_ = name;}
+  std::string const& getName() const { return name_;}
+
+  unsigned int iSector_;
+  void setSector(unsigned int iS) { iSector_ = iS;}
+  unsigned int getSector() const { return iSector_;}
+ 
 #endif
 
 };

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -149,8 +149,8 @@ public:
 
   void print_mem(BunchXingT bx) const
   {
-	for(int slot=0;slot<(kNSlots);slot++) {
-	  for (int i = 0; i < nentries_[bx][slot]; ++i) {
+	for(unsigned int slot=0;slot<(kNSlots);slot++) {
+	  for (unsigned int i = 0; i < nentries_[bx][slot]; ++i) {
 		std::cout << bx << " " << i << " ";
 		print_entry(bx, i + slot*(1<<(kNBitDataAddr)) );
  	  }
@@ -159,8 +159,8 @@ public:
 
   void print_mem() const
   {
-	for (int ibx = 0; ibx < (kNBxBins); ++ibx) {
-	  for (int i = 0; i < nentries_[ibx]; ++i) {
+	for (unsigned int ibx = 0; ibx < (kNBxBins); ++ibx) {
+	  for (unsigned int i = 0; i < nentries_[ibx]; ++i) {
 		std::cout << ibx << " " << i << " ";
 		print_entry(ibx,i);
 	  }
@@ -168,6 +168,14 @@ public:
   }
 
   static constexpr int getWidth() {return DataType::getWidth();}
+
+  std::string name_;
+  void setName(std::string name) { name_ = name;}
+  std::string const& getName() const { return name_;}
+
+  unsigned int iSector_;
+  void setSector(unsigned int iS) { iSector_ = iS;}
+  unsigned int getSector() const { return iSector_;}
   
 #endif
   

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -139,8 +139,8 @@ class MemoryTemplateBinnedCM{
     DataType data("0",16);
     for (size_t ibx=0; ibx<(kNBxBins); ++ibx) {
       // Clear data
-      for (int i = 0; i < getNBins(); ++i ) {
-        for (int j = 0; j < getNEntryPerBin(); ++j) {
+      for (unsigned int i = 0; i < getNBins(); ++i ) {
+        for (unsigned int j = 0; j < getNEntryPerBin(); ++j) {
           write_mem(ibx, i, data, j);
         }
       }
@@ -206,10 +206,10 @@ class MemoryTemplateBinnedCM{
 
   void print_mem(BunchXingT bx) const
   {
-	for(int slot=0;slot<8;slot++) {
+	for(unsigned int slot=0;slot<8;slot++) {
       //std::cout << "slot "<<slot<<" entries "
       //		<<nentries_[bx%NBX].range((slot+1)*4-1,slot*4)<<endl;
-      for (int i = 0; i < nentries8_[bx][slot]; ++i) {
+      for (unsigned int i = 0; i < nentries8_[bx][slot]; ++i) {
 		std::cout << bx << " " << i << " ";
 		print_entry(bx, i + slot*getNEntryPerBin() );
       }
@@ -218,8 +218,8 @@ class MemoryTemplateBinnedCM{
 
   void print_mem() const
   {
-	for (int ibx = 0; ibx < kNBxBins; ++ibx) {
-	  for (int i = 0; i < 8; ++i) {
+	for (unsigned int ibx = 0; ibx < kNBxBins; ++ibx) {
+	  for (unsigned int i = 0; i < 8; ++i) {
 		std::cout << ibx << " " << i << " ";
 		print_entry(ibx,i);
 	  }
@@ -227,6 +227,14 @@ class MemoryTemplateBinnedCM{
   }
 
   static constexpr int getWidth() {return DataType::getWidth();}
+
+  std::string name_;
+  void setName(std::string name) { name_ = name;}
+  std::string const& getName() const { return name_;}
+
+  unsigned int iSector_;
+  void setSector(unsigned int iS) { iSector_ = iS;}
+  unsigned int getSector() const { return iSector_;}
   
 #endif
   

--- a/TrackletAlgorithm/TrackletEngine.h
+++ b/TrackletAlgorithm/TrackletEngine.h
@@ -5,7 +5,10 @@
 #include "VMStubTEOuterMemory.h"
 #include "StubPairMemory.h"
 
-#include "hls_math.h"
+#if __has_include
+  #include "hls_math.h"
+#endif
+
 #include <string>
 
 class CandMatch;

--- a/TrackletAlgorithm/TrackletProjectionMemory.h
+++ b/TrackletAlgorithm/TrackletProjectionMemory.h
@@ -214,20 +214,17 @@ public:
   }
 
   std::string getBitStr() {
-
-     std::string str = decodeToBits(getTCID(),TrackletProjectionBase<TProjType>::kTProjTCIDSize);
-     str += "|"+decodeToBits(getTrackletIndex(),TrackletProjectionBase<TProjType>::kTProjTrackletIndexSize);
-     str += "|"+decodeToBits(getPhi(),TrackletProjectionBase<TProjType>::kTProjPhiSize);
-     str += "|"+decodeToBits(getRZ(),TrackletProjectionBase<TProjType>::kTProjRZSize);
-     str += "|"+decodeToBits(getPhiDer(),TrackletProjectionBase<TProjType>::kTProjPhiDSize);
-     str += "|"+decodeToBits(getRZDer(),TrackletProjectionBase<TProjType>::kTProjRZDSize);
-     return str;
+    std::string str = decodeToBits(getTCID(),TrackletProjectionBase<TProjType>::kTProjTCIDSize);
+    str += "|"+decodeToBits(getTrackletIndex(),TrackletProjectionBase<TProjType>::kTProjTrackletIndexSize);
+    str += "|"+decodeToBits(getPhi(),TrackletProjectionBase<TProjType>::kTProjPhiSize);
+    str += "|"+decodeToBits(getRZ(),TrackletProjectionBase<TProjType>::kTProjRZSize);
+    str += "|"+decodeToBits(getPhiDer(),TrackletProjectionBase<TProjType>::kTProjPhiDSize);
+    str += "|"+decodeToBits(getRZDer(),TrackletProjectionBase<TProjType>::kTProjRZDSize);
+    return str;
   }
 
   // TO DO: This belongs in some sort of helper class.
-  std::string decodeToBits(unsigned int field, unsigned int size) const
-  {
-
+  std::string decodeToBits(unsigned int field, unsigned int size) const {
     unsigned int valtmp = field;
     std::string str = "";
     for(unsigned int i=0; i< size; i++) {

--- a/TrackletAlgorithm/TrackletProjectionMemory.h
+++ b/TrackletAlgorithm/TrackletProjectionMemory.h
@@ -212,6 +212,30 @@ public:
   void setRZDer(const TProjRZDER zder) {
     data_.range(kTProjRZDMSB,kTProjRZDLSB) = zder;
   }
+
+  std::string getBitStr() {
+
+     std::string str = decodeToBits(getTCID(),TrackletProjectionBase<TProjType>::kTProjTCIDSize);
+     str += "|"+decodeToBits(getTrackletIndex(),TrackletProjectionBase<TProjType>::kTProjTrackletIndexSize);
+     str += "|"+decodeToBits(getPhi(),TrackletProjectionBase<TProjType>::kTProjPhiSize);
+     str += "|"+decodeToBits(getRZ(),TrackletProjectionBase<TProjType>::kTProjRZSize);
+     str += "|"+decodeToBits(getPhiDer(),TrackletProjectionBase<TProjType>::kTProjPhiDSize);
+     str += "|"+decodeToBits(getRZDer(),TrackletProjectionBase<TProjType>::kTProjRZDSize);
+     return str;
+  }
+
+  // TO DO: This belongs in some sort of helper class.
+  std::string decodeToBits(unsigned int field, unsigned int size) const
+  {
+
+    unsigned int valtmp = field;
+    std::string str = "";
+    for(unsigned int i=0; i< size; i++) {
+      str = ((valtmp & 1) ? "1" : "0") + str;
+      valtmp >>= 1;
+    }
+    return str;
+  }
   
 private:
   

--- a/TrackletAlgorithm/VMStubMEMemory.h
+++ b/TrackletAlgorithm/VMStubMEMemory.h
@@ -136,6 +136,27 @@ public:
     data_.range(kVMSMEFineZMSB,kVMSMEFineZLSB) = finez;
   }
 
+  std::string getBitStr()
+  {
+     std::string str = decodeToBits(getIndex(),VMStubMEBase<VMSMEType>::kVMSMEIndexSize);
+     str += "|"+decodeToBits(getBend(),VMStubMEBase<VMSMEType>::kVMSMEBendSize);
+     str += "|"+decodeToBits(getFineZ(),VMStubMEBase<VMSMEType>::kVMSMEFineZSize);
+     return str;
+  }
+
+  // TO DO: This belongs in some sort of helper class.
+  std::string decodeToBits(unsigned int field, unsigned int size) const
+  {
+
+    unsigned int valtmp = field;
+    std::string str = "";
+    for(unsigned int i=0; i< size; i++) {
+      str = ((valtmp & 1) ? "1" : "0") + str;
+      valtmp >>= 1;
+    }
+    return str;
+  }
+
 private:
 
   VMStubMEData data_;

--- a/TrackletAlgorithm/VMStubMEMemory.h
+++ b/TrackletAlgorithm/VMStubMEMemory.h
@@ -136,18 +136,15 @@ public:
     data_.range(kVMSMEFineZMSB,kVMSMEFineZLSB) = finez;
   }
 
-  std::string getBitStr()
-  {
-     std::string str = decodeToBits(getIndex(),VMStubMEBase<VMSMEType>::kVMSMEIndexSize);
-     str += "|"+decodeToBits(getBend(),VMStubMEBase<VMSMEType>::kVMSMEBendSize);
-     str += "|"+decodeToBits(getFineZ(),VMStubMEBase<VMSMEType>::kVMSMEFineZSize);
-     return str;
+  std::string getBitStr() {
+    std::string str = decodeToBits(getIndex(),VMStubMEBase<VMSMEType>::kVMSMEIndexSize);
+    str += "|"+decodeToBits(getBend(),VMStubMEBase<VMSMEType>::kVMSMEBendSize);
+    str += "|"+decodeToBits(getFineZ(),VMStubMEBase<VMSMEType>::kVMSMEFineZSize);
+    return str;
   }
 
   // TO DO: This belongs in some sort of helper class.
-  std::string decodeToBits(unsigned int field, unsigned int size) const
-  {
-
+  std::string decodeToBits(unsigned int field, unsigned int size) const {
     unsigned int valtmp = field;
     std::string str = "";
     for(unsigned int i=0; i< size; i++) {

--- a/TrackletAlgorithm/VMStubMEMemoryCM.h
+++ b/TrackletAlgorithm/VMStubMEMemoryCM.h
@@ -135,6 +135,27 @@ public:
     data_.range(kVMSMEFineZMSB,kVMSMEFineZLSB) = finez;
   }
 
+  std::string getBitStr()
+  {
+     std::string str = decodeToBits(getIndex(),VMStubMECMBase<VMSMEType>::kVMSMEIDSize);
+     str += "|"+decodeToBits(getBend(),VMStubMECMBase<VMSMEType>::kVMSMEBendSize);
+     str += "|"+decodeToBits(getFineZ(),VMStubMECMBase<VMSMEType>::kVMSMEFineZSize);
+     return str;
+  }
+
+  // TO DO: This belongs in some sort of helper class.
+  std::string decodeToBits(unsigned int field, unsigned int size) const
+  {
+
+    unsigned int valtmp = field;
+    std::string str = "";
+    for(unsigned int i=0; i< size; i++) {
+      str = ((valtmp & 1) ? "1" : "0") + str;
+      valtmp >>= 1;
+    }
+    return str;
+  }
+
 private:
 
   VMStubMECMData data_;

--- a/TrackletAlgorithm/VMStubMEMemoryCM.h
+++ b/TrackletAlgorithm/VMStubMEMemoryCM.h
@@ -135,18 +135,15 @@ public:
     data_.range(kVMSMEFineZMSB,kVMSMEFineZLSB) = finez;
   }
 
-  std::string getBitStr()
-  {
-     std::string str = decodeToBits(getIndex(),VMStubMECMBase<VMSMEType>::kVMSMEIDSize);
-     str += "|"+decodeToBits(getBend(),VMStubMECMBase<VMSMEType>::kVMSMEBendSize);
-     str += "|"+decodeToBits(getFineZ(),VMStubMECMBase<VMSMEType>::kVMSMEFineZSize);
-     return str;
+  std::string getBitStr() {
+    std::string str = decodeToBits(getIndex(),VMStubMECMBase<VMSMEType>::kVMSMEIDSize);
+    str += "|"+decodeToBits(getBend(),VMStubMECMBase<VMSMEType>::kVMSMEBendSize);
+    str += "|"+decodeToBits(getFineZ(),VMStubMECMBase<VMSMEType>::kVMSMEFineZSize);
+    return str;
   }
 
   // TO DO: This belongs in some sort of helper class.
-  std::string decodeToBits(unsigned int field, unsigned int size) const
-  {
-
+  std::string decodeToBits(unsigned int field, unsigned int size) const {
     unsigned int valtmp = field;
     std::string str = "";
     for(unsigned int i=0; i< size; i++) {


### PR DESCRIPTION
This pull request has the changes needed by the future CMSSW emulation to compile and run the match processor. The changes made are

1. getName() and getSector() functions are added to MemoryTemplate.h, MemoryTemplateBinned.h, and MemoryTemplateBinnedCM.h
2. The functions getBitStr() and decodeToBits() have been added to AllStubsMemory.h, FullMatchMemory.h, TrackletProjectionsMemory.h, and VMStubsMEMemoryCM.h in order to allow the emulation to write out the memories to file.
3. Ifndef statements have been added around #include hls_math.h in order to exclude them when in CMSSW
4. Ifndef statements are added to Constants.h to prevent redefining of N_LAYERS and N_DISKS
5. Changed ints to unsigned int in MatchProcessor.h, MemoryTemplate.h, MemoryTemplateBinned.h, and MemoryTemplateBinnedCM.h