### PR TITLE
TE-TC chain

### DIFF
--- a/IntegrationTests/TETC/hdl/SectorProcessor.vhd
+++ b/IntegrationTests/TETC/hdl/SectorProcessor.vhd
@@ -1,0 +1,1528 @@
+--! Standard libraries
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+--! User packages
+use work.tf_pkg.all;
+use work.memUtil_pkg.all;
+
+entity SectorProcessor is
+  port(
+    clk        : in std_logic;
+    reset      : in std_logic;
+    TE_start  : in std_logic;
+    TE_bx_in : in std_logic_vector(2 downto 0);
+    TC_bx_out : out std_logic_vector(2 downto 0);
+    TC_bx_out_vld : out std_logic;
+    TC_done   : out std_logic;
+    AS_36_mem_A_wea        : in t_arr_AS_36_1b;
+    AS_36_mem_AV_writeaddr : in t_arr_AS_36_ADDR;
+    AS_36_mem_AV_din       : in t_arr_AS_36_DATA;
+    VMSTE_22_mem_A_wea        : in t_arr_VMSTE_22_1b;
+    VMSTE_22_mem_AV_writeaddr : in t_arr_VMSTE_22_ADDR;
+    VMSTE_22_mem_AV_din       : in t_arr_VMSTE_22_DATA;
+    VMSTE_16_mem_A_wea        : in t_arr_VMSTE_16_1b;
+    VMSTE_16_mem_AV_writeaddr : in t_arr_VMSTE_16_ADDR;
+    VMSTE_16_mem_AV_din       : in t_arr_VMSTE_16_DATA;
+    TPROJ_60_mem_A_enb          : in t_arr_TPROJ_60_1b;
+    TPROJ_60_mem_AV_readaddr    : in t_arr_TPROJ_60_ADDR;
+    TPROJ_60_mem_AV_dout        : out t_arr_TPROJ_60_DATA;
+    TPROJ_60_mem_AAV_dout_nent  : out t_arr_TPROJ_60_NENT;
+    TPROJ_58_mem_A_enb          : in t_arr_TPROJ_58_1b;
+    TPROJ_58_mem_AV_readaddr    : in t_arr_TPROJ_58_ADDR;
+    TPROJ_58_mem_AV_dout        : out t_arr_TPROJ_58_DATA;
+    TPROJ_58_mem_AAV_dout_nent  : out t_arr_TPROJ_58_NENT;
+    TPROJ_59_mem_A_enb          : in t_arr_TPROJ_59_1b;
+    TPROJ_59_mem_AV_readaddr    : in t_arr_TPROJ_59_ADDR;
+    TPROJ_59_mem_AV_dout        : out t_arr_TPROJ_59_DATA;
+    TPROJ_59_mem_AAV_dout_nent  : out t_arr_TPROJ_59_NENT;
+    TPAR_70_mem_A_enb          : in t_arr_TPAR_70_1b;
+    TPAR_70_mem_AV_readaddr    : in t_arr_TPAR_70_ADDR;
+    TPAR_70_mem_AV_dout        : out t_arr_TPAR_70_DATA;
+    TPAR_70_mem_AAV_dout_nent  : out t_arr_TPAR_70_NENT
+  );
+end SectorProcessor;
+
+architecture rtl of SectorProcessor is
+
+  signal AS_36_mem_A_enb          : t_arr_AS_36_1b;
+  signal AS_36_mem_AV_readaddr    : t_arr_AS_36_ADDR;
+  signal AS_36_mem_AV_dout        : t_arr_AS_36_DATA;
+  signal VMSTE_22_mem_A_enb          : t_arr_VMSTE_22_1b;
+  signal VMSTE_22_mem_AV_readaddr    : t_arr_VMSTE_22_ADDR;
+  signal VMSTE_22_mem_AV_dout        : t_arr_VMSTE_22_DATA;
+  signal VMSTE_22_mem_AAV_dout_nent  : t_arr_VMSTE_22_NENT; -- (#page)
+  signal VMSTE_16_mem_A_enb          : t_arr_VMSTE_16_1b;
+  signal VMSTE_16_mem_AV_readaddr    : t_arr_VMSTE_16_ADDR;
+  signal VMSTE_16_mem_AV_dout        : t_arr_VMSTE_16_DATA;
+  signal VMSTE_16_mem_AAAV_dout_nent : t_arr_VMSTE_16_NENT; -- (#page)(#bin)
+  signal SP_14_mem_A_wea          : t_arr_SP_14_1b;
+  signal SP_14_mem_AV_writeaddr   : t_arr_SP_14_ADDR;
+  signal SP_14_mem_AV_din         : t_arr_SP_14_DATA;
+  signal SP_14_mem_A_enb          : t_arr_SP_14_1b;
+  signal SP_14_mem_AV_readaddr    : t_arr_SP_14_ADDR;
+  signal SP_14_mem_AV_dout        : t_arr_SP_14_DATA;
+  signal SP_14_mem_AAV_dout_nent  : t_arr_SP_14_NENT; -- (#page)
+  signal TPROJ_60_mem_A_wea          : t_arr_TPROJ_60_1b;
+  signal TPROJ_60_mem_AV_writeaddr   : t_arr_TPROJ_60_ADDR;
+  signal TPROJ_60_mem_AV_din         : t_arr_TPROJ_60_DATA;
+  signal TPROJ_58_mem_A_wea          : t_arr_TPROJ_58_1b;
+  signal TPROJ_58_mem_AV_writeaddr   : t_arr_TPROJ_58_ADDR;
+  signal TPROJ_58_mem_AV_din         : t_arr_TPROJ_58_DATA;
+  signal TPROJ_59_mem_A_wea          : t_arr_TPROJ_59_1b;
+  signal TPROJ_59_mem_AV_writeaddr   : t_arr_TPROJ_59_ADDR;
+  signal TPROJ_59_mem_AV_din         : t_arr_TPROJ_59_DATA;
+  signal TPAR_70_mem_A_wea          : t_arr_TPAR_70_1b;
+  signal TPAR_70_mem_AV_writeaddr   : t_arr_TPAR_70_ADDR;
+  signal TPAR_70_mem_AV_din         : t_arr_TPAR_70_DATA;
+  signal TE_done : std_logic := '0';
+  signal TE_bx_out : std_logic_vector(2 downto 0);
+  signal TE_bx_out_vld : std_logic;
+  signal TC_start : std_logic := '0';
+  signal TE_L1PHIC12_L2PHIB10_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB10_bendinnertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB10_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB10_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB10_bendoutertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB10_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB11_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB11_bendinnertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB11_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB11_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB11_bendoutertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB11_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB12_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB12_bendinnertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB12_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB12_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB12_bendoutertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB12_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB13_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB13_bendinnertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB13_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB13_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB13_bendoutertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB13_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB14_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB14_bendinnertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB14_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB14_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB14_bendoutertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB14_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB11_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB11_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB11_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB11_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB11_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB11_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB12_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB12_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB12_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB12_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB12_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB12_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB13_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB13_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB13_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB13_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB13_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB13_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB14_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB14_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB14_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB14_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB14_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB14_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB15_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB15_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB15_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB15_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB15_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB15_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB12_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB12_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB12_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB12_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB12_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB12_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB13_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB13_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB13_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB13_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB13_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB13_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB14_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB14_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB14_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB14_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB14_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB14_bendoutertable_dout : std_logic_vector(0 downto 0);
+
+begin
+
+  AS_36_loop : for var in enum_AS_36 generate
+  begin
+
+    AS_36 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 36,
+        NUM_PAGES       => 8,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => AS_36_mem_A_wea(var),
+        addra     => AS_36_mem_AV_writeaddr(var),
+        dina      => AS_36_mem_AV_din(var),
+        clkb      => clk,
+        enb       => AS_36_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => AS_36_mem_AV_readaddr(var),
+        doutb     => AS_36_mem_AV_dout(var),
+        sync_nent => TC_start,
+        nent_o    => open
+      );
+
+  end generate AS_36_loop;
+
+
+  VMSTE_22_loop : for var in enum_VMSTE_22 generate
+  begin
+
+    VMSTE_22 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 22,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => VMSTE_22_mem_A_wea(var),
+        addra     => VMSTE_22_mem_AV_writeaddr(var),
+        dina      => VMSTE_22_mem_AV_din(var),
+        clkb      => clk,
+        enb       => VMSTE_22_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => VMSTE_22_mem_AV_readaddr(var),
+        doutb     => VMSTE_22_mem_AV_dout(var),
+        sync_nent => TE_start,
+        nent_o    => VMSTE_22_mem_AAV_dout_nent(var)
+      );
+
+  end generate VMSTE_22_loop;
+
+
+  VMSTE_16_loop : for var in enum_VMSTE_16 generate
+  begin
+
+    VMSTE_16 : entity work.tf_mem_bin
+      generic map (
+        RAM_WIDTH       => 16,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => VMSTE_16_mem_A_wea(var),
+        addra     => VMSTE_16_mem_AV_writeaddr(var),
+        dina      => VMSTE_16_mem_AV_din(var),
+        clkb      => clk,
+        enb       => VMSTE_16_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => VMSTE_16_mem_AV_readaddr(var),
+        doutb     => VMSTE_16_mem_AV_dout(var),
+        sync_nent => TE_start,
+        nent_o    => VMSTE_16_mem_AAAV_dout_nent(var)
+      );
+
+  end generate VMSTE_16_loop;
+
+
+  SP_14_loop : for var in enum_SP_14 generate
+  begin
+
+    SP_14 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 14,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => SP_14_mem_A_wea(var),
+        addra     => SP_14_mem_AV_writeaddr(var),
+        dina      => SP_14_mem_AV_din(var),
+        clkb      => clk,
+        enb       => SP_14_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => SP_14_mem_AV_readaddr(var),
+        doutb     => SP_14_mem_AV_dout(var),
+        sync_nent => TC_start,
+        nent_o    => SP_14_mem_AAV_dout_nent(var)
+      );
+
+  end generate SP_14_loop;
+
+
+  TPROJ_60_loop : for var in enum_TPROJ_60 generate
+  begin
+
+    TPROJ_60 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 60,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => TPROJ_60_mem_A_wea(var),
+        addra     => TPROJ_60_mem_AV_writeaddr(var),
+        dina      => TPROJ_60_mem_AV_din(var),
+        clkb      => clk,
+        enb       => TPROJ_60_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => TPROJ_60_mem_AV_readaddr(var),
+        doutb     => TPROJ_60_mem_AV_dout(var),
+        sync_nent => TC_done,
+        nent_o    => TPROJ_60_mem_AAV_dout_nent(var)
+      );
+
+  end generate TPROJ_60_loop;
+
+
+  TPROJ_58_loop : for var in enum_TPROJ_58 generate
+  begin
+
+    TPROJ_58 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 58,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => TPROJ_58_mem_A_wea(var),
+        addra     => TPROJ_58_mem_AV_writeaddr(var),
+        dina      => TPROJ_58_mem_AV_din(var),
+        clkb      => clk,
+        enb       => TPROJ_58_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => TPROJ_58_mem_AV_readaddr(var),
+        doutb     => TPROJ_58_mem_AV_dout(var),
+        sync_nent => TC_done,
+        nent_o    => TPROJ_58_mem_AAV_dout_nent(var)
+      );
+
+  end generate TPROJ_58_loop;
+
+
+  TPROJ_59_loop : for var in enum_TPROJ_59 generate
+  begin
+
+    TPROJ_59 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 59,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => TPROJ_59_mem_A_wea(var),
+        addra     => TPROJ_59_mem_AV_writeaddr(var),
+        dina      => TPROJ_59_mem_AV_din(var),
+        clkb      => clk,
+        enb       => TPROJ_59_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => TPROJ_59_mem_AV_readaddr(var),
+        doutb     => TPROJ_59_mem_AV_dout(var),
+        sync_nent => TC_done,
+        nent_o    => TPROJ_59_mem_AAV_dout_nent(var)
+      );
+
+  end generate TPROJ_59_loop;
+
+
+  TPAR_70_loop : for var in enum_TPAR_70 generate
+  begin
+
+    TPAR_70 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 70,
+        NUM_PAGES       => 8,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => TPAR_70_mem_A_wea(var),
+        addra     => TPAR_70_mem_AV_writeaddr(var),
+        dina      => TPAR_70_mem_AV_din(var),
+        clkb      => clk,
+        enb       => TPAR_70_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => TPAR_70_mem_AV_readaddr(var),
+        doutb     => TPAR_70_mem_AV_dout(var),
+        sync_nent => TC_done,
+        nent_o    => TPAR_70_mem_AAV_dout_nent(var)
+      );
+
+  end generate TPAR_70_loop;
+
+
+
+  TE_L1PHIC12_L2PHIB10_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB10_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB10_bendinnertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB10_bendinnertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB10_bendinnertable_dout
+  );
+
+
+  TE_L1PHIC12_L2PHIB10_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB10_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB10_bendoutertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB10_bendoutertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB10_bendoutertable_dout
+  );
+
+  TC_start <= '1' when TE_done = '1';
+
+  TE_L1PHIC12_L2PHIB10 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => TE_done,
+      bx_V          => TE_bx_in,
+      bx_o_V        => TE_bx_out,
+      bx_o_V_ap_vld => TE_bx_out_vld,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHIC12n1),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHIC12n1),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHIC12n1),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n1)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n1)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB10n5),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB10n5),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB10n5),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHIC12_L2PHIB10_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHIC12_L2PHIB10_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHIC12_L2PHIB10_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHIC12_L2PHIB10_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHIC12_L2PHIB10_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHIC12_L2PHIB10_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHIC12_L2PHIB10),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHIC12_L2PHIB10),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHIC12_L2PHIB10)
+  );
+
+
+  TE_L1PHIC12_L2PHIB11_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB11_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB11_bendinnertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB11_bendinnertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB11_bendinnertable_dout
+  );
+
+
+  TE_L1PHIC12_L2PHIB11_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB11_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB11_bendoutertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB11_bendoutertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB11_bendoutertable_dout
+  );
+
+  TE_L1PHIC12_L2PHIB11 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHIC12n2),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHIC12n2),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHIC12n2),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n2)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n2)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB11n4),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB11n4),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB11n4),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHIC12_L2PHIB11_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHIC12_L2PHIB11_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHIC12_L2PHIB11_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHIC12_L2PHIB11_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHIC12_L2PHIB11_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHIC12_L2PHIB11_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHIC12_L2PHIB11),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHIC12_L2PHIB11),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHIC12_L2PHIB11)
+  );
+
+
+  TE_L1PHIC12_L2PHIB12_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB12_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB12_bendinnertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB12_bendinnertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB12_bendinnertable_dout
+  );
+
+
+  TE_L1PHIC12_L2PHIB12_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB12_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB12_bendoutertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB12_bendoutertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB12_bendoutertable_dout
+  );
+
+  TE_L1PHIC12_L2PHIB12 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHIC12n3),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHIC12n3),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHIC12n3),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n3)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n3)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB12n3),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB12n3),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB12n3),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHIC12_L2PHIB12_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHIC12_L2PHIB12_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHIC12_L2PHIB12_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHIC12_L2PHIB12_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHIC12_L2PHIB12_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHIC12_L2PHIB12_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHIC12_L2PHIB12),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHIC12_L2PHIB12),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHIC12_L2PHIB12)
+  );
+
+
+  TE_L1PHIC12_L2PHIB13_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB13_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB13_bendinnertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB13_bendinnertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB13_bendinnertable_dout
+  );
+
+
+  TE_L1PHIC12_L2PHIB13_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB13_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB13_bendoutertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB13_bendoutertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB13_bendoutertable_dout
+  );
+
+  TE_L1PHIC12_L2PHIB13 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHIC12n4),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHIC12n4),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHIC12n4),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n4)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n4)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB13n2),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB13n2),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB13n2),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHIC12_L2PHIB13_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHIC12_L2PHIB13_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHIC12_L2PHIB13_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHIC12_L2PHIB13_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHIC12_L2PHIB13_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHIC12_L2PHIB13_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHIC12_L2PHIB13),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHIC12_L2PHIB13),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHIC12_L2PHIB13)
+  );
+
+
+  TE_L1PHIC12_L2PHIB14_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB14_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB14_bendinnertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB14_bendinnertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB14_bendinnertable_dout
+  );
+
+
+  TE_L1PHIC12_L2PHIB14_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB14_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB14_bendoutertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB14_bendoutertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB14_bendoutertable_dout
+  );
+
+  TE_L1PHIC12_L2PHIB14 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHIC12n5),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHIC12n5),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHIC12n5),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n5)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n5)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB14n1),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB14n1),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB14n1),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHIC12_L2PHIB14_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHIC12_L2PHIB14_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHIC12_L2PHIB14_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHIC12_L2PHIB14_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHIC12_L2PHIB14_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHIC12_L2PHIB14_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHIC12_L2PHIB14),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHIC12_L2PHIB14),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHIC12_L2PHIB14)
+  );
+
+
+  TE_L1PHID13_L2PHIB11_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB11_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB11_bendinnertable_addr,
+      ce        => TE_L1PHID13_L2PHIB11_bendinnertable_ce,
+      dout      => TE_L1PHID13_L2PHIB11_bendinnertable_dout
+  );
+
+
+  TE_L1PHID13_L2PHIB11_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB11_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB11_bendoutertable_addr,
+      ce        => TE_L1PHID13_L2PHIB11_bendoutertable_ce,
+      dout      => TE_L1PHID13_L2PHIB11_bendoutertable_dout
+  );
+
+  TE_L1PHID13_L2PHIB11 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID13n1),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID13n1),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID13n1),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n1)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n1)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB11n5),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB11n5),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB11n5),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID13_L2PHIB11_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID13_L2PHIB11_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID13_L2PHIB11_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID13_L2PHIB11_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID13_L2PHIB11_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID13_L2PHIB11_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID13_L2PHIB11),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID13_L2PHIB11),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID13_L2PHIB11)
+  );
+
+
+  TE_L1PHID13_L2PHIB12_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB12_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB12_bendinnertable_addr,
+      ce        => TE_L1PHID13_L2PHIB12_bendinnertable_ce,
+      dout      => TE_L1PHID13_L2PHIB12_bendinnertable_dout
+  );
+
+
+  TE_L1PHID13_L2PHIB12_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB12_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB12_bendoutertable_addr,
+      ce        => TE_L1PHID13_L2PHIB12_bendoutertable_ce,
+      dout      => TE_L1PHID13_L2PHIB12_bendoutertable_dout
+  );
+
+  TE_L1PHID13_L2PHIB12 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID13n2),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID13n2),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID13n2),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n2)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n2)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB12n4),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB12n4),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB12n4),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID13_L2PHIB12_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID13_L2PHIB12_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID13_L2PHIB12_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID13_L2PHIB12_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID13_L2PHIB12_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID13_L2PHIB12_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID13_L2PHIB12),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID13_L2PHIB12),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID13_L2PHIB12)
+  );
+
+
+  TE_L1PHID13_L2PHIB13_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB13_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB13_bendinnertable_addr,
+      ce        => TE_L1PHID13_L2PHIB13_bendinnertable_ce,
+      dout      => TE_L1PHID13_L2PHIB13_bendinnertable_dout
+  );
+
+
+  TE_L1PHID13_L2PHIB13_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB13_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB13_bendoutertable_addr,
+      ce        => TE_L1PHID13_L2PHIB13_bendoutertable_ce,
+      dout      => TE_L1PHID13_L2PHIB13_bendoutertable_dout
+  );
+
+  TE_L1PHID13_L2PHIB13 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID13n3),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID13n3),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID13n3),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n3)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n3)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB13n3),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB13n3),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB13n3),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID13_L2PHIB13_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID13_L2PHIB13_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID13_L2PHIB13_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID13_L2PHIB13_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID13_L2PHIB13_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID13_L2PHIB13_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID13_L2PHIB13),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID13_L2PHIB13),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID13_L2PHIB13)
+  );
+
+
+  TE_L1PHID13_L2PHIB14_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB14_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB14_bendinnertable_addr,
+      ce        => TE_L1PHID13_L2PHIB14_bendinnertable_ce,
+      dout      => TE_L1PHID13_L2PHIB14_bendinnertable_dout
+  );
+
+
+  TE_L1PHID13_L2PHIB14_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB14_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB14_bendoutertable_addr,
+      ce        => TE_L1PHID13_L2PHIB14_bendoutertable_ce,
+      dout      => TE_L1PHID13_L2PHIB14_bendoutertable_dout
+  );
+
+  TE_L1PHID13_L2PHIB14 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID13n4),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID13n4),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID13n4),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n4)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n4)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB14n2),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB14n2),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB14n2),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID13_L2PHIB14_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID13_L2PHIB14_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID13_L2PHIB14_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID13_L2PHIB14_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID13_L2PHIB14_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID13_L2PHIB14_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID13_L2PHIB14),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID13_L2PHIB14),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID13_L2PHIB14)
+  );
+
+
+  TE_L1PHID13_L2PHIB15_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB15_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB15_bendinnertable_addr,
+      ce        => TE_L1PHID13_L2PHIB15_bendinnertable_ce,
+      dout      => TE_L1PHID13_L2PHIB15_bendinnertable_dout
+  );
+
+
+  TE_L1PHID13_L2PHIB15_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB15_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB15_bendoutertable_addr,
+      ce        => TE_L1PHID13_L2PHIB15_bendoutertable_ce,
+      dout      => TE_L1PHID13_L2PHIB15_bendoutertable_dout
+  );
+
+  TE_L1PHID13_L2PHIB15 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID13n5),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID13n5),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID13n5),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n5)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n5)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB15n1),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB15n1),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB15n1),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID13_L2PHIB15_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID13_L2PHIB15_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID13_L2PHIB15_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID13_L2PHIB15_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID13_L2PHIB15_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID13_L2PHIB15_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID13_L2PHIB15),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID13_L2PHIB15),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID13_L2PHIB15)
+  );
+
+
+  TE_L1PHID14_L2PHIB12_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB12_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB12_bendinnertable_addr,
+      ce        => TE_L1PHID14_L2PHIB12_bendinnertable_ce,
+      dout      => TE_L1PHID14_L2PHIB12_bendinnertable_dout
+  );
+
+
+  TE_L1PHID14_L2PHIB12_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB12_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB12_bendoutertable_addr,
+      ce        => TE_L1PHID14_L2PHIB12_bendoutertable_ce,
+      dout      => TE_L1PHID14_L2PHIB12_bendoutertable_dout
+  );
+
+  TE_L1PHID14_L2PHIB12 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID14n1),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID14n1),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID14n1),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n1)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n1)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB12n5),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB12n5),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB12n5),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID14_L2PHIB12_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID14_L2PHIB12_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID14_L2PHIB12_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID14_L2PHIB12_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID14_L2PHIB12_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID14_L2PHIB12_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID14_L2PHIB12),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID14_L2PHIB12),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID14_L2PHIB12)
+  );
+
+
+  TE_L1PHID14_L2PHIB13_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB13_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB13_bendinnertable_addr,
+      ce        => TE_L1PHID14_L2PHIB13_bendinnertable_ce,
+      dout      => TE_L1PHID14_L2PHIB13_bendinnertable_dout
+  );
+
+
+  TE_L1PHID14_L2PHIB13_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB13_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB13_bendoutertable_addr,
+      ce        => TE_L1PHID14_L2PHIB13_bendoutertable_ce,
+      dout      => TE_L1PHID14_L2PHIB13_bendoutertable_dout
+  );
+
+  TE_L1PHID14_L2PHIB13 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID14n2),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID14n2),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID14n2),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n2)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n2)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB13n4),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB13n4),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB13n4),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID14_L2PHIB13_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID14_L2PHIB13_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID14_L2PHIB13_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID14_L2PHIB13_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID14_L2PHIB13_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID14_L2PHIB13_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID14_L2PHIB13),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID14_L2PHIB13),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID14_L2PHIB13)
+  );
+
+
+  TE_L1PHID14_L2PHIB14_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB14_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB14_bendinnertable_addr,
+      ce        => TE_L1PHID14_L2PHIB14_bendinnertable_ce,
+      dout      => TE_L1PHID14_L2PHIB14_bendinnertable_dout
+  );
+
+
+  TE_L1PHID14_L2PHIB14_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB14_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB14_bendoutertable_addr,
+      ce        => TE_L1PHID14_L2PHIB14_bendoutertable_ce,
+      dout      => TE_L1PHID14_L2PHIB14_bendoutertable_dout
+  );
+
+  TE_L1PHID14_L2PHIB14 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID14n3),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID14n3),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID14n3),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n3)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n3)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB14n3),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB14n3),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB14n3),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID14_L2PHIB14_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID14_L2PHIB14_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID14_L2PHIB14_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID14_L2PHIB14_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID14_L2PHIB14_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID14_L2PHIB14_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID14_L2PHIB14),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID14_L2PHIB14),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID14_L2PHIB14)
+  );
+
+  TC_L1L2E : entity work.TC_L1L2E
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TC_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => TC_done,
+      bx_V          => TE_bx_out,
+      bx_o_V        => TC_bx_out,
+      bx_o_V_ap_vld => TC_bx_out_vld,
+      innerStubs_0_dataarray_data_V_ce0       => AS_36_mem_A_enb(L1PHICn4),
+      innerStubs_0_dataarray_data_V_address0  => AS_36_mem_AV_readaddr(L1PHICn4),
+      innerStubs_0_dataarray_data_V_q0        => AS_36_mem_AV_dout(L1PHICn4),
+      innerStubs_1_dataarray_data_V_ce0       => AS_36_mem_A_enb(L1PHIDn2),
+      innerStubs_1_dataarray_data_V_address0  => AS_36_mem_AV_readaddr(L1PHIDn2),
+      innerStubs_1_dataarray_data_V_q0        => AS_36_mem_AV_dout(L1PHIDn2),
+      outerStubs_0_dataarray_data_V_ce0       => AS_36_mem_A_enb(L2PHIBn4),
+      outerStubs_0_dataarray_data_V_address0  => AS_36_mem_AV_readaddr(L2PHIBn4),
+      outerStubs_0_dataarray_data_V_q0        => AS_36_mem_AV_dout(L2PHIBn4),
+      stubPairs_0_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHIC12_L2PHIB10),
+      stubPairs_0_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHIC12_L2PHIB10),
+      stubPairs_0_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHIC12_L2PHIB10),
+      stubPairs_0_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB10)(0),
+      stubPairs_0_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB10)(1),
+      stubPairs_1_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHIC12_L2PHIB11),
+      stubPairs_1_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHIC12_L2PHIB11),
+      stubPairs_1_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHIC12_L2PHIB11),
+      stubPairs_1_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB11)(0),
+      stubPairs_1_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB11)(1),
+      stubPairs_2_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHIC12_L2PHIB12),
+      stubPairs_2_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHIC12_L2PHIB12),
+      stubPairs_2_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHIC12_L2PHIB12),
+      stubPairs_2_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB12)(0),
+      stubPairs_2_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB12)(1),
+      stubPairs_3_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHIC12_L2PHIB13),
+      stubPairs_3_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHIC12_L2PHIB13),
+      stubPairs_3_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHIC12_L2PHIB13),
+      stubPairs_3_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB13)(0),
+      stubPairs_3_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB13)(1),
+      stubPairs_4_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHIC12_L2PHIB14),
+      stubPairs_4_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHIC12_L2PHIB14),
+      stubPairs_4_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHIC12_L2PHIB14),
+      stubPairs_4_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB14)(0),
+      stubPairs_4_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB14)(1),
+      stubPairs_5_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID13_L2PHIB11),
+      stubPairs_5_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID13_L2PHIB11),
+      stubPairs_5_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID13_L2PHIB11),
+      stubPairs_5_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB11)(0),
+      stubPairs_5_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB11)(1),
+      stubPairs_6_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID13_L2PHIB12),
+      stubPairs_6_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID13_L2PHIB12),
+      stubPairs_6_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID13_L2PHIB12),
+      stubPairs_6_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB12)(0),
+      stubPairs_6_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB12)(1),
+      stubPairs_7_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID13_L2PHIB13),
+      stubPairs_7_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID13_L2PHIB13),
+      stubPairs_7_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID13_L2PHIB13),
+      stubPairs_7_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB13)(0),
+      stubPairs_7_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB13)(1),
+      stubPairs_8_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID13_L2PHIB14),
+      stubPairs_8_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID13_L2PHIB14),
+      stubPairs_8_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID13_L2PHIB14),
+      stubPairs_8_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB14)(0),
+      stubPairs_8_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB14)(1),
+      stubPairs_9_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID13_L2PHIB15),
+      stubPairs_9_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID13_L2PHIB15),
+      stubPairs_9_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID13_L2PHIB15),
+      stubPairs_9_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB15)(0),
+      stubPairs_9_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB15)(1),
+      stubPairs_10_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID14_L2PHIB12),
+      stubPairs_10_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID14_L2PHIB12),
+      stubPairs_10_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID14_L2PHIB12),
+      stubPairs_10_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB12)(0),
+      stubPairs_10_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB12)(1),
+      stubPairs_11_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID14_L2PHIB13),
+      stubPairs_11_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID14_L2PHIB13),
+      stubPairs_11_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID14_L2PHIB13),
+      stubPairs_11_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB13)(0),
+      stubPairs_11_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB13)(1),
+      stubPairs_12_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID14_L2PHIB14),
+      stubPairs_12_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID14_L2PHIB14),
+      stubPairs_12_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID14_L2PHIB14),
+      stubPairs_12_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB14)(0),
+      stubPairs_12_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB14)(1),
+      trackletParameters_dataarray_data_V_ce0       => open,
+      trackletParameters_dataarray_data_V_we0       => TPAR_70_mem_A_wea(L1L2E),
+      trackletParameters_dataarray_data_V_address0  => TPAR_70_mem_AV_writeaddr(L1L2E),
+      trackletParameters_dataarray_data_V_d0        => TPAR_70_mem_AV_din(L1L2E),
+      projout_barrel_ps_13_dataarray_data_V_ce0       => open,
+      projout_barrel_ps_13_dataarray_data_V_we0       => TPROJ_60_mem_A_wea(L1L2E_L3PHIB),
+      projout_barrel_ps_13_dataarray_data_V_address0  => TPROJ_60_mem_AV_writeaddr(L1L2E_L3PHIB),
+      projout_barrel_ps_13_dataarray_data_V_d0        => TPROJ_60_mem_AV_din(L1L2E_L3PHIB),
+      projout_barrel_2s_0_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_0_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L4PHIA),
+      projout_barrel_2s_0_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L4PHIA),
+      projout_barrel_2s_0_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L4PHIA),
+      projout_barrel_2s_1_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_1_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L4PHIB),
+      projout_barrel_2s_1_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L4PHIB),
+      projout_barrel_2s_1_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L4PHIB),
+      projout_barrel_2s_2_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_2_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L4PHIC),
+      projout_barrel_2s_2_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L4PHIC),
+      projout_barrel_2s_2_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L4PHIC),
+      projout_barrel_2s_4_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_4_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L5PHIA),
+      projout_barrel_2s_4_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L5PHIA),
+      projout_barrel_2s_4_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L5PHIA),
+      projout_barrel_2s_5_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_5_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L5PHIB),
+      projout_barrel_2s_5_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L5PHIB),
+      projout_barrel_2s_5_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L5PHIB),
+      projout_barrel_2s_6_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_6_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L5PHIC),
+      projout_barrel_2s_6_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L5PHIC),
+      projout_barrel_2s_6_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L5PHIC),
+      projout_barrel_2s_8_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_8_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L6PHIA),
+      projout_barrel_2s_8_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L6PHIA),
+      projout_barrel_2s_8_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L6PHIA),
+      projout_barrel_2s_9_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_9_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L6PHIB),
+      projout_barrel_2s_9_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L6PHIB),
+      projout_barrel_2s_9_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L6PHIB),
+      projout_barrel_2s_10_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_10_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L6PHIC),
+      projout_barrel_2s_10_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L6PHIC),
+      projout_barrel_2s_10_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L6PHIC),
+      projout_disk_0_dataarray_data_V_ce0       => open,
+      projout_disk_0_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D1PHIA),
+      projout_disk_0_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D1PHIA),
+      projout_disk_0_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D1PHIA),
+      projout_disk_1_dataarray_data_V_ce0       => open,
+      projout_disk_1_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D1PHIB),
+      projout_disk_1_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D1PHIB),
+      projout_disk_1_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D1PHIB),
+      projout_disk_2_dataarray_data_V_ce0       => open,
+      projout_disk_2_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D1PHIC),
+      projout_disk_2_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D1PHIC),
+      projout_disk_2_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D1PHIC),
+      projout_disk_4_dataarray_data_V_ce0       => open,
+      projout_disk_4_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D2PHIA),
+      projout_disk_4_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D2PHIA),
+      projout_disk_4_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D2PHIA),
+      projout_disk_5_dataarray_data_V_ce0       => open,
+      projout_disk_5_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D2PHIB),
+      projout_disk_5_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D2PHIB),
+      projout_disk_5_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D2PHIB),
+      projout_disk_6_dataarray_data_V_ce0       => open,
+      projout_disk_6_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D2PHIC),
+      projout_disk_6_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D2PHIC),
+      projout_disk_6_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D2PHIC),
+      projout_disk_8_dataarray_data_V_ce0       => open,
+      projout_disk_8_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D3PHIA),
+      projout_disk_8_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D3PHIA),
+      projout_disk_8_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D3PHIA),
+      projout_disk_9_dataarray_data_V_ce0       => open,
+      projout_disk_9_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D3PHIB),
+      projout_disk_9_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D3PHIB),
+      projout_disk_9_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D3PHIB),
+      projout_disk_10_dataarray_data_V_ce0       => open,
+      projout_disk_10_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D3PHIC),
+      projout_disk_10_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D3PHIC),
+      projout_disk_10_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D3PHIC),
+      projout_disk_12_dataarray_data_V_ce0       => open,
+      projout_disk_12_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D4PHIA),
+      projout_disk_12_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D4PHIA),
+      projout_disk_12_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D4PHIA),
+      projout_disk_13_dataarray_data_V_ce0       => open,
+      projout_disk_13_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D4PHIB),
+      projout_disk_13_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D4PHIB),
+      projout_disk_13_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D4PHIB),
+      projout_disk_14_dataarray_data_V_ce0       => open,
+      projout_disk_14_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D4PHIC),
+      projout_disk_14_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D4PHIC),
+      projout_disk_14_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D4PHIC)
+  );
+
+
+
+end rtl;

--- a/IntegrationTests/TETC/hdl/SectorProcessor.vhd
+++ b/IntegrationTests/TETC/hdl/SectorProcessor.vhd
@@ -394,7 +394,7 @@ begin
 
   TE_L1PHIC12_L2PHIB10_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB10_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB10_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -408,7 +408,7 @@ begin
 
   TE_L1PHIC12_L2PHIB10_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB10_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB10_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -471,7 +471,7 @@ begin
 
   TE_L1PHIC12_L2PHIB11_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB11_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB11_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -485,7 +485,7 @@ begin
 
   TE_L1PHIC12_L2PHIB11_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB11_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB11_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -544,7 +544,7 @@ begin
 
   TE_L1PHIC12_L2PHIB12_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB12_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB12_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -558,7 +558,7 @@ begin
 
   TE_L1PHIC12_L2PHIB12_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB12_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB12_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -617,7 +617,7 @@ begin
 
   TE_L1PHIC12_L2PHIB13_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB13_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB13_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -631,7 +631,7 @@ begin
 
   TE_L1PHIC12_L2PHIB13_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB13_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB13_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -690,7 +690,7 @@ begin
 
   TE_L1PHIC12_L2PHIB14_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB14_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB14_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -704,7 +704,7 @@ begin
 
   TE_L1PHIC12_L2PHIB14_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB14_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB14_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -763,7 +763,7 @@ begin
 
   TE_L1PHID13_L2PHIB11_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB11_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB11_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -777,7 +777,7 @@ begin
 
   TE_L1PHID13_L2PHIB11_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB11_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB11_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -836,7 +836,7 @@ begin
 
   TE_L1PHID13_L2PHIB12_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB12_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB12_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -850,7 +850,7 @@ begin
 
   TE_L1PHID13_L2PHIB12_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB12_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB12_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -909,7 +909,7 @@ begin
 
   TE_L1PHID13_L2PHIB13_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB13_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB13_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -923,7 +923,7 @@ begin
 
   TE_L1PHID13_L2PHIB13_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB13_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB13_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -982,7 +982,7 @@ begin
 
   TE_L1PHID13_L2PHIB14_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB14_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB14_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -996,7 +996,7 @@ begin
 
   TE_L1PHID13_L2PHIB14_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB14_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB14_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1055,7 +1055,7 @@ begin
 
   TE_L1PHID13_L2PHIB15_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB15_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB15_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1069,7 +1069,7 @@ begin
 
   TE_L1PHID13_L2PHIB15_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB15_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB15_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1128,7 +1128,7 @@ begin
 
   TE_L1PHID14_L2PHIB12_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB12_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB12_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1142,7 +1142,7 @@ begin
 
   TE_L1PHID14_L2PHIB12_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB12_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB12_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1201,7 +1201,7 @@ begin
 
   TE_L1PHID14_L2PHIB13_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB13_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB13_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1215,7 +1215,7 @@ begin
 
   TE_L1PHID14_L2PHIB13_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB13_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB13_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1274,7 +1274,7 @@ begin
 
   TE_L1PHID14_L2PHIB14_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB14_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB14_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1288,7 +1288,7 @@ begin
 
   TE_L1PHID14_L2PHIB14_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB14_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB14_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )

--- a/IntegrationTests/TETC/hdl/SectorProcessorFull.vhd
+++ b/IntegrationTests/TETC/hdl/SectorProcessorFull.vhd
@@ -1,0 +1,1528 @@
+--! Standard libraries
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+--! User packages
+use work.tf_pkg.all;
+use work.memUtil_pkg.all;
+
+entity SectorProcessorFull is
+  port(
+    clk        : in std_logic;
+    reset      : in std_logic;
+    TE_start  : in std_logic;
+    TE_bx_in : in std_logic_vector(2 downto 0);
+    TC_bx_out : out std_logic_vector(2 downto 0);
+    TC_bx_out_vld : out std_logic;
+    TC_done   : out std_logic;
+    TE_bx_out : out std_logic_vector(2 downto 0);
+    TE_bx_out_vld : out std_logic;
+    TE_done   : out std_logic;
+    AS_36_mem_A_wea        : in t_arr_AS_36_1b;
+    AS_36_mem_AV_writeaddr : in t_arr_AS_36_ADDR;
+    AS_36_mem_AV_din       : in t_arr_AS_36_DATA;
+    VMSTE_22_mem_A_wea        : in t_arr_VMSTE_22_1b;
+    VMSTE_22_mem_AV_writeaddr : in t_arr_VMSTE_22_ADDR;
+    VMSTE_22_mem_AV_din       : in t_arr_VMSTE_22_DATA;
+    VMSTE_16_mem_A_wea        : in t_arr_VMSTE_16_1b;
+    VMSTE_16_mem_AV_writeaddr : in t_arr_VMSTE_16_ADDR;
+    VMSTE_16_mem_AV_din       : in t_arr_VMSTE_16_DATA;
+    SP_14_mem_A_wea        : out t_arr_SP_14_1b;
+    SP_14_mem_AV_writeaddr : out t_arr_SP_14_ADDR;
+    SP_14_mem_AV_din       : out t_arr_SP_14_DATA;
+    TPROJ_60_mem_A_enb          : in t_arr_TPROJ_60_1b;
+    TPROJ_60_mem_AV_readaddr    : in t_arr_TPROJ_60_ADDR;
+    TPROJ_60_mem_AV_dout        : out t_arr_TPROJ_60_DATA;
+    TPROJ_60_mem_AAV_dout_nent  : out t_arr_TPROJ_60_NENT;
+    TPROJ_58_mem_A_enb          : in t_arr_TPROJ_58_1b;
+    TPROJ_58_mem_AV_readaddr    : in t_arr_TPROJ_58_ADDR;
+    TPROJ_58_mem_AV_dout        : out t_arr_TPROJ_58_DATA;
+    TPROJ_58_mem_AAV_dout_nent  : out t_arr_TPROJ_58_NENT;
+    TPROJ_59_mem_A_enb          : in t_arr_TPROJ_59_1b;
+    TPROJ_59_mem_AV_readaddr    : in t_arr_TPROJ_59_ADDR;
+    TPROJ_59_mem_AV_dout        : out t_arr_TPROJ_59_DATA;
+    TPROJ_59_mem_AAV_dout_nent  : out t_arr_TPROJ_59_NENT;
+    TPAR_70_mem_A_enb          : in t_arr_TPAR_70_1b;
+    TPAR_70_mem_AV_readaddr    : in t_arr_TPAR_70_ADDR;
+    TPAR_70_mem_AV_dout        : out t_arr_TPAR_70_DATA;
+    TPAR_70_mem_AAV_dout_nent  : out t_arr_TPAR_70_NENT
+  );
+end SectorProcessorFull;
+
+architecture rtl of SectorProcessorFull is
+
+  signal AS_36_mem_A_enb          : t_arr_AS_36_1b;
+  signal AS_36_mem_AV_readaddr    : t_arr_AS_36_ADDR;
+  signal AS_36_mem_AV_dout        : t_arr_AS_36_DATA;
+  signal VMSTE_22_mem_A_enb          : t_arr_VMSTE_22_1b;
+  signal VMSTE_22_mem_AV_readaddr    : t_arr_VMSTE_22_ADDR;
+  signal VMSTE_22_mem_AV_dout        : t_arr_VMSTE_22_DATA;
+  signal VMSTE_22_mem_AAV_dout_nent  : t_arr_VMSTE_22_NENT; -- (#page)
+  signal VMSTE_16_mem_A_enb          : t_arr_VMSTE_16_1b;
+  signal VMSTE_16_mem_AV_readaddr    : t_arr_VMSTE_16_ADDR;
+  signal VMSTE_16_mem_AV_dout        : t_arr_VMSTE_16_DATA;
+  signal VMSTE_16_mem_AAAV_dout_nent : t_arr_VMSTE_16_NENT; -- (#page)(#bin)
+  signal SP_14_mem_A_enb          : t_arr_SP_14_1b;
+  signal SP_14_mem_AV_readaddr    : t_arr_SP_14_ADDR;
+  signal SP_14_mem_AV_dout        : t_arr_SP_14_DATA;
+  signal SP_14_mem_AAV_dout_nent  : t_arr_SP_14_NENT; -- (#page)
+  signal TPROJ_60_mem_A_wea          : t_arr_TPROJ_60_1b;
+  signal TPROJ_60_mem_AV_writeaddr   : t_arr_TPROJ_60_ADDR;
+  signal TPROJ_60_mem_AV_din         : t_arr_TPROJ_60_DATA;
+  signal TPROJ_58_mem_A_wea          : t_arr_TPROJ_58_1b;
+  signal TPROJ_58_mem_AV_writeaddr   : t_arr_TPROJ_58_ADDR;
+  signal TPROJ_58_mem_AV_din         : t_arr_TPROJ_58_DATA;
+  signal TPROJ_59_mem_A_wea          : t_arr_TPROJ_59_1b;
+  signal TPROJ_59_mem_AV_writeaddr   : t_arr_TPROJ_59_ADDR;
+  signal TPROJ_59_mem_AV_din         : t_arr_TPROJ_59_DATA;
+  signal TPAR_70_mem_A_wea          : t_arr_TPAR_70_1b;
+  signal TPAR_70_mem_AV_writeaddr   : t_arr_TPAR_70_ADDR;
+  signal TPAR_70_mem_AV_din         : t_arr_TPAR_70_DATA;
+  signal TC_start : std_logic := '0';
+  signal TE_L1PHIC12_L2PHIB10_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB10_bendinnertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB10_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB10_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB10_bendoutertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB10_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB11_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB11_bendinnertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB11_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB11_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB11_bendoutertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB11_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB12_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB12_bendinnertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB12_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB12_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB12_bendoutertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB12_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB13_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB13_bendinnertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB13_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB13_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB13_bendoutertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB13_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB14_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB14_bendinnertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB14_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHIC12_L2PHIB14_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHIC12_L2PHIB14_bendoutertable_ce       : std_logic;
+  signal TE_L1PHIC12_L2PHIB14_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB11_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB11_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB11_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB11_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB11_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB11_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB12_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB12_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB12_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB12_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB12_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB12_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB13_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB13_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB13_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB13_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB13_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB13_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB14_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB14_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB14_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB14_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB14_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB14_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB15_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB15_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB15_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID13_L2PHIB15_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID13_L2PHIB15_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID13_L2PHIB15_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB12_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB12_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB12_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB12_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB12_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB12_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB13_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB13_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB13_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB13_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB13_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB13_bendoutertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB14_bendinnertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB14_bendinnertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB14_bendinnertable_dout : std_logic_vector(0 downto 0);
+  signal TE_L1PHID14_L2PHIB14_bendoutertable_addr       : std_logic_vector(7 downto 0);
+  signal TE_L1PHID14_L2PHIB14_bendoutertable_ce       : std_logic;
+  signal TE_L1PHID14_L2PHIB14_bendoutertable_dout : std_logic_vector(0 downto 0);
+
+begin
+
+  AS_36_loop : for var in enum_AS_36 generate
+  begin
+
+    AS_36 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 36,
+        NUM_PAGES       => 8,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => AS_36_mem_A_wea(var),
+        addra     => AS_36_mem_AV_writeaddr(var),
+        dina      => AS_36_mem_AV_din(var),
+        clkb      => clk,
+        enb       => AS_36_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => AS_36_mem_AV_readaddr(var),
+        doutb     => AS_36_mem_AV_dout(var),
+        sync_nent => TC_start,
+        nent_o    => open
+      );
+
+  end generate AS_36_loop;
+
+
+  VMSTE_22_loop : for var in enum_VMSTE_22 generate
+  begin
+
+    VMSTE_22 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 22,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => VMSTE_22_mem_A_wea(var),
+        addra     => VMSTE_22_mem_AV_writeaddr(var),
+        dina      => VMSTE_22_mem_AV_din(var),
+        clkb      => clk,
+        enb       => VMSTE_22_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => VMSTE_22_mem_AV_readaddr(var),
+        doutb     => VMSTE_22_mem_AV_dout(var),
+        sync_nent => TE_start,
+        nent_o    => VMSTE_22_mem_AAV_dout_nent(var)
+      );
+
+  end generate VMSTE_22_loop;
+
+
+  VMSTE_16_loop : for var in enum_VMSTE_16 generate
+  begin
+
+    VMSTE_16 : entity work.tf_mem_bin
+      generic map (
+        RAM_WIDTH       => 16,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => VMSTE_16_mem_A_wea(var),
+        addra     => VMSTE_16_mem_AV_writeaddr(var),
+        dina      => VMSTE_16_mem_AV_din(var),
+        clkb      => clk,
+        enb       => VMSTE_16_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => VMSTE_16_mem_AV_readaddr(var),
+        doutb     => VMSTE_16_mem_AV_dout(var),
+        sync_nent => TE_start,
+        nent_o    => VMSTE_16_mem_AAAV_dout_nent(var)
+      );
+
+  end generate VMSTE_16_loop;
+
+
+  SP_14_loop : for var in enum_SP_14 generate
+  begin
+
+    SP_14 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 14,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => SP_14_mem_A_wea(var),
+        addra     => SP_14_mem_AV_writeaddr(var),
+        dina      => SP_14_mem_AV_din(var),
+        clkb      => clk,
+        enb       => SP_14_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => SP_14_mem_AV_readaddr(var),
+        doutb     => SP_14_mem_AV_dout(var),
+        sync_nent => TC_start,
+        nent_o    => SP_14_mem_AAV_dout_nent(var)
+      );
+
+  end generate SP_14_loop;
+
+
+  TPROJ_60_loop : for var in enum_TPROJ_60 generate
+  begin
+
+    TPROJ_60 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 60,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => TPROJ_60_mem_A_wea(var),
+        addra     => TPROJ_60_mem_AV_writeaddr(var),
+        dina      => TPROJ_60_mem_AV_din(var),
+        clkb      => clk,
+        enb       => TPROJ_60_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => TPROJ_60_mem_AV_readaddr(var),
+        doutb     => TPROJ_60_mem_AV_dout(var),
+        sync_nent => TC_done,
+        nent_o    => TPROJ_60_mem_AAV_dout_nent(var)
+      );
+
+  end generate TPROJ_60_loop;
+
+
+  TPROJ_58_loop : for var in enum_TPROJ_58 generate
+  begin
+
+    TPROJ_58 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 58,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => TPROJ_58_mem_A_wea(var),
+        addra     => TPROJ_58_mem_AV_writeaddr(var),
+        dina      => TPROJ_58_mem_AV_din(var),
+        clkb      => clk,
+        enb       => TPROJ_58_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => TPROJ_58_mem_AV_readaddr(var),
+        doutb     => TPROJ_58_mem_AV_dout(var),
+        sync_nent => TC_done,
+        nent_o    => TPROJ_58_mem_AAV_dout_nent(var)
+      );
+
+  end generate TPROJ_58_loop;
+
+
+  TPROJ_59_loop : for var in enum_TPROJ_59 generate
+  begin
+
+    TPROJ_59 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 59,
+        NUM_PAGES       => 2,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => TPROJ_59_mem_A_wea(var),
+        addra     => TPROJ_59_mem_AV_writeaddr(var),
+        dina      => TPROJ_59_mem_AV_din(var),
+        clkb      => clk,
+        enb       => TPROJ_59_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => TPROJ_59_mem_AV_readaddr(var),
+        doutb     => TPROJ_59_mem_AV_dout(var),
+        sync_nent => TC_done,
+        nent_o    => TPROJ_59_mem_AAV_dout_nent(var)
+      );
+
+  end generate TPROJ_59_loop;
+
+
+  TPAR_70_loop : for var in enum_TPAR_70 generate
+  begin
+
+    TPAR_70 : entity work.tf_mem
+      generic map (
+        RAM_WIDTH       => 70,
+        NUM_PAGES       => 8,
+        INIT_FILE       => "",
+        INIT_HEX        => true,
+        RAM_PERFORMANCE => "HIGH_PERFORMANCE"
+      )
+      port map (
+        clka      => clk,
+        wea       => TPAR_70_mem_A_wea(var),
+        addra     => TPAR_70_mem_AV_writeaddr(var),
+        dina      => TPAR_70_mem_AV_din(var),
+        clkb      => clk,
+        enb       => TPAR_70_mem_A_enb(var),
+        rstb      => '0',
+        regceb    => '1',
+        addrb     => TPAR_70_mem_AV_readaddr(var),
+        doutb     => TPAR_70_mem_AV_dout(var),
+        sync_nent => TC_done,
+        nent_o    => TPAR_70_mem_AAV_dout_nent(var)
+      );
+
+  end generate TPAR_70_loop;
+
+
+
+  TE_L1PHIC12_L2PHIB10_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB10_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB10_bendinnertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB10_bendinnertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB10_bendinnertable_dout
+  );
+
+
+  TE_L1PHIC12_L2PHIB10_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB10_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB10_bendoutertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB10_bendoutertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB10_bendoutertable_dout
+  );
+
+  TC_start <= '1' when TE_done = '1';
+
+  TE_L1PHIC12_L2PHIB10 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => TE_done,
+      bx_V          => TE_bx_in,
+      bx_o_V        => TE_bx_out,
+      bx_o_V_ap_vld => TE_bx_out_vld,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHIC12n1),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHIC12n1),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHIC12n1),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n1)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n1)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB10n5),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB10n5),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB10n5),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB10n5)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHIC12_L2PHIB10_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHIC12_L2PHIB10_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHIC12_L2PHIB10_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHIC12_L2PHIB10_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHIC12_L2PHIB10_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHIC12_L2PHIB10_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHIC12_L2PHIB10),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHIC12_L2PHIB10),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHIC12_L2PHIB10)
+  );
+
+
+  TE_L1PHIC12_L2PHIB11_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB11_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB11_bendinnertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB11_bendinnertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB11_bendinnertable_dout
+  );
+
+
+  TE_L1PHIC12_L2PHIB11_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB11_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB11_bendoutertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB11_bendoutertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB11_bendoutertable_dout
+  );
+
+  TE_L1PHIC12_L2PHIB11 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHIC12n2),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHIC12n2),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHIC12n2),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n2)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n2)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB11n4),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB11n4),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB11n4),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n4)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHIC12_L2PHIB11_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHIC12_L2PHIB11_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHIC12_L2PHIB11_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHIC12_L2PHIB11_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHIC12_L2PHIB11_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHIC12_L2PHIB11_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHIC12_L2PHIB11),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHIC12_L2PHIB11),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHIC12_L2PHIB11)
+  );
+
+
+  TE_L1PHIC12_L2PHIB12_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB12_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB12_bendinnertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB12_bendinnertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB12_bendinnertable_dout
+  );
+
+
+  TE_L1PHIC12_L2PHIB12_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB12_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB12_bendoutertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB12_bendoutertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB12_bendoutertable_dout
+  );
+
+  TE_L1PHIC12_L2PHIB12 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHIC12n3),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHIC12n3),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHIC12n3),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n3)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n3)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB12n3),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB12n3),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB12n3),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n3)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHIC12_L2PHIB12_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHIC12_L2PHIB12_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHIC12_L2PHIB12_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHIC12_L2PHIB12_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHIC12_L2PHIB12_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHIC12_L2PHIB12_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHIC12_L2PHIB12),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHIC12_L2PHIB12),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHIC12_L2PHIB12)
+  );
+
+
+  TE_L1PHIC12_L2PHIB13_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB13_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB13_bendinnertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB13_bendinnertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB13_bendinnertable_dout
+  );
+
+
+  TE_L1PHIC12_L2PHIB13_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB13_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB13_bendoutertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB13_bendoutertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB13_bendoutertable_dout
+  );
+
+  TE_L1PHIC12_L2PHIB13 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHIC12n4),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHIC12n4),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHIC12n4),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n4)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n4)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB13n2),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB13n2),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB13n2),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n2)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHIC12_L2PHIB13_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHIC12_L2PHIB13_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHIC12_L2PHIB13_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHIC12_L2PHIB13_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHIC12_L2PHIB13_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHIC12_L2PHIB13_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHIC12_L2PHIB13),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHIC12_L2PHIB13),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHIC12_L2PHIB13)
+  );
+
+
+  TE_L1PHIC12_L2PHIB14_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB14_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB14_bendinnertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB14_bendinnertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB14_bendinnertable_dout
+  );
+
+
+  TE_L1PHIC12_L2PHIB14_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB14_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHIC12_L2PHIB14_bendoutertable_addr,
+      ce        => TE_L1PHIC12_L2PHIB14_bendoutertable_ce,
+      dout      => TE_L1PHIC12_L2PHIB14_bendoutertable_dout
+  );
+
+  TE_L1PHIC12_L2PHIB14 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHIC12n5),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHIC12n5),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHIC12n5),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n5)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHIC12n5)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB14n1),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB14n1),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB14n1),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n1)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHIC12_L2PHIB14_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHIC12_L2PHIB14_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHIC12_L2PHIB14_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHIC12_L2PHIB14_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHIC12_L2PHIB14_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHIC12_L2PHIB14_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHIC12_L2PHIB14),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHIC12_L2PHIB14),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHIC12_L2PHIB14)
+  );
+
+
+  TE_L1PHID13_L2PHIB11_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB11_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB11_bendinnertable_addr,
+      ce        => TE_L1PHID13_L2PHIB11_bendinnertable_ce,
+      dout      => TE_L1PHID13_L2PHIB11_bendinnertable_dout
+  );
+
+
+  TE_L1PHID13_L2PHIB11_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB11_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB11_bendoutertable_addr,
+      ce        => TE_L1PHID13_L2PHIB11_bendoutertable_ce,
+      dout      => TE_L1PHID13_L2PHIB11_bendoutertable_dout
+  );
+
+  TE_L1PHID13_L2PHIB11 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID13n1),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID13n1),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID13n1),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n1)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n1)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB11n5),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB11n5),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB11n5),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB11n5)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID13_L2PHIB11_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID13_L2PHIB11_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID13_L2PHIB11_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID13_L2PHIB11_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID13_L2PHIB11_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID13_L2PHIB11_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID13_L2PHIB11),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID13_L2PHIB11),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID13_L2PHIB11)
+  );
+
+
+  TE_L1PHID13_L2PHIB12_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB12_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB12_bendinnertable_addr,
+      ce        => TE_L1PHID13_L2PHIB12_bendinnertable_ce,
+      dout      => TE_L1PHID13_L2PHIB12_bendinnertable_dout
+  );
+
+
+  TE_L1PHID13_L2PHIB12_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB12_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB12_bendoutertable_addr,
+      ce        => TE_L1PHID13_L2PHIB12_bendoutertable_ce,
+      dout      => TE_L1PHID13_L2PHIB12_bendoutertable_dout
+  );
+
+  TE_L1PHID13_L2PHIB12 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID13n2),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID13n2),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID13n2),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n2)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n2)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB12n4),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB12n4),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB12n4),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n4)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID13_L2PHIB12_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID13_L2PHIB12_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID13_L2PHIB12_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID13_L2PHIB12_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID13_L2PHIB12_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID13_L2PHIB12_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID13_L2PHIB12),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID13_L2PHIB12),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID13_L2PHIB12)
+  );
+
+
+  TE_L1PHID13_L2PHIB13_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB13_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB13_bendinnertable_addr,
+      ce        => TE_L1PHID13_L2PHIB13_bendinnertable_ce,
+      dout      => TE_L1PHID13_L2PHIB13_bendinnertable_dout
+  );
+
+
+  TE_L1PHID13_L2PHIB13_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB13_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB13_bendoutertable_addr,
+      ce        => TE_L1PHID13_L2PHIB13_bendoutertable_ce,
+      dout      => TE_L1PHID13_L2PHIB13_bendoutertable_dout
+  );
+
+  TE_L1PHID13_L2PHIB13 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID13n3),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID13n3),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID13n3),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n3)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n3)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB13n3),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB13n3),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB13n3),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n3)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID13_L2PHIB13_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID13_L2PHIB13_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID13_L2PHIB13_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID13_L2PHIB13_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID13_L2PHIB13_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID13_L2PHIB13_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID13_L2PHIB13),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID13_L2PHIB13),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID13_L2PHIB13)
+  );
+
+
+  TE_L1PHID13_L2PHIB14_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB14_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB14_bendinnertable_addr,
+      ce        => TE_L1PHID13_L2PHIB14_bendinnertable_ce,
+      dout      => TE_L1PHID13_L2PHIB14_bendinnertable_dout
+  );
+
+
+  TE_L1PHID13_L2PHIB14_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB14_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB14_bendoutertable_addr,
+      ce        => TE_L1PHID13_L2PHIB14_bendoutertable_ce,
+      dout      => TE_L1PHID13_L2PHIB14_bendoutertable_dout
+  );
+
+  TE_L1PHID13_L2PHIB14 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID13n4),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID13n4),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID13n4),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n4)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n4)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB14n2),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB14n2),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB14n2),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n2)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID13_L2PHIB14_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID13_L2PHIB14_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID13_L2PHIB14_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID13_L2PHIB14_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID13_L2PHIB14_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID13_L2PHIB14_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID13_L2PHIB14),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID13_L2PHIB14),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID13_L2PHIB14)
+  );
+
+
+  TE_L1PHID13_L2PHIB15_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB15_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB15_bendinnertable_addr,
+      ce        => TE_L1PHID13_L2PHIB15_bendinnertable_ce,
+      dout      => TE_L1PHID13_L2PHIB15_bendinnertable_dout
+  );
+
+
+  TE_L1PHID13_L2PHIB15_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB15_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID13_L2PHIB15_bendoutertable_addr,
+      ce        => TE_L1PHID13_L2PHIB15_bendoutertable_ce,
+      dout      => TE_L1PHID13_L2PHIB15_bendoutertable_dout
+  );
+
+  TE_L1PHID13_L2PHIB15 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID13n5),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID13n5),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID13n5),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n5)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID13n5)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB15n1),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB15n1),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB15n1),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB15n1)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID13_L2PHIB15_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID13_L2PHIB15_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID13_L2PHIB15_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID13_L2PHIB15_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID13_L2PHIB15_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID13_L2PHIB15_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID13_L2PHIB15),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID13_L2PHIB15),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID13_L2PHIB15)
+  );
+
+
+  TE_L1PHID14_L2PHIB12_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB12_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB12_bendinnertable_addr,
+      ce        => TE_L1PHID14_L2PHIB12_bendinnertable_ce,
+      dout      => TE_L1PHID14_L2PHIB12_bendinnertable_dout
+  );
+
+
+  TE_L1PHID14_L2PHIB12_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB12_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB12_bendoutertable_addr,
+      ce        => TE_L1PHID14_L2PHIB12_bendoutertable_ce,
+      dout      => TE_L1PHID14_L2PHIB12_bendoutertable_dout
+  );
+
+  TE_L1PHID14_L2PHIB12 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID14n1),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID14n1),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID14n1),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n1)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n1)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB12n5),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB12n5),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB12n5),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB12n5)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID14_L2PHIB12_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID14_L2PHIB12_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID14_L2PHIB12_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID14_L2PHIB12_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID14_L2PHIB12_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID14_L2PHIB12_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID14_L2PHIB12),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID14_L2PHIB12),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID14_L2PHIB12)
+  );
+
+
+  TE_L1PHID14_L2PHIB13_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB13_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB13_bendinnertable_addr,
+      ce        => TE_L1PHID14_L2PHIB13_bendinnertable_ce,
+      dout      => TE_L1PHID14_L2PHIB13_bendinnertable_dout
+  );
+
+
+  TE_L1PHID14_L2PHIB13_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB13_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB13_bendoutertable_addr,
+      ce        => TE_L1PHID14_L2PHIB13_bendoutertable_ce,
+      dout      => TE_L1PHID14_L2PHIB13_bendoutertable_dout
+  );
+
+  TE_L1PHID14_L2PHIB13 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID14n2),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID14n2),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID14n2),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n2)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n2)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB13n4),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB13n4),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB13n4),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB13n4)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID14_L2PHIB13_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID14_L2PHIB13_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID14_L2PHIB13_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID14_L2PHIB13_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID14_L2PHIB13_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID14_L2PHIB13_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID14_L2PHIB13),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID14_L2PHIB13),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID14_L2PHIB13)
+  );
+
+
+  TE_L1PHID14_L2PHIB14_bendinnertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB14_stubptinnercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB14_bendinnertable_addr,
+      ce        => TE_L1PHID14_L2PHIB14_bendinnertable_ce,
+      dout      => TE_L1PHID14_L2PHIB14_bendinnertable_dout
+  );
+
+
+  TE_L1PHID14_L2PHIB14_bendoutertable : entity work.tf_lut
+    generic map (
+      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB14_stubptoutercut.tab",
+      lut_width => 1,
+      lut_depth => 256
+    )
+    port map (
+      clk       => clk,
+      addr      => TE_L1PHID14_L2PHIB14_bendoutertable_addr,
+      ce        => TE_L1PHID14_L2PHIB14_bendoutertable_ce,
+      dout      => TE_L1PHID14_L2PHIB14_bendoutertable_dout
+  );
+
+  TE_L1PHID14_L2PHIB14 : entity work.TE_L1L2
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TE_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => open,
+      bx_V          => TE_bx_in,
+      instubinnerdata_dataarray_data_V_ce0       => VMSTE_22_mem_A_enb(L1PHID14n3),
+      instubinnerdata_dataarray_data_V_address0  => VMSTE_22_mem_AV_readaddr(L1PHID14n3),
+      instubinnerdata_dataarray_data_V_q0        => VMSTE_22_mem_AV_dout(L1PHID14n3),
+      instubinnerdata_nentries_0_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n3)(0),
+      instubinnerdata_nentries_1_V               => VMSTE_22_mem_AAV_dout_nent(L1PHID14n3)(1),
+      instubouterdata_dataarray_data_V_ce0       => VMSTE_16_mem_A_enb(L2PHIB14n3),
+      instubouterdata_dataarray_data_V_address0  => VMSTE_16_mem_AV_readaddr(L2PHIB14n3),
+      instubouterdata_dataarray_data_V_q0        => VMSTE_16_mem_AV_dout(L2PHIB14n3),
+      instubouterdata_nentries_0_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(0),
+      instubouterdata_nentries_0_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(1),
+      instubouterdata_nentries_0_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(2),
+      instubouterdata_nentries_0_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(3),
+      instubouterdata_nentries_0_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(4),
+      instubouterdata_nentries_0_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(5),
+      instubouterdata_nentries_0_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(6),
+      instubouterdata_nentries_0_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(0)(7),
+      instubouterdata_nentries_1_V_0     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(0),
+      instubouterdata_nentries_1_V_1     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(1),
+      instubouterdata_nentries_1_V_2     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(2),
+      instubouterdata_nentries_1_V_3     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(3),
+      instubouterdata_nentries_1_V_4     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(4),
+      instubouterdata_nentries_1_V_5     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(5),
+      instubouterdata_nentries_1_V_6     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(6),
+      instubouterdata_nentries_1_V_7     => VMSTE_16_mem_AAAV_dout_nent(L2PHIB14n3)(1)(7),
+      bendinnertable_V_address0                  => TE_L1PHID14_L2PHIB14_bendinnertable_addr,
+      bendinnertable_V_ce0                       => TE_L1PHID14_L2PHIB14_bendinnertable_ce,
+      bendinnertable_V_q0                        => TE_L1PHID14_L2PHIB14_bendinnertable_dout,
+      bendoutertable_V_address0                  => TE_L1PHID14_L2PHIB14_bendoutertable_addr,
+      bendoutertable_V_ce0                       => TE_L1PHID14_L2PHIB14_bendoutertable_ce,
+      bendoutertable_V_q0                        => TE_L1PHID14_L2PHIB14_bendoutertable_dout,
+      outstubpair_dataarray_data_V_ce0       => open,
+      outstubpair_dataarray_data_V_we0       => SP_14_mem_A_wea(L1PHID14_L2PHIB14),
+      outstubpair_dataarray_data_V_address0  => SP_14_mem_AV_writeaddr(L1PHID14_L2PHIB14),
+      outstubpair_dataarray_data_V_d0        => SP_14_mem_AV_din(L1PHID14_L2PHIB14)
+  );
+
+  TC_L1L2E : entity work.TC_L1L2E
+    port map (
+      ap_clk   => clk,
+      ap_rst   => reset,
+      ap_start => TC_start,
+      ap_idle  => open,
+      ap_ready => open,
+      ap_done  => TC_done,
+      bx_V          => TE_bx_out,
+      bx_o_V        => TC_bx_out,
+      bx_o_V_ap_vld => TC_bx_out_vld,
+      innerStubs_0_dataarray_data_V_ce0       => AS_36_mem_A_enb(L1PHICn4),
+      innerStubs_0_dataarray_data_V_address0  => AS_36_mem_AV_readaddr(L1PHICn4),
+      innerStubs_0_dataarray_data_V_q0        => AS_36_mem_AV_dout(L1PHICn4),
+      innerStubs_1_dataarray_data_V_ce0       => AS_36_mem_A_enb(L1PHIDn2),
+      innerStubs_1_dataarray_data_V_address0  => AS_36_mem_AV_readaddr(L1PHIDn2),
+      innerStubs_1_dataarray_data_V_q0        => AS_36_mem_AV_dout(L1PHIDn2),
+      outerStubs_0_dataarray_data_V_ce0       => AS_36_mem_A_enb(L2PHIBn4),
+      outerStubs_0_dataarray_data_V_address0  => AS_36_mem_AV_readaddr(L2PHIBn4),
+      outerStubs_0_dataarray_data_V_q0        => AS_36_mem_AV_dout(L2PHIBn4),
+      stubPairs_0_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHIC12_L2PHIB10),
+      stubPairs_0_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHIC12_L2PHIB10),
+      stubPairs_0_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHIC12_L2PHIB10),
+      stubPairs_0_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB10)(0),
+      stubPairs_0_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB10)(1),
+      stubPairs_1_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHIC12_L2PHIB11),
+      stubPairs_1_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHIC12_L2PHIB11),
+      stubPairs_1_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHIC12_L2PHIB11),
+      stubPairs_1_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB11)(0),
+      stubPairs_1_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB11)(1),
+      stubPairs_2_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHIC12_L2PHIB12),
+      stubPairs_2_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHIC12_L2PHIB12),
+      stubPairs_2_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHIC12_L2PHIB12),
+      stubPairs_2_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB12)(0),
+      stubPairs_2_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB12)(1),
+      stubPairs_3_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHIC12_L2PHIB13),
+      stubPairs_3_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHIC12_L2PHIB13),
+      stubPairs_3_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHIC12_L2PHIB13),
+      stubPairs_3_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB13)(0),
+      stubPairs_3_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB13)(1),
+      stubPairs_4_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHIC12_L2PHIB14),
+      stubPairs_4_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHIC12_L2PHIB14),
+      stubPairs_4_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHIC12_L2PHIB14),
+      stubPairs_4_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB14)(0),
+      stubPairs_4_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHIC12_L2PHIB14)(1),
+      stubPairs_5_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID13_L2PHIB11),
+      stubPairs_5_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID13_L2PHIB11),
+      stubPairs_5_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID13_L2PHIB11),
+      stubPairs_5_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB11)(0),
+      stubPairs_5_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB11)(1),
+      stubPairs_6_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID13_L2PHIB12),
+      stubPairs_6_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID13_L2PHIB12),
+      stubPairs_6_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID13_L2PHIB12),
+      stubPairs_6_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB12)(0),
+      stubPairs_6_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB12)(1),
+      stubPairs_7_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID13_L2PHIB13),
+      stubPairs_7_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID13_L2PHIB13),
+      stubPairs_7_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID13_L2PHIB13),
+      stubPairs_7_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB13)(0),
+      stubPairs_7_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB13)(1),
+      stubPairs_8_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID13_L2PHIB14),
+      stubPairs_8_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID13_L2PHIB14),
+      stubPairs_8_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID13_L2PHIB14),
+      stubPairs_8_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB14)(0),
+      stubPairs_8_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB14)(1),
+      stubPairs_9_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID13_L2PHIB15),
+      stubPairs_9_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID13_L2PHIB15),
+      stubPairs_9_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID13_L2PHIB15),
+      stubPairs_9_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB15)(0),
+      stubPairs_9_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID13_L2PHIB15)(1),
+      stubPairs_10_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID14_L2PHIB12),
+      stubPairs_10_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID14_L2PHIB12),
+      stubPairs_10_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID14_L2PHIB12),
+      stubPairs_10_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB12)(0),
+      stubPairs_10_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB12)(1),
+      stubPairs_11_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID14_L2PHIB13),
+      stubPairs_11_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID14_L2PHIB13),
+      stubPairs_11_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID14_L2PHIB13),
+      stubPairs_11_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB13)(0),
+      stubPairs_11_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB13)(1),
+      stubPairs_12_dataarray_data_V_ce0       => SP_14_mem_A_enb(L1PHID14_L2PHIB14),
+      stubPairs_12_dataarray_data_V_address0  => SP_14_mem_AV_readaddr(L1PHID14_L2PHIB14),
+      stubPairs_12_dataarray_data_V_q0        => SP_14_mem_AV_dout(L1PHID14_L2PHIB14),
+      stubPairs_12_nentries_0_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB14)(0),
+      stubPairs_12_nentries_1_V               => SP_14_mem_AAV_dout_nent(L1PHID14_L2PHIB14)(1),
+      trackletParameters_dataarray_data_V_ce0       => open,
+      trackletParameters_dataarray_data_V_we0       => TPAR_70_mem_A_wea(L1L2E),
+      trackletParameters_dataarray_data_V_address0  => TPAR_70_mem_AV_writeaddr(L1L2E),
+      trackletParameters_dataarray_data_V_d0        => TPAR_70_mem_AV_din(L1L2E),
+      projout_barrel_ps_13_dataarray_data_V_ce0       => open,
+      projout_barrel_ps_13_dataarray_data_V_we0       => TPROJ_60_mem_A_wea(L1L2E_L3PHIB),
+      projout_barrel_ps_13_dataarray_data_V_address0  => TPROJ_60_mem_AV_writeaddr(L1L2E_L3PHIB),
+      projout_barrel_ps_13_dataarray_data_V_d0        => TPROJ_60_mem_AV_din(L1L2E_L3PHIB),
+      projout_barrel_2s_0_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_0_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L4PHIA),
+      projout_barrel_2s_0_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L4PHIA),
+      projout_barrel_2s_0_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L4PHIA),
+      projout_barrel_2s_1_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_1_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L4PHIB),
+      projout_barrel_2s_1_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L4PHIB),
+      projout_barrel_2s_1_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L4PHIB),
+      projout_barrel_2s_2_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_2_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L4PHIC),
+      projout_barrel_2s_2_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L4PHIC),
+      projout_barrel_2s_2_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L4PHIC),
+      projout_barrel_2s_4_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_4_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L5PHIA),
+      projout_barrel_2s_4_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L5PHIA),
+      projout_barrel_2s_4_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L5PHIA),
+      projout_barrel_2s_5_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_5_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L5PHIB),
+      projout_barrel_2s_5_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L5PHIB),
+      projout_barrel_2s_5_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L5PHIB),
+      projout_barrel_2s_6_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_6_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L5PHIC),
+      projout_barrel_2s_6_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L5PHIC),
+      projout_barrel_2s_6_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L5PHIC),
+      projout_barrel_2s_8_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_8_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L6PHIA),
+      projout_barrel_2s_8_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L6PHIA),
+      projout_barrel_2s_8_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L6PHIA),
+      projout_barrel_2s_9_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_9_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L6PHIB),
+      projout_barrel_2s_9_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L6PHIB),
+      projout_barrel_2s_9_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L6PHIB),
+      projout_barrel_2s_10_dataarray_data_V_ce0       => open,
+      projout_barrel_2s_10_dataarray_data_V_we0       => TPROJ_58_mem_A_wea(L1L2E_L6PHIC),
+      projout_barrel_2s_10_dataarray_data_V_address0  => TPROJ_58_mem_AV_writeaddr(L1L2E_L6PHIC),
+      projout_barrel_2s_10_dataarray_data_V_d0        => TPROJ_58_mem_AV_din(L1L2E_L6PHIC),
+      projout_disk_0_dataarray_data_V_ce0       => open,
+      projout_disk_0_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D1PHIA),
+      projout_disk_0_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D1PHIA),
+      projout_disk_0_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D1PHIA),
+      projout_disk_1_dataarray_data_V_ce0       => open,
+      projout_disk_1_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D1PHIB),
+      projout_disk_1_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D1PHIB),
+      projout_disk_1_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D1PHIB),
+      projout_disk_2_dataarray_data_V_ce0       => open,
+      projout_disk_2_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D1PHIC),
+      projout_disk_2_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D1PHIC),
+      projout_disk_2_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D1PHIC),
+      projout_disk_4_dataarray_data_V_ce0       => open,
+      projout_disk_4_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D2PHIA),
+      projout_disk_4_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D2PHIA),
+      projout_disk_4_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D2PHIA),
+      projout_disk_5_dataarray_data_V_ce0       => open,
+      projout_disk_5_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D2PHIB),
+      projout_disk_5_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D2PHIB),
+      projout_disk_5_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D2PHIB),
+      projout_disk_6_dataarray_data_V_ce0       => open,
+      projout_disk_6_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D2PHIC),
+      projout_disk_6_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D2PHIC),
+      projout_disk_6_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D2PHIC),
+      projout_disk_8_dataarray_data_V_ce0       => open,
+      projout_disk_8_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D3PHIA),
+      projout_disk_8_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D3PHIA),
+      projout_disk_8_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D3PHIA),
+      projout_disk_9_dataarray_data_V_ce0       => open,
+      projout_disk_9_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D3PHIB),
+      projout_disk_9_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D3PHIB),
+      projout_disk_9_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D3PHIB),
+      projout_disk_10_dataarray_data_V_ce0       => open,
+      projout_disk_10_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D3PHIC),
+      projout_disk_10_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D3PHIC),
+      projout_disk_10_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D3PHIC),
+      projout_disk_12_dataarray_data_V_ce0       => open,
+      projout_disk_12_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D4PHIA),
+      projout_disk_12_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D4PHIA),
+      projout_disk_12_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D4PHIA),
+      projout_disk_13_dataarray_data_V_ce0       => open,
+      projout_disk_13_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D4PHIB),
+      projout_disk_13_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D4PHIB),
+      projout_disk_13_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D4PHIB),
+      projout_disk_14_dataarray_data_V_ce0       => open,
+      projout_disk_14_dataarray_data_V_we0       => TPROJ_59_mem_A_wea(L1L2E_D4PHIC),
+      projout_disk_14_dataarray_data_V_address0  => TPROJ_59_mem_AV_writeaddr(L1L2E_D4PHIC),
+      projout_disk_14_dataarray_data_V_d0        => TPROJ_59_mem_AV_din(L1L2E_D4PHIC)
+  );
+
+
+
+end rtl;

--- a/IntegrationTests/TETC/hdl/SectorProcessorFull.vhd
+++ b/IntegrationTests/TETC/hdl/SectorProcessorFull.vhd
@@ -394,7 +394,7 @@ begin
 
   TE_L1PHIC12_L2PHIB10_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB10_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB10_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -408,7 +408,7 @@ begin
 
   TE_L1PHIC12_L2PHIB10_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB10_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB10_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -471,7 +471,7 @@ begin
 
   TE_L1PHIC12_L2PHIB11_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB11_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB11_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -485,7 +485,7 @@ begin
 
   TE_L1PHIC12_L2PHIB11_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB11_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB11_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -544,7 +544,7 @@ begin
 
   TE_L1PHIC12_L2PHIB12_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB12_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB12_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -558,7 +558,7 @@ begin
 
   TE_L1PHIC12_L2PHIB12_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB12_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB12_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -617,7 +617,7 @@ begin
 
   TE_L1PHIC12_L2PHIB13_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB13_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB13_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -631,7 +631,7 @@ begin
 
   TE_L1PHIC12_L2PHIB13_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB13_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB13_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -690,7 +690,7 @@ begin
 
   TE_L1PHIC12_L2PHIB14_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB14_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB14_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -704,7 +704,7 @@ begin
 
   TE_L1PHIC12_L2PHIB14_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHIC12_L2PHIB14_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHIC12_L2PHIB14_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -763,7 +763,7 @@ begin
 
   TE_L1PHID13_L2PHIB11_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB11_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB11_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -777,7 +777,7 @@ begin
 
   TE_L1PHID13_L2PHIB11_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB11_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB11_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -836,7 +836,7 @@ begin
 
   TE_L1PHID13_L2PHIB12_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB12_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB12_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -850,7 +850,7 @@ begin
 
   TE_L1PHID13_L2PHIB12_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB12_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB12_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -909,7 +909,7 @@ begin
 
   TE_L1PHID13_L2PHIB13_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB13_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB13_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -923,7 +923,7 @@ begin
 
   TE_L1PHID13_L2PHIB13_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB13_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB13_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -982,7 +982,7 @@ begin
 
   TE_L1PHID13_L2PHIB14_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB14_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB14_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -996,7 +996,7 @@ begin
 
   TE_L1PHID13_L2PHIB14_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB14_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB14_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1055,7 +1055,7 @@ begin
 
   TE_L1PHID13_L2PHIB15_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB15_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB15_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1069,7 +1069,7 @@ begin
 
   TE_L1PHID13_L2PHIB15_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID13_L2PHIB15_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID13_L2PHIB15_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1128,7 +1128,7 @@ begin
 
   TE_L1PHID14_L2PHIB12_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB12_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB12_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1142,7 +1142,7 @@ begin
 
   TE_L1PHID14_L2PHIB12_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB12_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB12_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1201,7 +1201,7 @@ begin
 
   TE_L1PHID14_L2PHIB13_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB13_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB13_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1215,7 +1215,7 @@ begin
 
   TE_L1PHID14_L2PHIB13_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB13_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB13_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1274,7 +1274,7 @@ begin
 
   TE_L1PHID14_L2PHIB14_bendinnertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB14_stubptinnercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB14_stubptinnercut.tab",
       lut_width => 1,
       lut_depth => 256
     )
@@ -1288,7 +1288,7 @@ begin
 
   TE_L1PHID14_L2PHIB14_bendoutertable : entity work.tf_lut
     generic map (
-      lut_file  => "../../../../../../../../emData/LUTs/TE_L1PHID14_L2PHIB14_stubptoutercut.tab",
+      lut_file  => getDirEMDATA & "LUTs/TE_L1PHID14_L2PHIB14_stubptoutercut.tab",
       lut_width => 1,
       lut_depth => 256
     )

--- a/IntegrationTests/TETC/hdl/memUtil_pkg.vhd
+++ b/IntegrationTests/TETC/hdl/memUtil_pkg.vhd
@@ -1,0 +1,199 @@
+--! Standard libraries
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+--! User packages
+use work.tf_pkg.all;
+
+package memUtil_pkg is
+
+  -- ########################### Types ###########################
+
+  type enum_AS_36 is (L1PHICn4,L1PHIDn2,L2PHIBn4);
+
+  type enum_VMSTE_22 is (L1PHIC12n1,L1PHIC12n2,L1PHIC12n3,L1PHIC12n4,L1PHIC12n5,L1PHID13n1,L1PHID13n2,L1PHID13n3,L1PHID13n4,L1PHID13n5,L1PHID14n1,L1PHID14n2,L1PHID14n3);
+
+  type enum_VMSTE_16 is (L2PHIB10n5,L2PHIB11n4,L2PHIB11n5,L2PHIB12n3,L2PHIB12n4,L2PHIB12n5,L2PHIB13n2,L2PHIB13n3,L2PHIB13n4,L2PHIB14n1,L2PHIB14n2,L2PHIB14n3,L2PHIB15n1);
+
+  type enum_SP_14 is (L1PHIC12_L2PHIB10,L1PHIC12_L2PHIB11,L1PHIC12_L2PHIB12,L1PHIC12_L2PHIB13,L1PHIC12_L2PHIB14,L1PHID13_L2PHIB11,L1PHID13_L2PHIB12,L1PHID13_L2PHIB13,L1PHID13_L2PHIB14,L1PHID13_L2PHIB15,L1PHID14_L2PHIB12,L1PHID14_L2PHIB13,L1PHID14_L2PHIB14);
+
+  type enum_TPROJ_60 is (L1L2E_L3PHIB);
+
+  type enum_TPROJ_58 is (L1L2E_L4PHIA,L1L2E_L4PHIB,L1L2E_L4PHIC,L1L2E_L5PHIA,L1L2E_L5PHIB,L1L2E_L5PHIC,L1L2E_L6PHIA,L1L2E_L6PHIB,L1L2E_L6PHIC);
+
+  type enum_TPROJ_59 is (L1L2E_D1PHIA,L1L2E_D1PHIB,L1L2E_D1PHIC,L1L2E_D2PHIA,L1L2E_D2PHIB,L1L2E_D2PHIC,L1L2E_D3PHIA,L1L2E_D3PHIB,L1L2E_D3PHIC,L1L2E_D4PHIA,L1L2E_D4PHIB,L1L2E_D4PHIC);
+
+  type enum_TPAR_70 is (L1L2E);
+
+  type t_arr_AS_36_1b is array(enum_AS_36) of std_logic;
+  type t_arr_AS_36_ADDR is array(enum_AS_36) of std_logic_vector(9 downto 0);
+  type t_arr_AS_36_DATA is array(enum_AS_36) of std_logic_vector(35 downto 0);
+  type t_arr_AS_36_NENT is array(enum_AS_36) of t_arr8_7b;
+  type t_arr_VMSTE_22_1b is array(enum_VMSTE_22) of std_logic;
+  type t_arr_VMSTE_22_ADDR is array(enum_VMSTE_22) of std_logic_vector(7 downto 0);
+  type t_arr_VMSTE_22_DATA is array(enum_VMSTE_22) of std_logic_vector(21 downto 0);
+  type t_arr_VMSTE_22_NENT is array(enum_VMSTE_22) of t_arr2_7b;
+  type t_arr_VMSTE_16_1b is array(enum_VMSTE_16) of std_logic;
+  type t_arr_VMSTE_16_ADDR is array(enum_VMSTE_16) of std_logic_vector(7 downto 0);
+  type t_arr_VMSTE_16_DATA is array(enum_VMSTE_16) of std_logic_vector(15 downto 0);
+  type t_arr_VMSTE_16_NENT is array(enum_VMSTE_16) of t_arr2_8_5b;
+  type t_arr_SP_14_1b is array(enum_SP_14) of std_logic;
+  type t_arr_SP_14_ADDR is array(enum_SP_14) of std_logic_vector(7 downto 0);
+  type t_arr_SP_14_DATA is array(enum_SP_14) of std_logic_vector(13 downto 0);
+  type t_arr_SP_14_NENT is array(enum_SP_14) of t_arr2_7b;
+  type t_arr_TPROJ_60_1b is array(enum_TPROJ_60) of std_logic;
+  type t_arr_TPROJ_60_ADDR is array(enum_TPROJ_60) of std_logic_vector(7 downto 0);
+  type t_arr_TPROJ_60_DATA is array(enum_TPROJ_60) of std_logic_vector(59 downto 0);
+  type t_arr_TPROJ_60_NENT is array(enum_TPROJ_60) of t_arr2_7b;
+  type t_arr_TPROJ_58_1b is array(enum_TPROJ_58) of std_logic;
+  type t_arr_TPROJ_58_ADDR is array(enum_TPROJ_58) of std_logic_vector(7 downto 0);
+  type t_arr_TPROJ_58_DATA is array(enum_TPROJ_58) of std_logic_vector(57 downto 0);
+  type t_arr_TPROJ_58_NENT is array(enum_TPROJ_58) of t_arr2_7b;
+  type t_arr_TPROJ_59_1b is array(enum_TPROJ_59) of std_logic;
+  type t_arr_TPROJ_59_ADDR is array(enum_TPROJ_59) of std_logic_vector(7 downto 0);
+  type t_arr_TPROJ_59_DATA is array(enum_TPROJ_59) of std_logic_vector(58 downto 0);
+  type t_arr_TPROJ_59_NENT is array(enum_TPROJ_59) of t_arr2_7b;
+  type t_arr_TPAR_70_1b is array(enum_TPAR_70) of std_logic;
+  type t_arr_TPAR_70_ADDR is array(enum_TPAR_70) of std_logic_vector(9 downto 0);
+  type t_arr_TPAR_70_DATA is array(enum_TPAR_70) of std_logic_vector(69 downto 0);
+  type t_arr_TPAR_70_NENT is array(enum_TPAR_70) of t_arr8_7b;
+
+  -- ########################### Functions ###########################
+
+  -- Following functions are needed because VHDL doesn't preserve case when converting an enum to a string using image
+  function memory_enum_to_string(val: enum_AS_36) return string;
+  function memory_enum_to_string(val: enum_VMSTE_22) return string;
+  function memory_enum_to_string(val: enum_VMSTE_16) return string;
+  function memory_enum_to_string(val: enum_SP_14) return string;
+  function memory_enum_to_string(val: enum_TPROJ_60) return string;
+  function memory_enum_to_string(val: enum_TPROJ_58) return string;
+  function memory_enum_to_string(val: enum_TPROJ_59) return string;
+  function memory_enum_to_string(val: enum_TPAR_70) return string;
+
+end package memUtil_pkg;
+
+package body memUtil_pkg is
+
+  -- ########################### Functions ###########################
+
+  function memory_enum_to_string(val: enum_AS_36) return string is
+  begin
+    case val is
+       when L1PHICn4 => return "L1PHICn4";
+       when L1PHIDn2 => return "L1PHIDn2";
+       when L2PHIBn4 => return "L2PHIBn4";
+    end case;
+    return "No conversion found.";
+  end memory_enum_to_string;
+
+  function memory_enum_to_string(val: enum_VMSTE_22) return string is
+  begin
+    case val is
+       when L1PHIC12n1 => return "L1PHIC12n1";
+       when L1PHIC12n2 => return "L1PHIC12n2";
+       when L1PHIC12n3 => return "L1PHIC12n3";
+       when L1PHIC12n4 => return "L1PHIC12n4";
+       when L1PHIC12n5 => return "L1PHIC12n5";
+       when L1PHID13n1 => return "L1PHID13n1";
+       when L1PHID13n2 => return "L1PHID13n2";
+       when L1PHID13n3 => return "L1PHID13n3";
+       when L1PHID13n4 => return "L1PHID13n4";
+       when L1PHID13n5 => return "L1PHID13n5";
+       when L1PHID14n1 => return "L1PHID14n1";
+       when L1PHID14n2 => return "L1PHID14n2";
+       when L1PHID14n3 => return "L1PHID14n3";
+    end case;
+    return "No conversion found.";
+  end memory_enum_to_string;
+
+  function memory_enum_to_string(val: enum_VMSTE_16) return string is
+  begin
+    case val is
+       when L2PHIB10n5 => return "L2PHIB10n5";
+       when L2PHIB11n4 => return "L2PHIB11n4";
+       when L2PHIB11n5 => return "L2PHIB11n5";
+       when L2PHIB12n3 => return "L2PHIB12n3";
+       when L2PHIB12n4 => return "L2PHIB12n4";
+       when L2PHIB12n5 => return "L2PHIB12n5";
+       when L2PHIB13n2 => return "L2PHIB13n2";
+       when L2PHIB13n3 => return "L2PHIB13n3";
+       when L2PHIB13n4 => return "L2PHIB13n4";
+       when L2PHIB14n1 => return "L2PHIB14n1";
+       when L2PHIB14n2 => return "L2PHIB14n2";
+       when L2PHIB14n3 => return "L2PHIB14n3";
+       when L2PHIB15n1 => return "L2PHIB15n1";
+    end case;
+    return "No conversion found.";
+  end memory_enum_to_string;
+
+  function memory_enum_to_string(val: enum_SP_14) return string is
+  begin
+    case val is
+       when L1PHIC12_L2PHIB10 => return "L1PHIC12_L2PHIB10";
+       when L1PHIC12_L2PHIB11 => return "L1PHIC12_L2PHIB11";
+       when L1PHIC12_L2PHIB12 => return "L1PHIC12_L2PHIB12";
+       when L1PHIC12_L2PHIB13 => return "L1PHIC12_L2PHIB13";
+       when L1PHIC12_L2PHIB14 => return "L1PHIC12_L2PHIB14";
+       when L1PHID13_L2PHIB11 => return "L1PHID13_L2PHIB11";
+       when L1PHID13_L2PHIB12 => return "L1PHID13_L2PHIB12";
+       when L1PHID13_L2PHIB13 => return "L1PHID13_L2PHIB13";
+       when L1PHID13_L2PHIB14 => return "L1PHID13_L2PHIB14";
+       when L1PHID13_L2PHIB15 => return "L1PHID13_L2PHIB15";
+       when L1PHID14_L2PHIB12 => return "L1PHID14_L2PHIB12";
+       when L1PHID14_L2PHIB13 => return "L1PHID14_L2PHIB13";
+       when L1PHID14_L2PHIB14 => return "L1PHID14_L2PHIB14";
+    end case;
+    return "No conversion found.";
+  end memory_enum_to_string;
+
+  function memory_enum_to_string(val: enum_TPROJ_60) return string is
+  begin
+    case val is
+       when L1L2E_L3PHIB => return "L1L2E_L3PHIB";
+    end case;
+    return "No conversion found.";
+  end memory_enum_to_string;
+
+  function memory_enum_to_string(val: enum_TPROJ_58) return string is
+  begin
+    case val is
+       when L1L2E_L4PHIA => return "L1L2E_L4PHIA";
+       when L1L2E_L4PHIB => return "L1L2E_L4PHIB";
+       when L1L2E_L4PHIC => return "L1L2E_L4PHIC";
+       when L1L2E_L5PHIA => return "L1L2E_L5PHIA";
+       when L1L2E_L5PHIB => return "L1L2E_L5PHIB";
+       when L1L2E_L5PHIC => return "L1L2E_L5PHIC";
+       when L1L2E_L6PHIA => return "L1L2E_L6PHIA";
+       when L1L2E_L6PHIB => return "L1L2E_L6PHIB";
+       when L1L2E_L6PHIC => return "L1L2E_L6PHIC";
+    end case;
+    return "No conversion found.";
+  end memory_enum_to_string;
+
+  function memory_enum_to_string(val: enum_TPROJ_59) return string is
+  begin
+    case val is
+       when L1L2E_D1PHIA => return "L1L2E_D1PHIA";
+       when L1L2E_D1PHIB => return "L1L2E_D1PHIB";
+       when L1L2E_D1PHIC => return "L1L2E_D1PHIC";
+       when L1L2E_D2PHIA => return "L1L2E_D2PHIA";
+       when L1L2E_D2PHIB => return "L1L2E_D2PHIB";
+       when L1L2E_D2PHIC => return "L1L2E_D2PHIC";
+       when L1L2E_D3PHIA => return "L1L2E_D3PHIA";
+       when L1L2E_D3PHIB => return "L1L2E_D3PHIB";
+       when L1L2E_D3PHIC => return "L1L2E_D3PHIC";
+       when L1L2E_D4PHIA => return "L1L2E_D4PHIA";
+       when L1L2E_D4PHIB => return "L1L2E_D4PHIB";
+       when L1L2E_D4PHIC => return "L1L2E_D4PHIC";
+    end case;
+    return "No conversion found.";
+  end memory_enum_to_string;
+
+  function memory_enum_to_string(val: enum_TPAR_70) return string is
+  begin
+    case val is
+       when L1L2E => return "L1L2E";
+    end case;
+    return "No conversion found.";
+  end memory_enum_to_string;
+
+end package body memUtil_pkg;

--- a/IntegrationTests/TETC/script/compileHLS.sh
+++ b/IntegrationTests/TETC/script/compileHLS.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Create HLS IP for TE & TC.
+# Run this in IntegrationTests/xyz/script/ 
+
+pushd ../../../project
+
+vivado_hls -f script_TE.tcl
+vivado_hls -f script_TC.tcl
+
+popd

--- a/IntegrationTests/TETC/script/makeProject.tcl
+++ b/IntegrationTests/TETC/script/makeProject.tcl
@@ -1,0 +1,43 @@
+# Create Vivado project, with user HDL files & IP.
+# Run this in IntegrationTests/xyz/script/ 
+
+# Create project
+set projName "Work"
+set FPGA "xcvu7p-flvb2104-1-e"
+create_project -force ${projName} ./${projName} -part $FPGA
+set_property target_language VHDL [current_project]
+
+# Rebuild user HLS IP repos index before adding any source files
+set_property ip_repo_paths "../../../project/"  [get_filesets sources_1]
+update_ip_catalog -rebuild
+
+# Create .xci files for user HLS IP
+create_ip -name TrackletEngineTop -module_name TE_L1L2 -vendor xilinx.com -library hls -version 1.0
+create_ip -name TrackletCalculator_L1L2E -module_name TC_L1L2E -vendor xilinx.com -library hls -version 1.0
+
+# Provide name of top-level HDL (without .vhd extension).
+#set topLevelHDL "SectorProcessor"
+set topLevelHDL "SectorProcessorFull"
+
+# Add HDL for algo
+add_files -fileset sources_1 [glob ../hdl/SectorProcessor*.vhd]
+add_files -fileset sources_1 [glob ../hdl/memUtil_pkg.vhd]
+add_files -fileset sources_1 [glob ../../common/hdl/*.vhd]
+
+# Add HDL for TB
+add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]
+
+# Add constraints (clock etc.)
+add_files -fileset constrs_1 [glob ../../common/hdl/constraints.xdc]
+
+# Set 'sim_1' fileset properties
+set_property file_type {VHDL 2008} [get_files -filter {FILE_TYPE == VHDL}]
+set_property top -value ${topLevelHDL} -objects [get_filesets sources_1]
+set_property top -value "tb_tf_top" -objects [get_filesets sim_1]
+set_property xsim.simulate.runtime -value "0us" -objects  [get_filesets sim_1]
+
+update_compile_order -fileset sources_1 
+
+puts "INFO: Project created: ${projName}"
+
+exit

--- a/IntegrationTests/TETC/script/runSim.tcl
+++ b/IntegrationTests/TETC/script/runSim.tcl
@@ -1,0 +1,23 @@
+# Open project
+set projName "Work"
+open_project $projName/$projName.xpr
+
+reset_simulation sim_1
+
+# Create directory for output .txt file
+file delete -force dataOut/
+file mkdir dataOut/
+
+# Launch Simulation
+launch_simulation
+
+# Set default wave viewer cfg
+#open_wave_config {../tb/prmemc.wcfg}
+#open_wave_config {../tb/start_bx.wcfg}
+#open_wave_config {../tb/tf_top.wcfg}
+#open_wave_config {../tb/mem_tf.wcfg}
+#open_wave_config {../tb/mem_tf_wea.wcfg}
+
+restart
+# Need 4us + 0.45us per event (50us for 100 events, but 10us for quick test).
+run 50 us

--- a/IntegrationTests/TETC/tb/tb_tf_top.vhd
+++ b/IntegrationTests/TETC/tb/tb_tf_top.vhd
@@ -161,7 +161,7 @@ begin
       DELAY      => VMSTE_DELAY*MAX_ENTRIES,
       RAM_WIDTH  => 16,
       NUM_PAGES  => 2,
-      NUM_BINS   => 2,
+      NUM_BINS   => 8,
       DEBUG      => true,
       FILE_NAME_DEBUG => FILE_OUT_VMSTE_debug&memory_enum_to_string(var)&debugFileNameEnding
     )

--- a/IntegrationTests/TETC/tb/tb_tf_top.vhd
+++ b/IntegrationTests/TETC/tb/tb_tf_top.vhd
@@ -1,0 +1,435 @@
+
+--==========================================================================
+-- CU Boulder
+-------------------------------------------------------------------------------
+--! @file
+--! @brief Test bench for the TE-TC track finding.
+--! @author Ian Tomalin
+--! @date 2021-07-04
+--=============================================================================
+
+--! Standard library
+library ieee;
+--! Standard package
+use ieee.std_logic_1164.all;
+--! Signed/unsigned calculations
+use ieee.numeric_std.all;
+--! Math real
+use ieee.math_real.all;
+--! TextIO
+use ieee.std_logic_textio.all;
+--! Standard functions
+library std;
+--! Standard TextIO functions
+use std.textio.all;
+
+--! Xilinx library
+library unisim;
+--! Xilinx package
+use unisim.vcomponents.all;
+
+--! User packages
+use work.tf_pkg.all;
+use work.memUtil_pkg.all;
+
+--! @brief TB
+entity tb_tf_top is
+end tb_tf_top;
+
+--! @brief TB
+architecture behavior of tb_tf_top is
+
+  -- ########################### Constant Definitions ###########################
+  -- ############ Please change the constants in this section ###################
+
+  --=========================================================================
+  -- Specify version of chain to run from TB:
+  --    0 = SectorProcessor.vhd from python script.
+  --    1 = SectorProcessorFull.vhd from python script (gives intermediate MemPrints).
+  --    N.B. Change this also in makeProject.tcl !
+  constant INST_TOP_TF   : integer := 1; 
+  --=========================================================================
+
+  constant CLK_PERIOD        : time    := 4 ns;       --! 250 MHz
+  constant DEBUG             : boolean := false;      --! Debug off/on
+  constant VMSTE_DELAY       : integer := 0;          --! Number of BX delays
+  constant AS_DELAY          : integer := 1;          --! Number of BX delays 
+
+  -- Paths of data files specified relative to Vivado project's xsim directory. 
+  -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
+  constant emDataDir  : string := "../../../../../../../../emData/MemPrints/";
+  constant dataOutDir : string := "../../../../../dataOut/";
+
+  -- File directories and the start of the file names that memories have in common
+  -- Input files
+  constant FILE_IN_VMSTE : string := emDataDir&"VMStubsTE/VMStubs_VMSTE_";    
+  constant FILE_IN_AS : string := emDataDir&"Stubs/AllStubs_AS_";
+  -- Output files
+  constant FILE_OUT_SP : string := dataOutDir&"SP_";
+  constant FILE_OUT_TPAR : string := dataOutDir&"TPAR_";
+  constant FILE_OUT_TPROJ : string := dataOutDir&"TPROJ_";
+  -- Debug output files to check input was correctly read.
+  constant FILE_OUT_VMSTE_debug : string := dataOutDir&"VMSTE_";
+  constant FILE_OUT_AS_debug : string := dataOutDir&"AS_";
+  
+  -- File name endings
+  constant inputFileNameEnding : string := "_04.dat"; -- 04 specifies the nonant the testvectors represent
+  constant outputFileNameEnding : string := ".txt";
+  constant debugFileNameEnding : string := ".debug.txt";
+
+  -- ########################### Signals ###########################
+  -- ### UUT signals ###
+  signal clk       : std_logic := '0';
+  signal reset     : std_logic := '1';
+  signal TE_start  : std_logic := '0';
+  signal TE_idle   : std_logic := '0';
+  signal TE_ready  : std_logic := '0';
+  signal TE_bx_in  : std_logic_vector(2 downto 0) := (others => '1');
+  signal TE_bx_out : std_logic_vector(2 downto 0) := (others => '1');
+  signal TE_bx_out_vld : std_logic := '0';
+  signal TE_done   : std_logic := '0';
+  signal TC_bx_out : std_logic_vector(2 downto 0) := (others => '1');
+  signal TC_bx_out_vld : std_logic := '0';
+  signal TC_done   : std_logic := '0';
+
+  -- Signals matching ports of top-level VHDL
+  signal AS_36_mem_A_wea           : t_arr_AS_36_1b       := (others => '0');
+  signal AS_36_mem_AV_writeaddr    : t_arr_AS_36_ADDR     := (others => (others => '0'));
+  signal AS_36_mem_AV_din          : t_arr_AS_36_DATA     := (others => (others => '0'));
+  signal VMSTE_22_mem_A_wea        : t_arr_VMSTE_22_1b    := (others => '0');
+  signal VMSTE_22_mem_AV_writeaddr : t_arr_VMSTE_22_ADDR  := (others => (others => '0'));
+  signal VMSTE_22_mem_AV_din       : t_arr_VMSTE_22_DATA  := (others => (others => '0'));
+  signal VMSTE_16_mem_A_wea        : t_arr_VMSTE_16_1b    := (others => '0');
+  signal VMSTE_16_mem_AV_writeaddr : t_arr_VMSTE_16_ADDR  := (others => (others => '0'));
+  signal VMSTE_16_mem_AV_din       : t_arr_VMSTE_16_DATA  := (others => (others => '0'));
+  signal SP_14_mem_A_wea           : t_arr_SP_14_1b       := (others => '0');
+  signal SP_14_mem_AV_writeaddr    : t_arr_SP_14_ADDR     := (others => (others => '0'));
+  signal SP_14_mem_AV_din          : t_arr_SP_14_DATA     := (others => (others => '0'));
+  signal TPROJ_60_mem_A_enb           : t_arr_TPROJ_60_1b       := (others => '0');
+  signal TPROJ_60_mem_AV_readaddr     : t_arr_TPROJ_60_ADDR     := (others => (others => '0'));
+  signal TPROJ_60_mem_AV_dout         : t_arr_TPROJ_60_DATA     := (others => (others => '0'));
+  signal TPROJ_60_mem_AAV_dout_nent   : t_arr_TPROJ_60_NENT     := (others => (others => (others => '0')));
+  signal TPROJ_58_mem_A_enb           : t_arr_TPROJ_58_1b       := (others => '0');
+  signal TPROJ_58_mem_AV_readaddr     : t_arr_TPROJ_58_ADDR     := (others => (others => '0'));
+  signal TPROJ_58_mem_AV_dout         : t_arr_TPROJ_58_DATA     := (others => (others => '0'));
+  signal TPROJ_58_mem_AAV_dout_nent   : t_arr_TPROJ_58_NENT     := (others => (others => (others => '0')));
+  signal TPROJ_59_mem_A_enb           : t_arr_TPROJ_59_1b       := (others => '0');
+  signal TPROJ_59_mem_AV_readaddr     : t_arr_TPROJ_59_ADDR     := (others => (others => '0'));
+  signal TPROJ_59_mem_AV_dout         : t_arr_TPROJ_59_DATA     := (others => (others => '0'));
+  signal TPROJ_59_mem_AAV_dout_nent   : t_arr_TPROJ_59_NENT     := (others => (others => (others => '0')));
+  signal TPAR_70_mem_A_enb           : t_arr_TPAR_70_1b       := (others => '0');
+  signal TPAR_70_mem_AV_readaddr     : t_arr_TPAR_70_ADDR     := (others => (others => '0'));
+  signal TPAR_70_mem_AV_dout         : t_arr_TPAR_70_DATA     := (others => (others => '0'));
+  signal TPAR_70_mem_AAV_dout_nent   : t_arr_TPAR_70_NENT     := (others => (others => (others => '0')));
+
+  -- Indicates that writing of VMSTE memories of first event has started.
+  signal START_FIRST_WRITE : std_logic := '0';
+  signal START_VMSTE : t_arr_VMSTE_22_1b := (others => '0');
+
+begin
+
+  --! @brief Make clock ---------------------------------------
+  clk <= not clk after CLK_PERIOD/2;
+
+  -- Get signals from input .txt files
+
+  VMSTE_22_loop : for var in enum_VMSTE_22 generate
+  begin
+    readVMSTE_22 : entity work.FileReader 
+    generic map (
+      FILE_NAME  => FILE_IN_VMSTE&memory_enum_to_string(var)&inputFileNameEnding,
+      DELAY      => VMSTE_DELAY*MAX_ENTRIES,
+      RAM_WIDTH  => 22,
+      NUM_PAGES  => 2,
+      DEBUG      => true,
+      FILE_NAME_DEBUG => FILE_OUT_VMSTE_debug&memory_enum_to_string(var)&debugFileNameEnding
+    )
+    port map (
+      CLK => CLK,
+      ADDR => VMSTE_22_mem_AV_writeaddr(var),
+      DATA => VMSTE_22_mem_AV_din(var),
+      START => START_VMSTE(var),
+      WRITE_EN => VMSTE_22_mem_A_wea(var)
+    );
+  end generate VMSTE_22_loop;
+
+  VMSTE_16_loop : for var in enum_VMSTE_16 generate
+  begin
+    readVMSTE_16 : entity work.FileReader 
+    generic map (
+      FILE_NAME  => FILE_IN_VMSTE&memory_enum_to_string(var)&inputFileNameEnding,
+      DELAY      => VMSTE_DELAY*MAX_ENTRIES,
+      RAM_WIDTH  => 16,
+      NUM_PAGES  => 2,
+      NUM_BINS   => 2,
+      DEBUG      => true,
+      FILE_NAME_DEBUG => FILE_OUT_VMSTE_debug&memory_enum_to_string(var)&debugFileNameEnding
+    )
+    port map (
+      CLK => CLK,
+      ADDR => VMSTE_16_mem_AV_writeaddr(var),
+      DATA => VMSTE_16_mem_AV_din(var),
+      START => open,
+      WRITE_EN => VMSTE_16_mem_A_wea(var)
+    );
+  end generate VMSTE_16_loop;
+
+  -- As all TPPROJ signals start together, take first one, to determine when 
+  -- first event starts being written to first memory in chain.
+  START_FIRST_WRITE <= START_VMSTE(enum_VMSTE_22'val(0));
+
+
+  AS_36_loop : for var in enum_AS_36 generate
+  begin
+    readAS_36 : entity work.FileReader 
+    generic map (
+      FILE_NAME  => FILE_IN_AS&memory_enum_to_string(var)&inputFileNameEnding,
+      DELAY      => AS_DELAY*MAX_ENTRIES,
+      RAM_WIDTH  => 36,
+      NUM_PAGES  => 8,
+      DEBUG      => true,
+      FILE_NAME_DEBUG => FILE_OUT_AS_debug&memory_enum_to_string(var)&debugFileNameEnding
+    )
+    port map (
+      CLK => CLK,
+      ADDR => AS_36_mem_AV_writeaddr(var),
+      DATA => AS_36_mem_AV_din(var),
+      START => open,
+      WRITE_EN => AS_36_mem_A_wea(var)
+    );
+  end generate AS_36_loop;
+
+
+  procStart : process(CLK)
+    -- Process to start first module in chain & generate its BX counter input.
+    -- Also releases reset flag.
+    constant CLK_RESET : natural := 5; -- Any low number OK.
+    variable CLK_COUNT : natural := 1;
+    variable EVENT_COUNT : integer := -1;
+    variable v_line : line; -- Line for debug
+  begin
+
+    if START_FIRST_WRITE = '1' then
+      if rising_edge(CLK) then
+        if (CLK_COUNT < MAX_ENTRIES) then
+          CLK_COUNT := CLK_COUNT + 1;
+        else
+          CLK_COUNT := 1;
+          EVENT_COUNT := EVENT_COUNT + 1;
+
+          -- TE should start one TM period after time when first event starting being 
+          -- written to first memory in chain, as it takes this long to write full event.
+          TE_START <= '1';
+          TE_BX_IN <= std_logic_vector(to_unsigned(EVENT_COUNT, TE_BX_IN'length));
+
+          write(v_line, string'("=== Processing event ")); write(v_line,EVENT_COUNT); write(v_line, string'(" at SIM time ")); write(v_line, NOW); writeline(output, v_line);
+        end if;
+        -- Releae
+        if (CLK_COUNT = CLK_RESET) then 
+          RESET <= '0';
+        end if;
+      end if;
+    end if;
+  end process procStart;
+
+
+  -- ########################### Instantiation ###########################
+  -- Instantiate the Unit Under Test (UUT)
+
+  sectorProc : if INST_TOP_TF = 0 generate
+  begin
+    uut : entity work.SectorProcessor
+      port map(
+        clk                        => clk,
+        -- Control signals
+        reset                      => reset,
+        TE_start                   => TE_start,
+        TE_bx_in                   => TE_bx_in,
+        TC_bx_out                  => TC_bx_out,
+        TC_bx_out_vld              => TC_bx_out_vld,
+        TC_done                    => TC_done,
+        -- Input data
+        AS_36_mem_A_wea            => AS_36_mem_A_wea,
+        AS_36_mem_AV_writeaddr     => AS_36_mem_AV_writeaddr,
+        AS_36_mem_AV_din           => AS_36_mem_AV_din,
+        VMSTE_22_mem_A_wea         => VMSTE_22_mem_A_wea,
+        VMSTE_22_mem_AV_writeaddr  => VMSTE_22_mem_AV_writeaddr,
+        VMSTE_22_mem_AV_din        => VMSTE_22_mem_AV_din,
+        VMSTE_16_mem_A_wea         => VMSTE_16_mem_A_wea,
+        VMSTE_16_mem_AV_writeaddr  => VMSTE_16_mem_AV_writeaddr,
+        VMSTE_16_mem_AV_din        => VMSTE_16_mem_AV_din,
+        -- Output data
+        TPROJ_60_mem_A_enb         => TPROJ_60_mem_A_enb,
+        TPROJ_60_mem_AV_readaddr   => TPROJ_60_mem_AV_readaddr,
+        TPROJ_60_mem_AV_dout       => TPROJ_60_mem_AV_dout,
+        TPROJ_60_mem_AAV_dout_nent => TPROJ_60_mem_AAV_dout_nent,
+        TPROJ_58_mem_A_enb         => TPROJ_58_mem_A_enb,
+        TPROJ_58_mem_AV_readaddr   => TPROJ_58_mem_AV_readaddr,
+        TPROJ_58_mem_AV_dout       => TPROJ_58_mem_AV_dout,
+        TPROJ_58_mem_AAV_dout_nent => TPROJ_58_mem_AAV_dout_nent,
+        TPROJ_59_mem_A_enb         => TPROJ_59_mem_A_enb,
+        TPROJ_59_mem_AV_readaddr   => TPROJ_59_mem_AV_readaddr,
+        TPROJ_59_mem_AV_dout       => TPROJ_59_mem_AV_dout,
+        TPROJ_59_mem_AAV_dout_nent => TPROJ_59_mem_AAV_dout_nent,
+        TPAR_70_mem_A_enb          => TPAR_70_mem_A_enb,
+        TPAR_70_mem_AV_readaddr    => TPAR_70_mem_AV_readaddr,
+        TPAR_70_mem_AV_dout        => TPAR_70_mem_AV_dout,
+        TPAR_70_mem_AAV_dout_nent  => TPAR_70_mem_AAV_dout_nent
+      );
+  end generate sectorProc;
+
+
+  sectorProcFull : if INST_TOP_TF = 1 generate
+  begin
+    uut : entity work.SectorProcessorFull
+      port map(
+        clk                        => clk,
+        -- Control signals
+        reset                      => reset,
+        TE_start                   => TE_start,
+        TE_bx_in                   => TE_bx_in,
+        TC_bx_out                  => TC_bx_out,
+        TC_bx_out_vld              => TC_bx_out_vld,
+        TC_done                    => TC_done,
+        -- Debug control signals
+        TE_bx_out                  => TE_bx_out,
+        TE_bx_out_vld              => TE_bx_out_vld,
+        TE_done                    => TE_done,
+        -- Input data
+        AS_36_mem_A_wea            => AS_36_mem_A_wea,
+        AS_36_mem_AV_writeaddr     => AS_36_mem_AV_writeaddr,
+        AS_36_mem_AV_din           => AS_36_mem_AV_din,
+        VMSTE_22_mem_A_wea         => VMSTE_22_mem_A_wea,
+        VMSTE_22_mem_AV_writeaddr  => VMSTE_22_mem_AV_writeaddr,
+        VMSTE_22_mem_AV_din        => VMSTE_22_mem_AV_din,
+        VMSTE_16_mem_A_wea         => VMSTE_16_mem_A_wea,
+        VMSTE_16_mem_AV_writeaddr  => VMSTE_16_mem_AV_writeaddr,
+        VMSTE_16_mem_AV_din        => VMSTE_16_mem_AV_din,
+        -- Debug output data
+        SP_14_mem_A_wea        => SP_14_mem_A_wea,
+        SP_14_mem_AV_writeaddr => SP_14_mem_AV_writeaddr,
+        SP_14_mem_AV_din       => SP_14_mem_AV_din,
+        -- Output data
+        TPROJ_60_mem_A_enb         => TPROJ_60_mem_A_enb,
+        TPROJ_60_mem_AV_readaddr   => TPROJ_60_mem_AV_readaddr,
+        TPROJ_60_mem_AV_dout       => TPROJ_60_mem_AV_dout,
+        TPROJ_60_mem_AAV_dout_nent => TPROJ_60_mem_AAV_dout_nent,
+        TPROJ_58_mem_A_enb         => TPROJ_58_mem_A_enb,
+        TPROJ_58_mem_AV_readaddr   => TPROJ_58_mem_AV_readaddr,
+        TPROJ_58_mem_AV_dout       => TPROJ_58_mem_AV_dout,
+        TPROJ_58_mem_AAV_dout_nent => TPROJ_58_mem_AAV_dout_nent,
+        TPROJ_59_mem_A_enb         => TPROJ_59_mem_A_enb,
+        TPROJ_59_mem_AV_readaddr   => TPROJ_59_mem_AV_readaddr,
+        TPROJ_59_mem_AV_dout       => TPROJ_59_mem_AV_dout,
+        TPROJ_59_mem_AAV_dout_nent => TPROJ_59_mem_AAV_dout_nent,
+        TPAR_70_mem_A_enb          => TPAR_70_mem_A_enb,
+        TPAR_70_mem_AV_readaddr    => TPAR_70_mem_AV_readaddr,
+        TPAR_70_mem_AV_dout        => TPAR_70_mem_AV_dout,
+        TPAR_70_mem_AAV_dout_nent  => TPAR_70_mem_AAV_dout_nent
+      );
+  end generate sectorProcFull;
+
+
+  -- Write signals to output .txt files
+
+  writeIntermediateRAMs : if INST_TOP_TF = 1 generate
+  begin
+
+    -- This writes signals going to intermediate memories in chain.
+
+    SP_14_loop : for var in enum_SP_14 generate
+    begin
+      writeSP_14 : entity work.FileWriter 
+      generic map (
+        FILE_NAME  => FILE_OUT_SP&memory_enum_to_string(var)&outputFileNameEnding,
+        RAM_WIDTH  => 14,
+        NUM_PAGES  => 2
+      )
+      port map (
+        CLK => CLK,
+        ADDR => SP_14_mem_AV_writeaddr(var),
+        DATA => SP_14_mem_AV_din(var),
+        WRITE_EN => SP_14_mem_A_wea(var),
+        START => TE_START,
+        DONE => TE_DONE
+      );
+    end generate SP_14_loop;
+
+  end generate writeIntermediateRAMs;
+
+
+-- Write memories from end of chain.
+
+  TPROJ_60_loop : for var in enum_TPROJ_60 generate
+  begin
+    writeTPROJ_60 : entity work.FileWriterFromRAM 
+    generic map (
+      FILE_NAME  => FILE_OUT_TPROJ&memory_enum_to_string(var)&outputFileNameEnding,
+      RAM_WIDTH  => 60,
+      NUM_PAGES  => 2
+    )
+    port map (
+      CLK => CLK,
+      DONE => TC_DONE,
+      NENT_ARR => TPROJ_60_mem_AAV_dout_nent(var),
+      ADDR => TPROJ_60_mem_AV_readaddr(var),
+      DATA => TPROJ_60_mem_AV_dout(var),
+      READ_EN => TPROJ_60_mem_A_enb(var)
+    );
+  end generate TPROJ_60_loop;
+
+  TPROJ_59_loop : for var in enum_TPROJ_59 generate
+  begin
+    writeTPROJ_59 : entity work.FileWriterFromRAM 
+    generic map (
+      FILE_NAME  => FILE_OUT_TPROJ&memory_enum_to_string(var)&outputFileNameEnding,
+      RAM_WIDTH  => 59,
+      NUM_PAGES  => 2
+    )
+    port map (
+      CLK => CLK,
+      DONE => TC_DONE,
+      NENT_ARR => TPROJ_59_mem_AAV_dout_nent(var),
+      ADDR => TPROJ_59_mem_AV_readaddr(var),
+      DATA => TPROJ_59_mem_AV_dout(var),
+      READ_EN => TPROJ_59_mem_A_enb(var)
+    );
+  end generate TPROJ_59_loop;
+
+  TPROJ_58_loop : for var in enum_TPROJ_58 generate
+  begin
+    writeTPROJ_58 : entity work.FileWriterFromRAM 
+    generic map (
+      FILE_NAME  => FILE_OUT_TPROJ&memory_enum_to_string(var)&outputFileNameEnding,
+      RAM_WIDTH  => 58,
+      NUM_PAGES  => 2
+    )
+    port map (
+      CLK => CLK,
+      DONE => TC_DONE,
+      NENT_ARR => TPROJ_58_mem_AAV_dout_nent(var),
+      ADDR => TPROJ_58_mem_AV_readaddr(var),
+      DATA => TPROJ_58_mem_AV_dout(var),
+      READ_EN => TPROJ_58_mem_A_enb(var)
+    );
+  end generate TPROJ_58_loop;
+
+  TPAR_70_loop : for var in enum_TPAR_70 generate
+  begin
+    writeTPAR_70 : entity work.FileWriterFromRAM 
+    generic map (
+      FILE_NAME  => FILE_OUT_TPAR&memory_enum_to_string(var)&outputFileNameEnding,
+      RAM_WIDTH  => 70,
+      NUM_PAGES  => 8
+    )
+    port map (
+      CLK => CLK,
+      DONE => TC_DONE,
+      NENT_ARR => TPAR_70_mem_AAV_dout_nent(var),
+      ADDR => TPAR_70_mem_AV_readaddr(var),
+      DATA => TPAR_70_mem_AV_dout(var),
+      READ_EN => TPAR_70_mem_A_enb(var)
+    );
+  end generate TPAR_70_loop;
+
+end behavior;

--- a/IntegrationTests/common/hdl/tf_lut.vhd
+++ b/IntegrationTests/common/hdl/tf_lut.vhd
@@ -35,7 +35,7 @@ architecture behavioral of tf_lut is
     variable line_in : line;
     -- Determines number of 4*chars needed to be read from lut_file
     -- to correspond to specified LUT width.
-    constant lut_width_4 : integer := 4*integer(ceil(real(lut_width)/4));
+    constant lut_width_4 : integer := 4*integer(ceil(real(lut_width)/4.0));
     variable line_data : std_logic_vector(lut_width_4-1 downto 0) := (others => '0'); 
     variable rom_data : romType;
   begin

--- a/IntegrationTests/common/hdl/tf_lut.vhd
+++ b/IntegrationTests/common/hdl/tf_lut.vhd
@@ -26,14 +26,35 @@ end entity tf_lut;
 
 architecture behavioral of tf_lut is
   type romType is array(0 to lut_depth-1) of std_logic_vector(lut_width-1 downto 0);
+
   impure function initRomFromFile return romType is
     file data_file : text open read_mode is lut_file;
-    variable data_fileLine : line;
+    variable line_in : line;
+    variable line_data : std_logic_vector(127 downto 0) := (others => '0'); -- A wide vector compared to any LUT width.
+    variable hasComma : boolean := false;
+    variable nCharSkip : natural := 0;
     variable rom_data : romType;
+    variable addr : natural := 0;
   begin
-    for I in romType'range loop
-      readline(data_file, data_fileLine);
-      hread(data_fileLine, rom_data(I));
+    while not endfile(data_file) loop
+      readline(data_file, line_in);
+      -- Skip lines without hex numbers
+      if (line_in'length >= 1) then
+        -- Skip brackets at start & end of file.
+        if (line_in.all(1 to 1) /= "{" and line_in.all(1 to 1) /= "}") then
+          -- Check if line ends in comma, in which case drop comma.
+          hasComma := (line_in.all(line_in'length to line_in'length) = ",");
+          if hasComma then
+            nCharSkip := 1;
+          else
+            nCharSkip := 0;
+          end if;
+          hread(line_in, line_data((line_in'length-nCharSkip)*4-1 downto 0));
+          -- Truncate data word to desired width.
+          rom_data(addr) := line_data(lut_width-1 downto 0);
+          addr := addr + 1;
+        end if;
+      end if;
     end loop;
     return rom_data;
   end function;

--- a/IntegrationTests/common/hdl/tf_lut.vhd
+++ b/IntegrationTests/common/hdl/tf_lut.vhd
@@ -7,18 +7,19 @@
 library ieee ;
 use ieee.std_logic_1164.all;
 use ieee.numeric_Std.all;
-library std ;
+use ieee.math_real.all;
+library std;
 use std.textio.all;
 
 use work.tf_pkg.all;
 
 entity tf_lut is
-  generic (lut_file : string := "lut.dat";
-           lut_width   : integer := 1;
-           lut_depth    : integer := 256);
+  generic (lut_file  : string := "lut.dat";
+           lut_width : integer := 1;
+           lut_depth : integer := 256);
   port (
-    clk : in std_logic;
-    ce : in std_logic;
+    clk  : in std_logic;
+    ce   : in std_logic;
     addr : in std_logic_vector(clogb2(lut_depth)-1 downto 0);
     dout : out std_logic_vector(lut_width-1 downto 0)
     );
@@ -30,31 +31,23 @@ architecture behavioral of tf_lut is
   impure function initRomFromFile return romType is
     file data_file : text open read_mode is lut_file;
     variable line_in : line;
-    variable line_data : std_logic_vector(127 downto 0) := (others => '0'); -- A wide vector compared to any LUT width.
-    variable hasComma : boolean := false;
-    variable nCharSkip : natural := 0;
+    -- Determines number of 4*chars needed to be read from lut_file
+    -- to correspond to specified LUT width.
+    constant lut_width_4 : integer := 4*integer(ceil(real(lut_width)/4));
+    variable line_data : std_logic_vector(lut_width_4-1 downto 0) := (others => '0'); 
     variable rom_data : romType;
-    variable addr : natural := 0;
   begin
-    while not endfile(data_file) loop
+    -- N.B. line_in.all is not supported by synthesis.
+
+    -- Skip first line (just a bracket).
+    readline(data_file, line_in);
+
+    for I in romType'range loop
       readline(data_file, line_in);
-      -- Skip lines without hex numbers
-      if (line_in'length >= 1) then
-        -- Skip brackets at start & end of file.
-        if (line_in.all(1 to 1) /= "{" and line_in.all(1 to 1) /= "}") then
-          -- Check if line ends in comma, in which case drop comma.
-          hasComma := (line_in.all(line_in'length to line_in'length) = ",");
-          if hasComma then
-            nCharSkip := 1;
-          else
-            nCharSkip := 0;
-          end if;
-          hread(line_in, line_data((line_in'length-nCharSkip)*4-1 downto 0));
-          -- Truncate data word to desired width.
-          rom_data(addr) := line_data(lut_width-1 downto 0);
-          addr := addr + 1;
-        end if;
-      end if;
+      -- This avoid reading the final comma that appears on some lines.
+      hread(line_in, line_data);
+      -- Truncate data word to desired width.
+      rom_data(I) := line_data(lut_width-1 downto 0);
     end loop;
     return rom_data;
   end function;

--- a/IntegrationTests/common/hdl/tf_pkg.vhd
+++ b/IntegrationTests/common/hdl/tf_pkg.vhd
@@ -46,8 +46,18 @@ package tf_pkg is
   constant RAM_WIDTH_TPROJ : natural := 60; --! Width for memories
   constant RAM_WIDTH_AP    : natural := 60; --! Width for memories
 
+  -- Boolean indicating if this is Vivado simulation.
+  constant IS_SIMULATION : boolean := FALSE
+-- pragma synthesis_off
+    or TRUE    -- this line is only executed if Vivado simulation.
+-- pragma synthesis_on
+  ;
+  
   -- ########################### Functions ################################################################
   function clogb2     (bit_depth : integer) return integer;
+
+  function getDirEMDATA return string;
+
 
   -- ########################### Types ###########################
 
@@ -159,6 +169,22 @@ package body tf_pkg is
   begin
     return integer( ceil( log2( real( bit_depth ) ) ) );
   end;
+
+
+  --! @brief Returns directory path to emData/
+  function getDirEMDATA return string is
+  begin
+    if IS_SIMULATION then
+      -- Sim path specified relative to Vivado project's xsim directory. 
+      -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
+      return "../../../../../../../../emData/";
+    else
+      -- Synth path specified relative to dir where you run Vivado.
+      -- e.g. IntegrationTests/PRMEMC/script/
+      return "../../../emData/";
+    end if;
+  end;
+
 
   -- ########################### Procedures ################################################################
   --! @brief Convert character to integer

--- a/TestBenches/TrackletEngine_test.cpp
+++ b/TestBenches/TrackletEngine_test.cpp
@@ -30,17 +30,28 @@ int main(){
 
 
   // open input files from emulation
-  ifstream fin_vmstubsinner("../../../../../emData/TE/TE_L1PHIE18_L2PHIC17/VMStubs_VMSTE_L1PHIE18n2_04.dat");
-  ifstream fin_vmstubsouter("../../../../../emData/TE/TE_L1PHIE18_L2PHIC17/VMStubs_VMSTE_L2PHIC17n4_04.dat");
-  ifstream fin_stubpairs("../../../../../emData/TE/TE_L1PHIE18_L2PHIC17/StubPairs_SP_L1PHIE18_L2PHIC17_04.dat");  
+  // TE_L1PHIE18_L2PHIC17
+  //ifstream fin_vmstubsinner("../../../../../emData/TE/TE_L1PHIE18_L2PHIC17/VMStubs_VMSTE_L1PHIE18n2_04.dat");
+  //ifstream fin_vmstubsouter("../../../../../emData/TE/TE_L1PHIE18_L2PHIC17/VMStubs_VMSTE_L2PHIC17n4_04.dat");
+  //ifstream fin_stubpairs("../../../../../emData/TE/TE_L1PHIE18_L2PHIC17/StubPairs_SP_L1PHIE18_L2PHIC17_04.dat");  
+  // TE_L1PHIC12_L2PHIB12/
+  ifstream fin_vmstubsinner("../../../../../emData/TE/TE_L1PHIC12_L2PHIB12/VMStubs_VMSTE_L1PHIC12n3_04.dat");
+  ifstream fin_vmstubsouter("../../../../../emData/TE/TE_L1PHIC12_L2PHIB12/VMStubs_VMSTE_L2PHIB12n3_04.dat");
+  ifstream fin_stubpairs("../../../../../emData/TE/TE_L1PHIC12_L2PHIB12/StubPairs_SP_L1PHIC12_L2PHIB12_04.dat");  
   assert(fin_vmstubsinner.good());
   assert(fin_vmstubsouter.good());
   assert(fin_stubpairs.good());
 
+  // TE_L1PHIE18_L2PHIC17
+  //ap_uint<1> bendinnertable[256] =
+  //#include "../emData/TE/tables/TE_L1PHIE18_L2PHIC17_stubptinnercut.tab"
+  //ap_uint<1> bendoutertable[256] =
+  //#include "../emData/TE/tables/TE_L1PHIE18_L2PHIC17_stubptoutercut.tab"
+  // TE_L1PHIC12_L2PHIB12/
   ap_uint<1> bendinnertable[256] =
-#include "../emData/TE/tables/TE_L1PHIE18_L2PHIC17_stubptinnercut.tab"
+#include "../emData/TE/tables/TE_L1PHIC12_L2PHIB12_stubptinnercut.tab"
   ap_uint<1> bendoutertable[256] =
-#include "../emData/TE/tables/TE_L1PHIE18_L2PHIC17_stubptoutercut.tab"
+#include "../emData/TE/tables/TE_L1PHIC12_L2PHIB12_stubptoutercut.tab"
 
   // loop over events
   for (int ievt = 0; ievt < nevents; ++ievt) {

--- a/emData/download.sh
+++ b/emData/download.sh
@@ -43,6 +43,7 @@ declare -a processing_modules=(
   "VMRCM_L2PHIA"
 
   # TrackletEngine
+  "TE_L1PHIC12_L2PHIB12"
   "TE_L1PHIE18_L2PHIC17"
 
   # TrackletCalculator


### PR DESCRIPTION
TE-TC chain, including VHDL test bench. The top-level VHDL was produced by the python scripts.  The CompareMemPrintsFW.py scripts says that 98% of events agree with C++ emulation.

This include a few bug fixes to common/hdl/tf_lut.vhd, including changing the read latency to 2, to correspond to that specified in the HLS https://github.com/cms-L1TK/firmware-hls/blob/master/TrackletAlgorithm/TrackletEngineTop.cc#L11 . (Though I doubt that an output reg is required simply to read ROM data).

A new function getDirEMDATA has been added to tf_pkg.vhd. It returns the relative directory path to emData/  . This function solves the issue then when tf_lut.vhd reads the .tab file, it must use a different relative dir path during the SIM vs SYNTH steps.

P.S. TrackletEngine_test.cpp edited to set default TE to one used inside this chain, to faciltate debugging.