### PR TITLE
DummyMessageLogger

### DIFF
--- a/TrackletAlgorithm/Constants.h
+++ b/TrackletAlgorithm/Constants.h
@@ -5,7 +5,6 @@
 
 #ifdef CMSSW_GIT_HASH
 #include "L1Trigger/TrackFindingTracklet/interface/Settings.h"
-using namespace trklet;
 #endif
 
 // Inline function to convert floating point values to integers, given a
@@ -66,12 +65,14 @@ constexpr double c = 0.299792458; // m/ns
 
 // detector constants
 #ifndef CMSSW_GIT_HASH
+namespace trklet{
   constexpr int N_LAYER = 6; // # of barrel layers assumed
   constexpr int N_DISK = 5; // # of endcap disks assumed
+}
 #endif
 constexpr double bfield = 3.8112; // T
-constexpr int rmean[N_LAYER + N_DISK] = { 851, 1269, 1784, 2347, 2936, 3697,   -1,   -1,   -1,   -1,   -1 }; // valid for layers
-constexpr int zmean[N_LAYER + N_DISK] = {  -1,   -1,   -1,   -1,   -1,   -1, 2239, 2645, 3163, 3782, 4523 }; // valid for disks
+constexpr int rmean[trklet::N_LAYER + trklet::N_DISK] = { 851, 1269, 1784, 2347, 2936, 3697,   -1,   -1,   -1,   -1,   -1 }; // valid for layers
+constexpr int zmean[trklet::N_LAYER + trklet::N_DISK] = {  -1,   -1,   -1,   -1,   -1,   -1, 2239, 2645, 3163, 3782, 4523 }; // valid for disks
 constexpr double zlength = 120.0; // cm
 constexpr double rmindiskvm = 22.5; // cm
 constexpr double rmindisk = 20.0; // cm
@@ -83,7 +84,7 @@ constexpr double kphi = 7.71867e-06;
 constexpr double kz = 0.0585938;
 
 // stub digitization constants for combined modules
-constexpr double kz_cm[N_LAYER] = {2*zlength/(1<<12), 2*zlength/(1<<12), 2*zlength/(1<<12), 2*zlength/(1<<8), 2*zlength/(1<<8), 2*zlength/(1<<8)};
+constexpr double kz_cm[trklet::N_LAYER] = {2*zlength/(1<<12), 2*zlength/(1<<12), 2*zlength/(1<<12), 2*zlength/(1<<8), 2*zlength/(1<<8), 2*zlength/(1<<8)};
 
 // tracklet digitization constants
 constexpr double krinv = 1.04549e-06;
@@ -110,17 +111,19 @@ constexpr double z0cut = 15.0; // cm
 
 // cut constants for combined modules
 #ifndef CMSSW_GIT_HASH
+namespace trklet{
 constexpr double VMROUTERCUTZL2 = 50.0;      //Min L2 z for inner allstub in cm
 constexpr double VMROUTERCUTZL1L3L5 = 95.0;  //Max z for inner barrel layers in cm
 constexpr double VMROUTERCUTZL1 = 70.0;      //Max z for L1 barrel seeding in cm
 constexpr double VMROUTERCUTRD1D3 = 55.0;    //Max r for disk seeds in cm
+}
 #endif
 
 // various bit widths
-constexpr unsigned nbitsallstubs[N_LAYER + N_DISK] = {3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
+constexpr unsigned nbitsallstubs[trklet::N_LAYER + trklet::N_DISK] = {3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
 constexpr unsigned int nbits_maxvm = 5; // number of bits needed for max number of VMs per layer/disk (max number is 32)
 // number of bits used to distinguish VMs in one allstub block for each layer
-constexpr unsigned int nbits_vmmeall[N_LAYER + N_DISK]={2,3,3,3,3,3,3,2,2,2,2};
+constexpr unsigned int nbits_vmmeall[trklet::N_LAYER + trklet::N_DISK]={2,3,3,3,3,3,3,2,2,2,2};
 
 // List of regions for memory template parameters
 enum regionType {BARRELPS, BARREL2S, BARRELOL, BARREL, DISKPS, DISK2S, DISK, BARREL_FOR_MC, DISK_FOR_MC};

--- a/TrackletAlgorithm/Constants.h
+++ b/TrackletAlgorithm/Constants.h
@@ -4,8 +4,8 @@
 #include "ap_int.h"
 
 #ifdef CMSSW_GIT_HASH
-  #include "Settings.h"
-  using namespace trklet;
+#include "L1Trigger/TrackFindingTracklet/interface/Settings.h"
+using namespace trklet;
 #endif
 
 // Inline function to convert floating point values to integers, given a
@@ -109,10 +109,12 @@ constexpr double rinvcut = 0.01 * c * bfield / ptcut; // 0.01 to convert to 1/cm
 constexpr double z0cut = 15.0; // cm
 
 // cut constants for combined modules
+#ifndef CMSSW_GIT_HASH
 constexpr double VMROUTERCUTZL2 = 50.0;      //Min L2 z for inner allstub in cm
 constexpr double VMROUTERCUTZL1L3L5 = 95.0;  //Max z for inner barrel layers in cm
 constexpr double VMROUTERCUTZL1 = 70.0;      //Max z for L1 barrel seeding in cm
 constexpr double VMROUTERCUTRD1D3 = 55.0;    //Max r for disk seeds in cm
+#endif
 
 // various bit widths
 constexpr unsigned nbitsallstubs[N_LAYER + N_DISK] = {3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};

--- a/TrackletAlgorithm/DummyMessageLogger.h
+++ b/TrackletAlgorithm/DummyMessageLogger.h
@@ -5,7 +5,7 @@
 namespace edm {
   class LogVerbatim{
   public:
-    LogVerbatim(std::string type) { if(0) {std::cout<<type<<std::endl;} }
+    LogVerbatim(std::string type) { std::cout<<type<<std::endl; }
     ~LogVerbatim() { std::cout << std::endl;}
     template <class T> LogVerbatim& operator<<(T const& t) {std::cout << t;return *this;}
     LogVerbatim& operator<<(std::ostream& (*f)(std::ostream&)) {std::cout << f;return *this;}
@@ -13,7 +13,7 @@ namespace edm {
   };
   class LogPrint{
   public:
-    LogPrint(std::string type) { if(0) {std::cout<<type<<std::endl;} }
+    LogPrint(std::string type) { std::cout<<type<<std::endl; }
     ~LogPrint() { std::cout << std::endl;}
     template <class T> LogPrint& operator<<(T const& t) {std::cout << t;return *this;}
     LogPrint& operator<<(std::ostream& (*f)(std::ostream&)) {std::cout << f;return *this;}
@@ -21,7 +21,7 @@ namespace edm {
   };
   class LogWarning{
   public:
-    LogWarning(std::string type) { if(0) {std::cout<<type<<std::endl;} }
+    LogWarning(std::string type) { std::cout<<type<<std::endl; }
     ~LogWarning() { std::cout << std::endl;}
     template <class T> LogWarning& operator<<(T const& t) {std::cout << t;return *this;}
     LogWarning& operator<<(std::ostream& (*f)(std::ostream&)) {std::cout << f;return *this;}
@@ -29,7 +29,7 @@ namespace edm {
   };
   class LogProblem{
   public:
-    LogProblem(std::string type) { if(0) {std::cout<<type<<std::endl;} }
+    LogProblem(std::string type) { std::cout<<type<<std::endl; }
     ~LogProblem() { std::cout << std::endl;}
     template <class T> LogProblem& operator<<(T const& t) {std::cout << t;return *this;}
     LogProblem& operator<<(std::ostream& (*f)(std::ostream&)) {std::cout << f;return *this;}

--- a/TrackletAlgorithm/DummyMessageLogger.h
+++ b/TrackletAlgorithm/DummyMessageLogger.h
@@ -1,6 +1,7 @@
-#ifndef MessageLogger_MessageLogger_h
-#ifndef L1Trigger_TrackFindingTracklet_interface_Logger_h
-#define L1Trigger_TrackFindingTracklet_interface_Logger_h
+// Class definitions for dummy message logger which uses the same syntax as MessageLogger.h to cout messages. This allows users to use the message logger while running in CMSSW and to cout otherwise with a single line..
+#ifndef __SYNTHESIS__
+#ifndef TrackletAlgorithm_DummyMessageLogger_h
+#define TrackletAlgorithm_DummyMessageLogger_h
 #include<iostream>
 namespace edm {
   class LogVerbatim{

--- a/TrackletAlgorithm/DummyMessageLogger.h
+++ b/TrackletAlgorithm/DummyMessageLogger.h
@@ -1,0 +1,40 @@
+#ifndef MessageLogger_MessageLogger_h
+#ifndef L1Trigger_TrackFindingTracklet_interface_Logger_h
+#define L1Trigger_TrackFindingTracklet_interface_Logger_h
+#include<iostream>
+namespace edm {
+  class LogVerbatim{
+  public:
+    LogVerbatim(std::string type) { if(0) {std::cout<<type<<std::endl;} }
+    ~LogVerbatim() { std::cout << std::endl;}
+    template <class T> LogVerbatim& operator<<(T const& t) {std::cout << t;return *this;}
+    LogVerbatim& operator<<(std::ostream& (*f)(std::ostream&)) {std::cout << f;return *this;}
+    LogVerbatim& operator<<(std::ios_base& (*f)(std::ios_base&)) {std::cout << f;return *this;}
+  };
+  class LogPrint{
+  public:
+    LogPrint(std::string type) { if(0) {std::cout<<type<<std::endl;} }
+    ~LogPrint() { std::cout << std::endl;}
+    template <class T> LogPrint& operator<<(T const& t) {std::cout << t;return *this;}
+    LogPrint& operator<<(std::ostream& (*f)(std::ostream&)) {std::cout << f;return *this;}
+    LogPrint& operator<<(std::ios_base& (*f)(std::ios_base&)) {std::cout << f;return *this;}
+  };
+  class LogWarning{
+  public:
+    LogWarning(std::string type) { if(0) {std::cout<<type<<std::endl;} }
+    ~LogWarning() { std::cout << std::endl;}
+    template <class T> LogWarning& operator<<(T const& t) {std::cout << t;return *this;}
+    LogWarning& operator<<(std::ostream& (*f)(std::ostream&)) {std::cout << f;return *this;}
+    LogWarning& operator<<(std::ios_base& (*f)(std::ios_base&)) {std::cout << f;return *this;}
+  };
+  class LogProblem{
+  public:
+    LogProblem(std::string type) { if(0) {std::cout<<type<<std::endl;} }
+    ~LogProblem() { std::cout << std::endl;}
+    template <class T> LogProblem& operator<<(T const& t) {std::cout << t;return *this;}
+    LogProblem& operator<<(std::ostream& (*f)(std::ostream&)) {std::cout << f;return *this;}
+    LogProblem& operator<<(std::ios_base& (*f)(std::ios_base&)) {std::cout << f;return *this;}
+  };
+};
+#endif
+#endif

--- a/TrackletAlgorithm/InputRouter.h
+++ b/TrackletAlgorithm/InputRouter.h
@@ -254,7 +254,7 @@ void InputRouter( const BXType bx
 	  if( hVldBt == 0 ){ 
 	  	#ifndef __SYNTHESIS__
 	  		#if IR_DEBUG
-	                edm::LogWarning("HLS") << "\t.. Invalid Stub : " << std::hex << hStub << std::dec << "\n";
+	                edm::LogWarning("FWHLS") << "\t.. Invalid Stub : " << std::hex << hStub << std::dec << "\n";
 	  		#endif
 	  	#endif
 	  	continue;
@@ -325,7 +325,7 @@ void InputRouter( const BXType bx
 	  assert(cMemIndx < nMems);
 	  #ifndef __SYNTHESIS__
 	  	#if IR_DEBUG
-	  edm::LogVerbatim("HLS") << "\t.. Stub : " << std::hex << hStub << std::dec 
+	  edm::LogVerbatim("FWHLS") << "\t.. Stub : " << std::hex << hStub << std::dec 
 		   				<< " rel. parts : " << std::hex << hStbWrd << std::dec
 			            << " [ EncLyrId " << hEncLyr << " ] "
 						<< "[ LyrId " << hLyrId << " ] "

--- a/TrackletAlgorithm/InputRouter.h
+++ b/TrackletAlgorithm/InputRouter.h
@@ -22,7 +22,7 @@ static const int kBINMAPwidth = 12;
 static const int kSizeBinWord =  3; 
 static const int kNMEMwidth = 5;
 #ifndef __SYNTHESIS__
-	#include <bitset> 
+#include <bitset> 
 #endif
 
 
@@ -121,8 +121,8 @@ void getPhiBinWithCorrection(ap_uint<kBRAMwidth> hStbWrd
 		, const int cNbits 
 		, int &phiBn ) 
 {
-	#pragma HLS inline
-  	#pragma HLS array_partition variable = phicorrtable complete
+#pragma HLS inline
+#pragma HLS array_partition variable = phicorrtable complete
 
   	AllStub<InType> hAStub(hStbWrd);
   	auto hPhi = hAStub.getPhi();
@@ -154,7 +154,7 @@ void getPhiBin( ap_uint<kBRAMwidth> hStbWrd
 		, const int cNbits 
 		, int &phiBn ) 
 {
-	#pragma HLS inline
+#pragma HLS inline
   	
 	AllStub<InType> hAStub(hStbWrd);
 	//typename AllStub<InType>::ASPHI
@@ -168,12 +168,12 @@ template<unsigned int nEntriesSize>
 void ClearCounters(unsigned int nMemories
 	, ap_uint<kNBits_MemAddr> nEntries[nEntriesSize]) 
 {
-  #pragma HLS inline
-  #pragma HLS array_partition variable = nEntries complete
+#pragma HLS inline
+#pragma HLS array_partition variable = nEntries complete
   LOOP_ClearCounters:
 	for (int cIndx = 0; cIndx < nEntriesSize ; cIndx++) 
   {
-    #pragma HLS unroll
+#pragma HLS unroll
     nEntries[cIndx]=0; 
   }
 }
@@ -184,13 +184,13 @@ void CountMemories(const ap_uint<kBINMAPwidth> hPhBnWord
 	, unsigned int &nMems
 	, unsigned int nMemsPerLyr[nLyrs]) 
 {
-  #pragma HLS inline
-  #pragma HLS array_partition variable = nMemsPerLyr complete
+#pragma HLS inline
+#pragma HLS array_partition variable = nMemsPerLyr complete
   int cPrevSize=0; 
   LOOP_CountOutputMemories:
   for (int cLyr = 0; cLyr < kMaxLyrsPerDTC ; cLyr++) 
   {
-     #pragma HLS unroll
+#pragma HLS unroll
   	 auto hBnWrd = hPhBnWord.range(kSizeBinWord * cLyr + (kSizeBinWord-1), kSizeBinWord * cLyr);
      nMemsPerLyr[cLyr] = (cLyr < nLyrs) ?  (1+(int)(hBnWrd)) : 0 ; 
      nMems = (cLyr < nLyrs) ? (cPrevSize +  (1+(int)(hBnWrd))) : cPrevSize; 
@@ -205,14 +205,14 @@ void GetMemoryIndex(unsigned int nMemsPerLyr[nLyrs]
 	, ap_uint<kLyBitsSize> hEncLyr 
 	, unsigned int &hIndx ) 
 {
-  #pragma HLS inline
-  #pragma HLS array_partition variable = nMemsPerLyr complete
+#pragma HLS inline
+#pragma HLS array_partition variable = nMemsPerLyr complete
 	// update index
 	int cPrevIndx=0; 
 	LOOP_UpdateMemIndx:
 	for (int cLyr = 0; cLyr < nLyrs; cLyr++) 
 	{
-		#pragma HLS unroll
+#pragma HLS unroll
 		int cUpdate = (cLyr < hEncLyr) ? nMemsPerLyr[cLyr] : 0; 
 		hIndx = cPrevIndx + cUpdate; 
 		cPrevIndx = hIndx;
@@ -228,8 +228,8 @@ void InputRouter( const BXType bx
 	, DTCStubMemory hOutputStubs[nOMems])
 {
 	
-	#pragma HLS inline
-	#pragma HLS array_partition variable = hOutputStubs complete
+#pragma HLS inline
+#pragma HLS array_partition variable = hOutputStubs complete
 
 	ap_uint<1> hIs2S= hLinkWord.range(kLINKMAPwidth-4,kLINKMAPwidth-4);
 
@@ -244,8 +244,8 @@ void InputRouter( const BXType bx
 	LOOP_ProcessIR:
 	for (int cStubCounter = 0; cStubCounter < kMaxProc; cStubCounter++) 
 	{
-	#pragma HLS pipeline II = 1
-	#pragma HLS PIPELINE rewind
+#pragma HLS pipeline II = 1
+#pragma HLS PIPELINE rewind
 	  // decode stub
 	  auto hStub = hInputStubs[cStubCounter];
 	  // add check of valid bit here 
@@ -253,12 +253,12 @@ void InputRouter( const BXType bx
 	  // check valid bit
 	  auto hVldBt = hStub.range( kMSBVldBt ,  kLSBVldBt);
 	  if( hVldBt == 0 ){ 
-	  	#ifndef __SYNTHESIS__
-	  		#if IR_DEBUG
-	                edm::LogWarning("L1trackHLS") << "\t.. Invalid Stub : " << std::hex << hStub << std::dec << "\n";
-	  		#endif
-	  	#endif
-	  	continue;
+#ifndef __SYNTHESIS__
+#if IR_DEBUG
+	    edm::LogWarning("L1trackHLS") << "\t.. Invalid Stub : " << std::hex << hStub << std::dec << "\n";
+#endif
+#endif
+	    continue;
 	  }
 	  // check which memory
 	  // needs to be filled 
@@ -324,8 +324,8 @@ void InputRouter( const BXType bx
 	  // assign memory index
 	  auto cMemIndx = cIndx+cIndxThisBn;
 	  assert(cMemIndx < nMems);
-	  #ifndef __SYNTHESIS__
-	  	#if IR_DEBUG
+#ifndef __SYNTHESIS__
+#if IR_DEBUG
 	  edm::LogVerbatim("L1trackHLS") << "\t.. Stub : " << std::hex << hStub << std::dec 
 		   				<< " rel. parts : " << std::hex << hStbWrd << std::dec
 			            << " [ EncLyrId " << hEncLyr << " ] "
@@ -336,8 +336,8 @@ void InputRouter( const BXType bx
 			            << " [ Indx " << cIndx << " ] "
 			            << " [ memIndx " << cMemIndx << " ] "
 			            << "\n";
-		#endif
-	#endif
+#endif
+#endif
 	  
 	  // update  counters 
 	  auto hEntries = hNStubs[cMemIndx];

--- a/TrackletAlgorithm/InputRouter.h
+++ b/TrackletAlgorithm/InputRouter.h
@@ -6,12 +6,13 @@
 #include "Constants.h"
 #include "AllStubMemory.h"
 #include "DTCStubMemory.h"
+#ifndef __SYNTHESIS__
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #else
 #include "DummyMessageLogger.h"
 #endif
-
+#endif
 // link map
 static const int kNBitsLnkDsc = 4; 
 static const int kNBitsNLnks = 6; 
@@ -254,7 +255,7 @@ void InputRouter( const BXType bx
 	  if( hVldBt == 0 ){ 
 	  	#ifndef __SYNTHESIS__
 	  		#if IR_DEBUG
-	                edm::LogWarning("FWHLS") << "\t.. Invalid Stub : " << std::hex << hStub << std::dec << "\n";
+	                edm::LogWarning("L1trackHLS") << "\t.. Invalid Stub : " << std::hex << hStub << std::dec << "\n";
 	  		#endif
 	  	#endif
 	  	continue;
@@ -325,7 +326,7 @@ void InputRouter( const BXType bx
 	  assert(cMemIndx < nMems);
 	  #ifndef __SYNTHESIS__
 	  	#if IR_DEBUG
-	  edm::LogVerbatim("FWHLS") << "\t.. Stub : " << std::hex << hStub << std::dec 
+	  edm::LogVerbatim("L1trackHLS") << "\t.. Stub : " << std::hex << hStub << std::dec 
 		   				<< " rel. parts : " << std::hex << hStbWrd << std::dec
 			            << " [ EncLyrId " << hEncLyr << " ] "
 						<< "[ LyrId " << hLyrId << " ] "

--- a/TrackletAlgorithm/InputRouter.h
+++ b/TrackletAlgorithm/InputRouter.h
@@ -6,7 +6,11 @@
 #include "Constants.h"
 #include "AllStubMemory.h"
 #include "DTCStubMemory.h"
-
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#else
+#include "DummyMessageLogger.h"
+#endif
 
 // link map
 static const int kNBitsLnkDsc = 4; 
@@ -250,7 +254,7 @@ void InputRouter( const BXType bx
 	  if( hVldBt == 0 ){ 
 	  	#ifndef __SYNTHESIS__
 	  		#if IR_DEBUG
-	  			std::cout << "\t.. Invalid Stub : " << std::hex << hStub << std::dec << "\n";
+	                edm::LogWarning("HLS") << "\t.. Invalid Stub : " << std::hex << hStub << std::dec << "\n";
 	  		#endif
 	  	#endif
 	  	continue;
@@ -321,7 +325,7 @@ void InputRouter( const BXType bx
 	  assert(cMemIndx < nMems);
 	  #ifndef __SYNTHESIS__
 	  	#if IR_DEBUG
-		   std::cout << "\t.. Stub : " << std::hex << hStub << std::dec 
+	  edm::LogVerbatim("HLS") << "\t.. Stub : " << std::hex << hStub << std::dec 
 		   				<< " rel. parts : " << std::hex << hStbWrd << std::dec
 			            << " [ EncLyrId " << hEncLyr << " ] "
 						<< "[ LyrId " << hLyrId << " ] "

--- a/TrackletAlgorithm/MatchEngine.cc
+++ b/TrackletAlgorithm/MatchEngine.cc
@@ -71,7 +71,7 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 	#pragma HLS dependence variable=istub intra WAR true
 
 #ifdef DEBUG
-	edm::LogVerbatim("FWHLS") << "ProjectionIndex\tStubIndex\t<=== (PASS/FAIL)" << std::endl;
+	edm::LogVerbatim("L1trackHLS") << "ProjectionIndex\tStubIndex\t<=== (PASS/FAIL)" << std::endl;
 #endif
 
 	// Main processing loops starts here.
@@ -128,11 +128,11 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 				projectionBuffer[head_writeindex_tmp_last] = nstublast.concat(tmp2);
 			}
 #ifdef DEBUG
-			edm::LogVerbatim("FWHLS") << "Writing " << savefirst+savelast << " z-bins ==> head_writeindex " << head_writeindex << "-->";
+			edm::LogVerbatim("L1trackHLS") << "Writing " << savefirst+savelast << " z-bins ==> head_writeindex " << head_writeindex << "-->";
 #endif
 			head_writeindex = head_writeindex + savefirst + savelast;
 #ifdef DEBUG
-			edm::LogVerbatim("FWHLS") << head_writeindex << std::endl;
+			edm::LogVerbatim("L1trackHLS") << head_writeindex << std::endl;
 #endif
 		}
 
@@ -186,7 +186,7 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 
 			// Check if stub bend and proj rinv consistent
 #ifdef DEBUG
-			edm::LogVerbatim("FWHLS") << projindex.to_string() << "\t" << stubindex.to_string() << "\t<=== ";
+			edm::LogVerbatim("L1trackHLS") << projindex.to_string() << "\t" << stubindex.to_string() << "\t<=== ";
 #endif
 			auto const index=projrinv.concat(stubbend);
 			if ( passphi && pass && table[index]) {
@@ -194,14 +194,14 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 				outputCandidateMatch.write_mem(bx,cmatch,ncmatch);
 				ncmatch++;
 #ifdef DEBUG
-				edm::LogVerbatim("FWHLS") << "PASS -- " << ncmatch-1 << "\n";
+				edm::LogVerbatim("L1trackHLS") << "PASS -- " << ncmatch-1 << "\n";
 #endif
 			}
 #ifdef DEBUG
 			else {
-			  edm::LogVerbatim("FWHLS") << "FAIL" << "\n";
+			  edm::LogVerbatim("L1trackHLS") << "FAIL" << "\n";
 			}
-			edm::LogVerbatim("FWHLS") << "\ttail_readindex: " << tail_readindex << "\n"
+			edm::LogVerbatim("L1trackHLS") << "\ttail_readindex: " << tail_readindex << "\n"
 					  << "\thead_writeindex: " << head_writeindex << "\n"
 					  << "\tsecond: " << second << "\n"
 					  << "\tprojfinez: " << projfinez << "\n"

--- a/TrackletAlgorithm/MatchEngine.cc
+++ b/TrackletAlgorithm/MatchEngine.cc
@@ -71,7 +71,7 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 	#pragma HLS dependence variable=istub intra WAR true
 
 #ifdef DEBUG
-	std::cout << "ProjectionIndex\tStubIndex\t<=== (PASS/FAIL)" << std::endl;
+	edm::LogVerbatim("HLS") << "ProjectionIndex\tStubIndex\t<=== (PASS/FAIL)" << std::endl;
 #endif
 
 	// Main processing loops starts here.
@@ -128,11 +128,11 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 				projectionBuffer[head_writeindex_tmp_last] = nstublast.concat(tmp2);
 			}
 #ifdef DEBUG
-			std::cout << "Writing " << savefirst+savelast << " z-bins ==> head_writeindex " << head_writeindex << "-->";
+			edm::LogVerbatim("HLS") << "Writing " << savefirst+savelast << " z-bins ==> head_writeindex " << head_writeindex << "-->";
 #endif
 			head_writeindex = head_writeindex + savefirst + savelast;
 #ifdef DEBUG
-			std::cout << head_writeindex << std::endl;
+			edm::LogVerbatim("HLS") << head_writeindex << std::endl;
 #endif
 		}
 
@@ -186,7 +186,7 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 
 			// Check if stub bend and proj rinv consistent
 #ifdef DEBUG
-			std::cout << projindex.to_string() << "\t" << stubindex.to_string() << "\t<=== ";
+			edm::LogVerbatim("HLS") << projindex.to_string() << "\t" << stubindex.to_string() << "\t<=== ";
 #endif
 			auto const index=projrinv.concat(stubbend);
 			if ( passphi && pass && table[index]) {
@@ -194,14 +194,14 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 				outputCandidateMatch.write_mem(bx,cmatch,ncmatch);
 				ncmatch++;
 #ifdef DEBUG
-				std::cout << "PASS -- " << ncmatch-1 << "\n";
+				edm::LogVerbatim("HLS") << "PASS -- " << ncmatch-1 << "\n";
 #endif
 			}
 #ifdef DEBUG
 			else {
-				std::cout << "FAIL" << "\n";
+			  edm::LogVerbatim("HLS") << "FAIL" << "\n";
 			}
-			std::cout << "\ttail_readindex: " << tail_readindex << "\n"
+			edm::LogVerbatim("HLS") << "\ttail_readindex: " << tail_readindex << "\n"
 					  << "\thead_writeindex: " << head_writeindex << "\n"
 					  << "\tsecond: " << second << "\n"
 					  << "\tprojfinez: " << projfinez << "\n"

--- a/TrackletAlgorithm/MatchEngine.cc
+++ b/TrackletAlgorithm/MatchEngine.cc
@@ -71,7 +71,7 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 	#pragma HLS dependence variable=istub intra WAR true
 
 #ifdef DEBUG
-	edm::LogVerbatim("HLS") << "ProjectionIndex\tStubIndex\t<=== (PASS/FAIL)" << std::endl;
+	edm::LogVerbatim("FWHLS") << "ProjectionIndex\tStubIndex\t<=== (PASS/FAIL)" << std::endl;
 #endif
 
 	// Main processing loops starts here.
@@ -128,11 +128,11 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 				projectionBuffer[head_writeindex_tmp_last] = nstublast.concat(tmp2);
 			}
 #ifdef DEBUG
-			edm::LogVerbatim("HLS") << "Writing " << savefirst+savelast << " z-bins ==> head_writeindex " << head_writeindex << "-->";
+			edm::LogVerbatim("FWHLS") << "Writing " << savefirst+savelast << " z-bins ==> head_writeindex " << head_writeindex << "-->";
 #endif
 			head_writeindex = head_writeindex + savefirst + savelast;
 #ifdef DEBUG
-			edm::LogVerbatim("HLS") << head_writeindex << std::endl;
+			edm::LogVerbatim("FWHLS") << head_writeindex << std::endl;
 #endif
 		}
 
@@ -186,7 +186,7 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 
 			// Check if stub bend and proj rinv consistent
 #ifdef DEBUG
-			edm::LogVerbatim("HLS") << projindex.to_string() << "\t" << stubindex.to_string() << "\t<=== ";
+			edm::LogVerbatim("FWHLS") << projindex.to_string() << "\t" << stubindex.to_string() << "\t<=== ";
 #endif
 			auto const index=projrinv.concat(stubbend);
 			if ( passphi && pass && table[index]) {
@@ -194,14 +194,14 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 				outputCandidateMatch.write_mem(bx,cmatch,ncmatch);
 				ncmatch++;
 #ifdef DEBUG
-				edm::LogVerbatim("HLS") << "PASS -- " << ncmatch-1 << "\n";
+				edm::LogVerbatim("FWHLS") << "PASS -- " << ncmatch-1 << "\n";
 #endif
 			}
 #ifdef DEBUG
 			else {
-			  edm::LogVerbatim("HLS") << "FAIL" << "\n";
+			  edm::LogVerbatim("FWHLS") << "FAIL" << "\n";
 			}
-			edm::LogVerbatim("HLS") << "\ttail_readindex: " << tail_readindex << "\n"
+			edm::LogVerbatim("FWHLS") << "\ttail_readindex: " << tail_readindex << "\n"
 					  << "\thead_writeindex: " << head_writeindex << "\n"
 					  << "\tsecond: " << second << "\n"
 					  << "\tprojfinez: " << projfinez << "\n"

--- a/TrackletAlgorithm/MatchEngine.h
+++ b/TrackletAlgorithm/MatchEngine.h
@@ -11,12 +11,13 @@
 #include <iostream>
 #include <fstream>
 
+#ifndef __SYNTHESIS__
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #else
 #include "DummyMessageLogger.h"
 #endif
-
+#endif
 /////////////////////////////
 // -- PREPROCESSOR FUNCTIONS
 #define IS_REPRESENTIBLE_IN_D_BITS(D, N)                \

--- a/TrackletAlgorithm/MatchEngine.h
+++ b/TrackletAlgorithm/MatchEngine.h
@@ -11,6 +11,12 @@
 #include <iostream>
 #include <fstream>
 
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#else
+#include "DummyMessageLogger.h"
+#endif
+
 /////////////////////////////
 // -- PREPROCESSOR FUNCTIONS
 #define IS_REPRESENTIBLE_IN_D_BITS(D, N)                \

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -747,10 +747,10 @@ void MatchProcessor(BXType bx,
       //memory the projection points to
       
       // number of bits used to distinguish the different modules in each layer/disk
-      auto nbits_all = LAYER!=0 ? nbitsallstubs[LAYER-1] : nbitsallstubs[N_LAYER + DISK-1];
+      auto nbits_all = LAYER!=0 ? nbitsallstubs[LAYER-1] : nbitsallstubs[trklet::N_LAYER + DISK-1];
       
       // number of bits used to distinguish between VMs within a module
-      auto nbits_vmme = LAYER!=0 ? nbits_vmmeall[LAYER-1] : nbits_vmmeall[N_LAYER + DISK-1];
+      auto nbits_vmme = LAYER!=0 ? nbits_vmmeall[LAYER-1] : nbits_vmmeall[trklet::N_LAYER + DISK-1];
       
       // bits used for routing
       iphi = iphiproj.range(iphiproj.length()-nbits_all-1,iphiproj.length()-nbits_all-nbits_vmme);

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -6,7 +6,15 @@
 
 template<int> class AllStub;
 
+#ifdef CMSSW_GIT_HASH
+#define NBIT_BX 0
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+template<class DataType, unsigned int DUMMY, unsigned int NBIT_ADDR>
+#else
+#include "DummyMessageLogger.h"
 template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR>
+#endif
+
 // DataType: type of data object stored in the array
 // NBIT_BX: number of bits for BX;
 // (1<<NBIT_BIN): number of BXs the memory is keeping track of
@@ -119,8 +127,8 @@ public:
   // print memory contents
   void print_data(const DataType data) const
   {
-	std::cout << std::hex << data.raw() << std::endl;
-	// TODO: overload '<<' in data class
+    edm::LogVerbatim("HLS") << std::hex << data.raw() << std::endl;
+        // TODO: overload '<<' in data class
   }
 
   void print_entry(BunchXingT bx, ap_uint<NBIT_ADDR> index) const
@@ -131,7 +139,7 @@ public:
   void print_mem(BunchXingT bx) const
   {
 	for (unsigned int i = 0; i <  nentries_[bx]; ++i) {
-	  std::cout << bx << " " << i << " ";
+	  edm::LogVerbatim("HLS") << bx << " " << i << " ";
 	  print_entry(bx,i);
 	}
   }
@@ -140,8 +148,8 @@ public:
   {
 	for (unsigned int ibx = 0; ibx < (1<<NBIT_BX); ++ibx) {
 	  for (unsigned int i = 0; i < nentries_[ibx]; ++i) {
-		std::cout << ibx << " " << i << " ";
-		print_entry(ibx,i);
+	    edm::LogVerbatim("HLS") << ibx << " " << i << " ";
+	    print_entry(ibx,i);
 	  }
 	}
   }

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -6,12 +6,18 @@
 
 template<int> class AllStub;
 
+#ifndef __SYNTHESIS__
 #ifdef CMSSW_GIT_HASH
-#define NBIT_BX 0
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-template<class DataType, unsigned int DUMMY, unsigned int NBIT_ADDR>
 #else
 #include "DummyMessageLogger.h"
+#endif
+#endif
+
+#ifdef CMSSW_GIT_HASH
+#define NBIT_BX 0
+template<class DataType, unsigned int DUMMY, unsigned int NBIT_ADDR>
+#else
 template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR>
 #endif
 
@@ -127,7 +133,7 @@ public:
   // print memory contents
   void print_data(const DataType data) const
   {
-    edm::LogVerbatim("FWHLS") << std::hex << data.raw() << std::endl;
+    edm::LogVerbatim("L1trackHLS") << std::hex << data.raw() << std::endl;
         // TODO: overload '<<' in data class
   }
 
@@ -139,7 +145,7 @@ public:
   void print_mem(BunchXingT bx) const
   {
 	for (unsigned int i = 0; i <  nentries_[bx]; ++i) {
-	  edm::LogVerbatim("FWHLS") << bx << " " << i << " ";
+	  edm::LogVerbatim("L1trackHLS") << bx << " " << i << " ";
 	  print_entry(bx,i);
 	}
   }
@@ -148,7 +154,7 @@ public:
   {
 	for (unsigned int ibx = 0; ibx < (1<<NBIT_BX); ++ibx) {
 	  for (unsigned int i = 0; i < nentries_[ibx]; ++i) {
-	    edm::LogVerbatim("FWHLS") << ibx << " " << i << " ";
+	    edm::LogVerbatim("L1trackHLS") << ibx << " " << i << " ";
 	    print_entry(ibx,i);
 	  }
 	}

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -127,7 +127,7 @@ public:
   // print memory contents
   void print_data(const DataType data) const
   {
-    edm::LogVerbatim("HLS") << std::hex << data.raw() << std::endl;
+    edm::LogVerbatim("FWHLS") << std::hex << data.raw() << std::endl;
         // TODO: overload '<<' in data class
   }
 
@@ -139,7 +139,7 @@ public:
   void print_mem(BunchXingT bx) const
   {
 	for (unsigned int i = 0; i <  nentries_[bx]; ++i) {
-	  edm::LogVerbatim("HLS") << bx << " " << i << " ";
+	  edm::LogVerbatim("FWHLS") << bx << " " << i << " ";
 	  print_entry(bx,i);
 	}
   }
@@ -148,7 +148,7 @@ public:
   {
 	for (unsigned int ibx = 0; ibx < (1<<NBIT_BX); ++ibx) {
 	  for (unsigned int i = 0; i < nentries_[ibx]; ++i) {
-	    edm::LogVerbatim("HLS") << ibx << " " << i << " ";
+	    edm::LogVerbatim("FWHLS") << ibx << " " << i << " ";
 	    print_entry(ibx,i);
 	  }
 	}

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -79,7 +79,7 @@ public:
 	}
 	else {
 #ifndef __SYNTHESIS__
-edm::LogWarning("HLS") << "Warning out of range: adress within bin " << nentry_ibx << ", stub " << data.raw() << std::endl;
+edm::LogWarning("FWHLS") << "Warning out of range: adress within bin " << nentry_ibx << ", stub " << data.raw() << std::endl;
 #endif
 	  return false;
 	}
@@ -144,7 +144,7 @@ edm::LogWarning("HLS") << "Warning out of range: adress within bin " << nentry_i
   // print memory contents
   void print_data(const DataType data) const
   {
-    edm::LogVerbatim("HLS") << std::hex << data.raw() << std::endl;
+    edm::LogVerbatim("FWHLS") << std::hex << data.raw() << std::endl;
 	// TODO: overload '<<' in data class
   }
 
@@ -157,7 +157,7 @@ edm::LogWarning("HLS") << "Warning out of range: adress within bin " << nentry_i
   {
 	for(unsigned int slot=0;slot<(kNSlots);slot++) {
 	  for (unsigned int i = 0; i < nentries_[bx][slot]; ++i) {
-	    edm::LogVerbatim("HLS") << bx << " " << i << " ";
+	    edm::LogVerbatim("FWHLS") << bx << " " << i << " ";
 	    print_entry(bx, i + slot*(1<<(kNBitDataAddr)) );
  	  }
 	}
@@ -167,7 +167,7 @@ edm::LogWarning("HLS") << "Warning out of range: adress within bin " << nentry_i
   {
 	for (unsigned int ibx = 0; ibx < (kNBxBins); ++ibx) {
 	  for (unsigned int i = 0; i < nentries_[ibx]; ++i) {
-	    edm::LogVerbatim("HLS") << ibx << " " << i << " ";
+	    edm::LogVerbatim("FWHLS") << ibx << " " << i << " ";
 	    print_entry(ibx,i);
 	  }
 	}

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -6,14 +6,17 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#else
+#include "DummyMessageLogger.h"
+#endif
 #endif
 
 #ifdef CMSSW_GIT_HASH
 #define NBIT_BX 0
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 template<class DataType, unsigned int DUMMY, unsigned int NBIT_ADDR, unsigned int NBIT_BIN>
 #else
-#include "DummyMessageLogger.h"
 template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR, unsigned int NBIT_BIN>
 #endif
 
@@ -79,7 +82,7 @@ public:
 	}
 	else {
 #ifndef __SYNTHESIS__
-edm::LogWarning("FWHLS") << "Warning out of range: adress within bin " << nentry_ibx << ", stub " << data.raw() << std::endl;
+edm::LogWarning("L1trackHLS") << "Warning out of range: adress within bin " << nentry_ibx << ", stub " << data.raw() << std::endl;
 #endif
 	  return false;
 	}
@@ -144,7 +147,7 @@ edm::LogWarning("FWHLS") << "Warning out of range: adress within bin " << nentry
   // print memory contents
   void print_data(const DataType data) const
   {
-    edm::LogVerbatim("FWHLS") << std::hex << data.raw() << std::endl;
+    edm::LogVerbatim("L1trackHLS") << std::hex << data.raw() << std::endl;
 	// TODO: overload '<<' in data class
   }
 
@@ -157,7 +160,7 @@ edm::LogWarning("FWHLS") << "Warning out of range: adress within bin " << nentry
   {
 	for(unsigned int slot=0;slot<(kNSlots);slot++) {
 	  for (unsigned int i = 0; i < nentries_[bx][slot]; ++i) {
-	    edm::LogVerbatim("FWHLS") << bx << " " << i << " ";
+	    edm::LogVerbatim("L1trackHLS") << bx << " " << i << " ";
 	    print_entry(bx, i + slot*(1<<(kNBitDataAddr)) );
  	  }
 	}
@@ -167,7 +170,7 @@ edm::LogWarning("FWHLS") << "Warning out of range: adress within bin " << nentry
   {
 	for (unsigned int ibx = 0; ibx < (kNBxBins); ++ibx) {
 	  for (unsigned int i = 0; i < nentries_[ibx]; ++i) {
-	    edm::LogVerbatim("FWHLS") << ibx << " " << i << " ";
+	    edm::LogVerbatim("L1trackHLS") << ibx << " " << i << " ";
 	    print_entry(ibx,i);
 	  }
 	}

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -8,9 +8,15 @@
 #include <vector>
 #endif
 
+#ifdef CMSSW_GIT_HASH
+#define NBIT_BX 0
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+template<class DataType, unsigned int DUMMY, unsigned int NBIT_ADDR, unsigned int NBIT_BIN>
+#else
+#include "DummyMessageLogger.h"
+template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR, unsigned int NBIT_BIN>
+#endif
 
-template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR,
-		 unsigned int NBIT_BIN>
 // DataType: type of data object stored in the array
 // NBIT_BX: number of bits for BX;
 // (1<<NBIT_BX): number of BXs the memory is keeping track of
@@ -73,7 +79,7 @@ public:
 	}
 	else {
 #ifndef __SYNTHESIS__
-	  std::cout << "Warning out of range: adress within bin " << nentry_ibx << ", stub " << data.raw() << std::endl;
+edm::LogWarning("HLS") << "Warning out of range: adress within bin " << nentry_ibx << ", stub " << data.raw() << std::endl;
 #endif
 	  return false;
 	}
@@ -138,7 +144,7 @@ public:
   // print memory contents
   void print_data(const DataType data) const
   {
-	std::cout << std::hex << data.raw() << std::endl;
+    edm::LogVerbatim("HLS") << std::hex << data.raw() << std::endl;
 	// TODO: overload '<<' in data class
   }
 
@@ -151,8 +157,8 @@ public:
   {
 	for(unsigned int slot=0;slot<(kNSlots);slot++) {
 	  for (unsigned int i = 0; i < nentries_[bx][slot]; ++i) {
-		std::cout << bx << " " << i << " ";
-		print_entry(bx, i + slot*(1<<(kNBitDataAddr)) );
+	    edm::LogVerbatim("HLS") << bx << " " << i << " ";
+	    print_entry(bx, i + slot*(1<<(kNBitDataAddr)) );
  	  }
 	}
   }
@@ -161,8 +167,8 @@ public:
   {
 	for (unsigned int ibx = 0; ibx < (kNBxBins); ++ibx) {
 	  for (unsigned int i = 0; i < nentries_[ibx]; ++i) {
-		std::cout << ibx << " " << i << " ";
-		print_entry(ibx,i);
+	    edm::LogVerbatim("HLS") << ibx << " " << i << " ";
+	    print_entry(ibx,i);
 	  }
 	}
   }

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -124,7 +124,7 @@ class MemoryTemplateBinnedCM{
     else {
 #ifndef __SYNTHESIS__
       if (data.raw() != 0) { // To avoid lots of prints when we're clearing the memories
-	edm::LogWarning("HLS") << "Warning out of range. nentry_ibx = "<<nentry_ibx<<" NBIT_ADDR-NBIT_BIN = "<<NBIT_ADDR-NBIT_BIN << std::endl;
+	edm::LogWarning("FWHLS") << "Warning out of range. nentry_ibx = "<<nentry_ibx<<" NBIT_ADDR-NBIT_BIN = "<<NBIT_ADDR-NBIT_BIN << std::endl;
       }
 #endif
       return false;
@@ -202,7 +202,7 @@ class MemoryTemplateBinnedCM{
   // print memory contents
   void print_data(const DataType data) const
   {
-    edm::LogVerbatim("HLS") << std::hex << data.raw() << std::endl;
+    edm::LogVerbatim("FWHLS") << std::hex << data.raw() << std::endl;
 	// TODO: overload '<<' in data class
   }
 
@@ -217,7 +217,7 @@ class MemoryTemplateBinnedCM{
       //std::cout << "slot "<<slot<<" entries "
       //		<<nentries_[bx%NBX].range((slot+1)*4-1,slot*4)<<endl;
       for (unsigned int i = 0; i < nentries8_[bx][slot]; ++i) {
-	edm::LogVerbatim("HLS") << bx << " " << i << " ";
+	edm::LogVerbatim("FWHLS") << bx << " " << i << " ";
 	print_entry(bx, i + slot*getNEntryPerBin() );
       }
     }
@@ -227,7 +227,7 @@ class MemoryTemplateBinnedCM{
   {
 	for (unsigned int ibx = 0; ibx < kNBxBins; ++ibx) {
 	  for (unsigned int i = 0; i < 8; ++i) {
-	    edm::LogVerbatim("HLS") << ibx << " " << i << " ";
+	    edm::LogVerbatim("FWHLS") << ibx << " " << i << " ";
 	    print_entry(ibx,i);
 	  }
 	}

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -7,14 +7,17 @@
 #include <sstream>
 #include <vector>
 #include <bitset>
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#else
+#include "DummyMessageLogger.h"
+#endif
 #endif
 
 #ifdef CMSSW_GIT_HASH
 #define NBIT_BX 0
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 template<class DataType, unsigned int DUMMY, unsigned int NBIT_ADDR, unsigned int NBIT_BIN, unsigned int NCOPY>
 #else
-#include "DummyMessageLogger.h"
 template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR, unsigned int NBIT_BIN, unsigned int NCOPY>
 #endif
 
@@ -124,7 +127,7 @@ class MemoryTemplateBinnedCM{
     else {
 #ifndef __SYNTHESIS__
       if (data.raw() != 0) { // To avoid lots of prints when we're clearing the memories
-	edm::LogWarning("FWHLS") << "Warning out of range. nentry_ibx = "<<nentry_ibx<<" NBIT_ADDR-NBIT_BIN = "<<NBIT_ADDR-NBIT_BIN << std::endl;
+	edm::LogWarning("L1trackHLS") << "Warning out of range. nentry_ibx = "<<nentry_ibx<<" NBIT_ADDR-NBIT_BIN = "<<NBIT_ADDR-NBIT_BIN << std::endl;
       }
 #endif
       return false;
@@ -202,7 +205,7 @@ class MemoryTemplateBinnedCM{
   // print memory contents
   void print_data(const DataType data) const
   {
-    edm::LogVerbatim("FWHLS") << std::hex << data.raw() << std::endl;
+    edm::LogVerbatim("L1trackHLS") << std::hex << data.raw() << std::endl;
 	// TODO: overload '<<' in data class
   }
 
@@ -217,7 +220,7 @@ class MemoryTemplateBinnedCM{
       //std::cout << "slot "<<slot<<" entries "
       //		<<nentries_[bx%NBX].range((slot+1)*4-1,slot*4)<<endl;
       for (unsigned int i = 0; i < nentries8_[bx][slot]; ++i) {
-	edm::LogVerbatim("FWHLS") << bx << " " << i << " ";
+	edm::LogVerbatim("L1trackHLS") << bx << " " << i << " ";
 	print_entry(bx, i + slot*getNEntryPerBin() );
       }
     }
@@ -227,7 +230,7 @@ class MemoryTemplateBinnedCM{
   {
 	for (unsigned int ibx = 0; ibx < kNBxBins; ++ibx) {
 	  for (unsigned int i = 0; i < 8; ++i) {
-	    edm::LogVerbatim("FWHLS") << ibx << " " << i << " ";
+	    edm::LogVerbatim("L1trackHLS") << ibx << " " << i << " ";
 	    print_entry(ibx,i);
 	  }
 	}

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -9,8 +9,15 @@
 #include <bitset>
 #endif
 
-template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR,
-  unsigned int NBIT_BIN, unsigned int NCOPY>
+#ifdef CMSSW_GIT_HASH
+#define NBIT_BX 0
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+template<class DataType, unsigned int DUMMY, unsigned int NBIT_ADDR, unsigned int NBIT_BIN, unsigned int NCOPY>
+#else
+#include "DummyMessageLogger.h"
+template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR, unsigned int NBIT_BIN, unsigned int NCOPY>
+#endif
+
 // DataType: type of data object stored in the array
 // NBIT_BX: number of bits for BX;
 // (1<<NBIT_BIN): number of BXs the memory is keeping track of
@@ -117,7 +124,7 @@ class MemoryTemplateBinnedCM{
     else {
 #ifndef __SYNTHESIS__
       if (data.raw() != 0) { // To avoid lots of prints when we're clearing the memories
-        std::cout << "Warning out of range. nentry_ibx = "<<nentry_ibx<<" NBIT_ADDR-NBIT_BIN = "<<NBIT_ADDR-NBIT_BIN << std::endl;
+	edm::LogWarning("HLS") << "Warning out of range. nentry_ibx = "<<nentry_ibx<<" NBIT_ADDR-NBIT_BIN = "<<NBIT_ADDR-NBIT_BIN << std::endl;
       }
 #endif
       return false;
@@ -195,7 +202,7 @@ class MemoryTemplateBinnedCM{
   // print memory contents
   void print_data(const DataType data) const
   {
-	std::cout << std::hex << data.raw() << std::endl;
+    edm::LogVerbatim("HLS") << std::hex << data.raw() << std::endl;
 	// TODO: overload '<<' in data class
   }
 
@@ -210,8 +217,8 @@ class MemoryTemplateBinnedCM{
       //std::cout << "slot "<<slot<<" entries "
       //		<<nentries_[bx%NBX].range((slot+1)*4-1,slot*4)<<endl;
       for (unsigned int i = 0; i < nentries8_[bx][slot]; ++i) {
-		std::cout << bx << " " << i << " ";
-		print_entry(bx, i + slot*getNEntryPerBin() );
+	edm::LogVerbatim("HLS") << bx << " " << i << " ";
+	print_entry(bx, i + slot*getNEntryPerBin() );
       }
     }
   }
@@ -220,8 +227,8 @@ class MemoryTemplateBinnedCM{
   {
 	for (unsigned int ibx = 0; ibx < kNBxBins; ++ibx) {
 	  for (unsigned int i = 0; i < 8; ++i) {
-		std::cout << ibx << " " << i << " ";
-		print_entry(ibx,i);
+	    edm::LogVerbatim("HLS") << ibx << " " << i << " ";
+	    print_entry(ibx,i);
 	  }
 	}
   }

--- a/TrackletAlgorithm/ProjectionRouter.h
+++ b/TrackletAlgorithm/ProjectionRouter.h
@@ -6,6 +6,11 @@
 #include "TrackletProjectionMemory.h"
 #include "AllProjectionMemory.h"
 #include "VMProjectionMemory.h"
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#else
+#include "DummyMessageLogger.h"
+#endif
 
 //#include <assert.h>
 
@@ -187,7 +192,7 @@ void ProjectionRouter(BXType bx,
       typename VMProjection<VMPTYPE>::VMPRINV rinv = (1<<(nbits_maxvm-1))+irinv_tmp.range(irinv_tmp.length()-1,irinv_tmp.length()-nbits_maxvm);
       //assert(rinv >=0 and rinv < 32);
 
-      std::cout << "finez zbin1 psseed: "<<finez<<" "<<zbin1<<" "<<psseed<<std::endl;
+      edm::LogVerbatim("HLS") << "finez zbin1 psseed: "<<finez<<" "<<zbin1<<" "<<psseed<<std::endl;
 
       // VM Projection
       VMProjection<VMPTYPE> vmproj(index, zbin, finez, finephi, rinv, psseed);

--- a/TrackletAlgorithm/ProjectionRouter.h
+++ b/TrackletAlgorithm/ProjectionRouter.h
@@ -6,12 +6,13 @@
 #include "TrackletProjectionMemory.h"
 #include "AllProjectionMemory.h"
 #include "VMProjectionMemory.h"
+#ifndef __SYNTHESIS__
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #else
 #include "DummyMessageLogger.h"
 #endif
-
+#endif
 //#include <assert.h>
 
 namespace PR
@@ -192,7 +193,7 @@ void ProjectionRouter(BXType bx,
       typename VMProjection<VMPTYPE>::VMPRINV rinv = (1<<(nbits_maxvm-1))+irinv_tmp.range(irinv_tmp.length()-1,irinv_tmp.length()-nbits_maxvm);
       //assert(rinv >=0 and rinv < 32);
 #ifndef __SYNTHESIS__
-      edm::LogVerbatim("FWHLS") << "finez zbin1 psseed: "<<finez<<" "<<zbin1<<" "<<psseed<<std::endl;
+      edm::LogVerbatim("L1trackHLS") << "finez zbin1 psseed: "<<finez<<" "<<zbin1<<" "<<psseed<<std::endl;
 #endif
       // VM Projection
       VMProjection<VMPTYPE> vmproj(index, zbin, finez, finephi, rinv, psseed);

--- a/TrackletAlgorithm/ProjectionRouter.h
+++ b/TrackletAlgorithm/ProjectionRouter.h
@@ -120,10 +120,10 @@ void ProjectionRouter(BXType bx,
       // hourglass configuration
 
       // number of bits used to distinguish the different modules in each layer/disk
-      auto nbits_all = LAYER!=0 ? nbitsallstubs[LAYER-1] : nbitsallstubs[N_LAYER + DISK-1];
+      auto nbits_all = LAYER!=0 ? nbitsallstubs[LAYER-1] : nbitsallstubs[trklet::N_LAYER + DISK-1];
 
       // number of bits used to distinguish between VMs within a module
-      auto nbits_vmme = LAYER!=0 ? nbits_vmmeall[LAYER-1] : nbits_vmmeall[N_LAYER + DISK-1];
+      auto nbits_vmme = LAYER!=0 ? nbits_vmmeall[LAYER-1] : nbits_vmmeall[trklet::N_LAYER + DISK-1];
 
       // bits used for routing
       auto iphi = iphiproj.range(iphiproj.length()-nbits_all-1,iphiproj.length()-nbits_all-nbits_vmme);

--- a/TrackletAlgorithm/ProjectionRouter.h
+++ b/TrackletAlgorithm/ProjectionRouter.h
@@ -191,9 +191,9 @@ void ProjectionRouter(BXType bx,
       // and is shifted to be positive
       typename VMProjection<VMPTYPE>::VMPRINV rinv = (1<<(nbits_maxvm-1))+irinv_tmp.range(irinv_tmp.length()-1,irinv_tmp.length()-nbits_maxvm);
       //assert(rinv >=0 and rinv < 32);
-
+#ifndef __SYNTHESIS__
       edm::LogVerbatim("FWHLS") << "finez zbin1 psseed: "<<finez<<" "<<zbin1<<" "<<psseed<<std::endl;
-
+#endif
       // VM Projection
       VMProjection<VMPTYPE> vmproj(index, zbin, finez, finephi, rinv, psseed);
 

--- a/TrackletAlgorithm/ProjectionRouter.h
+++ b/TrackletAlgorithm/ProjectionRouter.h
@@ -192,7 +192,7 @@ void ProjectionRouter(BXType bx,
       typename VMProjection<VMPTYPE>::VMPRINV rinv = (1<<(nbits_maxvm-1))+irinv_tmp.range(irinv_tmp.length()-1,irinv_tmp.length()-nbits_maxvm);
       //assert(rinv >=0 and rinv < 32);
 
-      edm::LogVerbatim("HLS") << "finez zbin1 psseed: "<<finez<<" "<<zbin1<<" "<<psseed<<std::endl;
+      edm::LogVerbatim("FWHLS") << "finez zbin1 psseed: "<<finez<<" "<<zbin1<<" "<<psseed<<std::endl;
 
       // VM Projection
       VMProjection<VMPTYPE> vmproj(index, zbin, finez, finephi, rinv, psseed);

--- a/TrackletAlgorithm/ProjectionRouterBuffer.h
+++ b/TrackletAlgorithm/ProjectionRouterBuffer.h
@@ -5,6 +5,11 @@
 #include "MemoryTemplate.h"
 #include "VMProjectionMemory.h"
 #include "AllProjectionMemory.h"
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#else
+#include "DummyMessageLogger.h"
+#endif
 
 // ProjectionRouterBufferBase is where we define the bit widths, which depend on the class template parameter.
 template<int VMProjType, int AllProjetionType> class ProjectionRouterBufferBase {};
@@ -123,8 +128,8 @@ public:
   #ifndef __SYNTHESIS__
   void Print()
   {
-    std::cout << "Contents in buffer:" << std::endl;
-    std::cout << std::hex << "tcid=" << getTCID() << " shift=" << shift() << " nstub=" << getNStubs() << " zbin=" << getZBin() << " projid=" << getIndex() << " proj=" << getProjection() << " isPS=" << getIsPSSeed() << std::endl;
+    edm::LogVerbatim("HLS") << "Contents in buffer:" << std::endl;
+    edm::LogVerbatim("HLS") << std::hex << "tcid=" << getTCID() << " shift=" << shift() << " nstub=" << getNStubs() << " zbin=" << getZBin() << " projid=" << getIndex() << " proj=" << getProjection() << " isPS=" << getIsPSSeed() << std::endl;
   }
   #endif
   

--- a/TrackletAlgorithm/ProjectionRouterBuffer.h
+++ b/TrackletAlgorithm/ProjectionRouterBuffer.h
@@ -128,8 +128,8 @@ public:
   #ifndef __SYNTHESIS__
   void Print()
   {
-    edm::LogVerbatim("HLS") << "Contents in buffer:" << std::endl;
-    edm::LogVerbatim("HLS") << std::hex << "tcid=" << getTCID() << " shift=" << shift() << " nstub=" << getNStubs() << " zbin=" << getZBin() << " projid=" << getIndex() << " proj=" << getProjection() << " isPS=" << getIsPSSeed() << std::endl;
+    edm::LogVerbatim("FWHLS") << "Contents in buffer:" << std::endl;
+    edm::LogVerbatim("FWHLS") << std::hex << "tcid=" << getTCID() << " shift=" << shift() << " nstub=" << getNStubs() << " zbin=" << getZBin() << " projid=" << getIndex() << " proj=" << getProjection() << " isPS=" << getIsPSSeed() << std::endl;
   }
   #endif
   

--- a/TrackletAlgorithm/ProjectionRouterBuffer.h
+++ b/TrackletAlgorithm/ProjectionRouterBuffer.h
@@ -5,10 +5,12 @@
 #include "MemoryTemplate.h"
 #include "VMProjectionMemory.h"
 #include "AllProjectionMemory.h"
+#ifndef __SYNTHESIS__
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #else
 #include "DummyMessageLogger.h"
+#endif
 #endif
 
 // ProjectionRouterBufferBase is where we define the bit widths, which depend on the class template parameter.
@@ -128,8 +130,8 @@ public:
   #ifndef __SYNTHESIS__
   void Print()
   {
-    edm::LogVerbatim("FWHLS") << "Contents in buffer:" << std::endl;
-    edm::LogVerbatim("FWHLS") << std::hex << "tcid=" << getTCID() << " shift=" << shift() << " nstub=" << getNStubs() << " zbin=" << getZBin() << " projid=" << getIndex() << " proj=" << getProjection() << " isPS=" << getIsPSSeed() << std::endl;
+    edm::LogVerbatim("L1trackHLS") << "Contents in buffer:" << std::endl;
+    edm::LogVerbatim("L1trackHLS") << std::hex << "tcid=" << getTCID() << " shift=" << shift() << " nstub=" << getNStubs() << " zbin=" << getZBin() << " projid=" << getIndex() << " proj=" << getProjection() << " isPS=" << getIsPSSeed() << std::endl;
   }
   #endif
   

--- a/TrackletAlgorithm/TrackletCalculator.h
+++ b/TrackletAlgorithm/TrackletCalculator.h
@@ -279,7 +279,7 @@ TC::barrelSeeding(const AllStub<InnerRegion<Seed>()> &innerStub, const AllStub<O
   );
 
 // Determine which layer projections are valid.
-  valid_proj: for (ap_uint<3> i = 0; i < N_LAYER - 2; i++) {
+ valid_proj: for (ap_uint<3> i = 0; i < trklet::N_LAYER - 2; i++) {
     valid_proj[i] = true;
     if (zL[i] < -(1 << (TrackletProjection<BARRELPS>::kTProjRZSize - 1)))
       valid_proj[i] = false;
@@ -299,7 +299,7 @@ TC::barrelSeeding(const AllStub<InnerRegion<Seed>()> &innerStub, const AllStub<O
   }
 
 // Determine which disk projections are valid.
-  valid_proj_disk: for (ap_uint<3> i = 0; i < N_DISK - 1; i++) {
+ valid_proj_disk: for (ap_uint<3> i = 0; i < trklet::N_DISK - 1; i++) {
     valid_proj_disk[i] = true;
     if (abs(*t) < floatToInt(1.0, kt)) // disk projections are invalid if |t| < 1
       valid_proj_disk[i] = false;
@@ -430,16 +430,16 @@ TC::processStubPair(
   TrackletParameters::PHI0PAR phi0;
   TC::Types::z0 z0;
   TrackletParameters::TPAR t;
-  TC::Types::phiL phiL[N_LAYER - 2];
-  TC::Types::zL zL[N_LAYER - 2];
+  TC::Types::phiL phiL[trklet::N_LAYER - 2];
+  TC::Types::zL zL[trklet::N_LAYER - 2];
   TC::Types::der_phiL der_phiL;
   TC::Types::der_zL der_zL;
-  TC::Types::flag valid_proj[N_LAYER - 2];
-  TC::Types::phiD phiD[N_DISK - 1];
-  TC::Types::rD rD[N_DISK - 1];
+  TC::Types::flag valid_proj[trklet::N_LAYER - 2];
+  TC::Types::phiD phiD[trklet::N_DISK - 1];
+  TC::Types::rD rD[trklet::N_DISK - 1];
   TC::Types::der_phiD der_phiD;
   TC::Types::der_rD der_rD;
-  TC::Types::flag valid_proj_disk[N_DISK - 1];
+  TC::Types::flag valid_proj_disk[trklet::N_DISK - 1];
   bool success;
 
 // Calculate the tracklet parameters and projections.

--- a/TrackletAlgorithm/TrackletCalculator.h
+++ b/TrackletAlgorithm/TrackletCalculator.h
@@ -279,7 +279,7 @@ TC::barrelSeeding(const AllStub<InnerRegion<Seed>()> &innerStub, const AllStub<O
   );
 
 // Determine which layer projections are valid.
- valid_proj: for (ap_uint<3> i = 0; i < trklet::N_LAYER - 2; i++) {
+  valid_proj: for (ap_uint<3> i = 0; i < trklet::N_LAYER - 2; i++) {
     valid_proj[i] = true;
     if (zL[i] < -(1 << (TrackletProjection<BARRELPS>::kTProjRZSize - 1)))
       valid_proj[i] = false;

--- a/TrackletAlgorithm/VMRouter.h
+++ b/TrackletAlgorithm/VMRouter.h
@@ -25,7 +25,11 @@
 #include "VMStubMEMemory.h"
 #include "VMStubTEInnerMemory.h"
 #include "VMStubTEOuterMemory.h"
-
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#else
+#include "DummyMessageLogger.h"
+#endif
 
 /////////////////////////////////////////
 // Constants
@@ -716,7 +720,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			std::cout << std::endl << "Stub index no. " << i << std::endl << "Out put stub: " << std::hex << allstub.raw() << std::dec
+			edm::LogVerbatim("HLS") << std::endl << "Stub index no. " << i << std::endl << "Out put stub: " << std::hex << allstub.raw() << std::dec
 					<< std::endl;
 #endif // DEBUG
 
@@ -739,8 +743,8 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			std::cout << "ME stub " << std::hex << stubME.raw() << std::endl;
-			std::cout << "ivm Minus,Plus = " << std::dec << ivmMinus << " " << ivmPlus << " " << "\t0x"
+			edm::LogVerbatim("HLS") << "ME stub " << std::hex << stubME.raw() << std::endl;
+			edm::LogVerbatim("HLS") << "ivm Minus,Plus = " << std::dec << ivmMinus << " " << ivmPlus << " " << "\t0x"
 					<< std::setfill('0') << std::setw(4) << std::hex
 					<< stubME.raw().to_int() << std::dec << ", to bin " << bin << std::endl;
 			if (!maskME[ivmPlus]) {
@@ -788,9 +792,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			std::cout << "TEInner stub " << std::hex << stubTEI.raw()
+			edm::LogVerbatim("HLS") << "TEInner stub " << std::hex << stubTEI.raw()
 					<< std::endl;
-			std::cout << "ivm: " << std::dec << ivm <<std::endl
+			edm::LogVerbatim("HLS") << "ivm: " << std::dec << ivm <<std::endl
 					<< std::endl;
 #endif // DEBUG
 
@@ -828,9 +832,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			std::cout << "TEOuter stub " << std::hex << stubTEO.raw()
+			edm::LogVerbatim("HLS") << "TEOuter stub " << std::hex << stubTEO.raw()
 					<< std::endl;
-			std::cout << "    ivm: " << std::dec << ivm << "       to bin " << bin << std::endl;
+			edm::LogVerbatim("HLS") << "    ivm: " << std::dec << ivm << "       to bin " << bin << std::endl;
 #endif // DEBUG
 
 			// Write the TE Outer stub to the correct memory
@@ -872,9 +876,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			std::cout << "Overlap stub " << " " << std::hex
+			edm::LogVerbatim("HLS") << "Overlap stub " << " " << std::hex
 					<< stubOL.raw() << std::endl;
-			std::cout << "ivm: " << std::dec << ivm << std::endl
+			edm::LogVerbatim("HLS") << "ivm: " << std::dec << ivm << std::endl
 					<< std::endl;
 #endif // DEBUG
 
@@ -897,7 +901,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 // For debugging
 #ifndef __SYNTHESIS__
 			else {
-				std::cout << "NO OVERLAP" << std::endl << std::endl;
+			  edm::LogVerbatim("HLS") << "NO OVERLAP" << std::endl << std::endl;
 			}
 #endif // DEBUG
 

--- a/TrackletAlgorithm/VMRouter.h
+++ b/TrackletAlgorithm/VMRouter.h
@@ -720,7 +720,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			edm::LogVerbatim("HLS") << std::endl << "Stub index no. " << i << std::endl << "Out put stub: " << std::hex << allstub.raw() << std::dec
+			edm::LogVerbatim("FWHLS") << std::endl << "Stub index no. " << i << std::endl << "Out put stub: " << std::hex << allstub.raw() << std::dec
 					<< std::endl;
 #endif // DEBUG
 
@@ -743,8 +743,8 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			edm::LogVerbatim("HLS") << "ME stub " << std::hex << stubME.raw() << std::endl;
-			edm::LogVerbatim("HLS") << "ivm Minus,Plus = " << std::dec << ivmMinus << " " << ivmPlus << " " << "\t0x"
+			edm::LogVerbatim("FWHLS") << "ME stub " << std::hex << stubME.raw() << std::endl;
+			edm::LogVerbatim("FWHLS") << "ivm Minus,Plus = " << std::dec << ivmMinus << " " << ivmPlus << " " << "\t0x"
 					<< std::setfill('0') << std::setw(4) << std::hex
 					<< stubME.raw().to_int() << std::dec << ", to bin " << bin << std::endl;
 			if (!maskME[ivmPlus]) {
@@ -792,9 +792,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			edm::LogVerbatim("HLS") << "TEInner stub " << std::hex << stubTEI.raw()
+			edm::LogVerbatim("FWHLS") << "TEInner stub " << std::hex << stubTEI.raw()
 					<< std::endl;
-			edm::LogVerbatim("HLS") << "ivm: " << std::dec << ivm <<std::endl
+			edm::LogVerbatim("FWHLS") << "ivm: " << std::dec << ivm <<std::endl
 					<< std::endl;
 #endif // DEBUG
 
@@ -832,9 +832,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			edm::LogVerbatim("HLS") << "TEOuter stub " << std::hex << stubTEO.raw()
+			edm::LogVerbatim("FWHLS") << "TEOuter stub " << std::hex << stubTEO.raw()
 					<< std::endl;
-			edm::LogVerbatim("HLS") << "    ivm: " << std::dec << ivm << "       to bin " << bin << std::endl;
+			edm::LogVerbatim("FWHLS") << "    ivm: " << std::dec << ivm << "       to bin " << bin << std::endl;
 #endif // DEBUG
 
 			// Write the TE Outer stub to the correct memory
@@ -876,9 +876,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			edm::LogVerbatim("HLS") << "Overlap stub " << " " << std::hex
+			edm::LogVerbatim("FWHLS") << "Overlap stub " << " " << std::hex
 					<< stubOL.raw() << std::endl;
-			edm::LogVerbatim("HLS") << "ivm: " << std::dec << ivm << std::endl
+			edm::LogVerbatim("FWHLS") << "ivm: " << std::dec << ivm << std::endl
 					<< std::endl;
 #endif // DEBUG
 
@@ -901,7 +901,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 // For debugging
 #ifndef __SYNTHESIS__
 			else {
-			  edm::LogVerbatim("HLS") << "NO OVERLAP" << std::endl << std::endl;
+			  edm::LogVerbatim("FWHLS") << "NO OVERLAP" << std::endl << std::endl;
 			}
 #endif // DEBUG
 

--- a/TrackletAlgorithm/VMRouter.h
+++ b/TrackletAlgorithm/VMRouter.h
@@ -25,12 +25,13 @@
 #include "VMStubMEMemory.h"
 #include "VMStubTEInnerMemory.h"
 #include "VMStubTEOuterMemory.h"
+#ifndef __SYNTHESIS__
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #else
 #include "DummyMessageLogger.h"
 #endif
-
+#endif
 /////////////////////////////////////////
 // Constants
 
@@ -720,7 +721,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			edm::LogVerbatim("FWHLS") << std::endl << "Stub index no. " << i << std::endl << "Out put stub: " << std::hex << allstub.raw() << std::dec
+			edm::LogVerbatim("L1trackHLS") << std::endl << "Stub index no. " << i << std::endl << "Out put stub: " << std::hex << allstub.raw() << std::dec
 					<< std::endl;
 #endif // DEBUG
 
@@ -743,8 +744,8 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			edm::LogVerbatim("FWHLS") << "ME stub " << std::hex << stubME.raw() << std::endl;
-			edm::LogVerbatim("FWHLS") << "ivm Minus,Plus = " << std::dec << ivmMinus << " " << ivmPlus << " " << "\t0x"
+			edm::LogVerbatim("L1trackHLS") << "ME stub " << std::hex << stubME.raw() << std::endl;
+			edm::LogVerbatim("L1trackHLS") << "ivm Minus,Plus = " << std::dec << ivmMinus << " " << ivmPlus << " " << "\t0x"
 					<< std::setfill('0') << std::setw(4) << std::hex
 					<< stubME.raw().to_int() << std::dec << ", to bin " << bin << std::endl;
 			if (!maskME[ivmPlus]) {
@@ -792,9 +793,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			edm::LogVerbatim("FWHLS") << "TEInner stub " << std::hex << stubTEI.raw()
+			edm::LogVerbatim("L1trackHLS") << "TEInner stub " << std::hex << stubTEI.raw()
 					<< std::endl;
-			edm::LogVerbatim("FWHLS") << "ivm: " << std::dec << ivm <<std::endl
+			edm::LogVerbatim("L1trackHLS") << "ivm: " << std::dec << ivm <<std::endl
 					<< std::endl;
 #endif // DEBUG
 
@@ -832,9 +833,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			edm::LogVerbatim("FWHLS") << "TEOuter stub " << std::hex << stubTEO.raw()
+			edm::LogVerbatim("L1trackHLS") << "TEOuter stub " << std::hex << stubTEO.raw()
 					<< std::endl;
-			edm::LogVerbatim("FWHLS") << "    ivm: " << std::dec << ivm << "       to bin " << bin << std::endl;
+			edm::LogVerbatim("L1trackHLS") << "    ivm: " << std::dec << ivm << "       to bin " << bin << std::endl;
 #endif // DEBUG
 
 			// Write the TE Outer stub to the correct memory
@@ -876,9 +877,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 
 // For debugging
 #ifndef __SYNTHESIS__
-			edm::LogVerbatim("FWHLS") << "Overlap stub " << " " << std::hex
+			edm::LogVerbatim("L1trackHLS") << "Overlap stub " << " " << std::hex
 					<< stubOL.raw() << std::endl;
-			edm::LogVerbatim("FWHLS") << "ivm: " << std::dec << ivm << std::endl
+			edm::LogVerbatim("L1trackHLS") << "ivm: " << std::dec << ivm << std::endl
 					<< std::endl;
 #endif // DEBUG
 
@@ -901,7 +902,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 // For debugging
 #ifndef __SYNTHESIS__
 			else {
-			  edm::LogVerbatim("FWHLS") << "NO OVERLAP" << std::endl << std::endl;
+			  edm::LogVerbatim("L1trackHLS") << "NO OVERLAP" << std::endl << std::endl;
 			}
 #endif // DEBUG
 

--- a/TrackletAlgorithm/VMRouterCM.h
+++ b/TrackletAlgorithm/VMRouterCM.h
@@ -19,6 +19,11 @@
 #include "AllStubInnerMemory.h"
 #include "VMStubMEMemoryCM.h"
 #include "VMStubTEOuterMemoryCM.h"
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#else
+#include "DummyMessageLogger.h"
+#endif
 
 /////////////////////////////////////////
 // Constants
@@ -288,7 +293,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-		std::cout << std::endl << "Stub index no. " << i << std::endl
+		edm::LogVerbatim("HLS") << std::endl << "Stub index no. " << i << std::endl
 				<< "Out put stub: " << std::hex << allstub.raw() << std::dec
 				<< std::endl;
 #endif // DEBUG
@@ -371,7 +376,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-				std::cout << std::endl << "Allstub Inner: " << std::hex
+				edm::LogVerbatim("HLS") << std::endl << "Allstub Inner: " << std::hex
 						<< allstubinner.raw() << std::dec << std::endl;
 #endif // DEBUG
 
@@ -394,7 +399,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-		std::cout << "ME stub " << std::hex << stubME.raw() << std::dec
+		edm::LogVerbatim("HLS") << "ME stub " << std::hex << stubME.raw() << std::dec
 				<< "       to slot " << slotME << std::endl;
 #endif // DEBUG
 		// End ME memories
@@ -420,7 +425,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-			std::cout << "TEOuter stub " << std::hex << stubTEO.raw()
+			edm::LogVerbatim("HLS") << "TEOuter stub " << std::hex << stubTEO.raw()
 					<< std::dec << "       to slot " << slotTE << std::endl;
 #endif // DEBUG
 

--- a/TrackletAlgorithm/VMRouterCM.h
+++ b/TrackletAlgorithm/VMRouterCM.h
@@ -293,7 +293,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-		edm::LogVerbatim("HLS") << std::endl << "Stub index no. " << i << std::endl
+		edm::LogVerbatim("FWHLS") << std::endl << "Stub index no. " << i << std::endl
 				<< "Out put stub: " << std::hex << allstub.raw() << std::dec
 				<< std::endl;
 #endif // DEBUG
@@ -376,7 +376,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-				edm::LogVerbatim("HLS") << std::endl << "Allstub Inner: " << std::hex
+				edm::LogVerbatim("FWHLS") << std::endl << "Allstub Inner: " << std::hex
 						<< allstubinner.raw() << std::dec << std::endl;
 #endif // DEBUG
 
@@ -399,7 +399,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-		edm::LogVerbatim("HLS") << "ME stub " << std::hex << stubME.raw() << std::dec
+		edm::LogVerbatim("FWHLS") << "ME stub " << std::hex << stubME.raw() << std::dec
 				<< "       to slot " << slotME << std::endl;
 #endif // DEBUG
 		// End ME memories
@@ -425,7 +425,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-			edm::LogVerbatim("HLS") << "TEOuter stub " << std::hex << stubTEO.raw()
+			edm::LogVerbatim("FWHLS") << "TEOuter stub " << std::hex << stubTEO.raw()
 					<< std::dec << "       to slot " << slotTE << std::endl;
 #endif // DEBUG
 

--- a/TrackletAlgorithm/VMRouterCM.h
+++ b/TrackletAlgorithm/VMRouterCM.h
@@ -19,12 +19,13 @@
 #include "AllStubInnerMemory.h"
 #include "VMStubMEMemoryCM.h"
 #include "VMStubTEOuterMemoryCM.h"
+#ifndef __SYNTHESIS__
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #else
 #include "DummyMessageLogger.h"
 #endif
-
+#endif
 /////////////////////////////////////////
 // Constants
 
@@ -113,7 +114,7 @@ inline T createVMStub(const InputStub<InType> inputStub,
 	constexpr int nbitsztable = (Layer) ? nbitsztablelayer : nbitsztabledisk; // Number of MSBs of z used in LUT table
 	constexpr int nbitsrtable = (Layer) ? nbitsrtablelayer : nbitsrtabledisk; // Number of MSBs of r used in LUT table
 	constexpr auto vmbits = (Layer) ? nbitsvmlayer[Layer-1] : nbitsvmdisk[Disk-1]; // Number of bits for standard VMs
-	constexpr unsigned int nbitsall = (Layer) ? nbitsallstubs[Layer-1] : nbitsallstubs[N_LAYER+Disk-1]; // Number of bits for the number of Alltub memories in a layer/disk
+	constexpr unsigned int nbitsall = (Layer) ? nbitsallstubs[Layer-1] : nbitsallstubs[trklet::N_LAYER+Disk-1]; // Number of bits for the number of Alltub memories in a layer/disk
 
 	// Number of bits for the memory bins
 	constexpr int nbitsbin = (isMEStub) ? ((Layer) ? MEBinsBits : MEBinsBits + 1) : TEBinsBits; // ME in disks has double the amount of bins
@@ -293,7 +294,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-		edm::LogVerbatim("FWHLS") << std::endl << "Stub index no. " << i << std::endl
+		edm::LogVerbatim("L1trackHLS") << std::endl << "Stub index no. " << i << std::endl
 				<< "Out put stub: " << std::hex << allstub.raw() << std::dec
 				<< std::endl;
 #endif // DEBUG
@@ -309,19 +310,19 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 			// Use comparison_rz to check if they pass the RZ cuts
 			if (Layer == 1) { // TODO: use comparison value 2 for LMR memories
-				constexpr float comparison_value = (Layer) ? VMROUTERCUTZL1L3L5 / kz_cm[Layer - 1] : 0;
-				constexpr float comparison_valueLMR = (Layer) ? VMROUTERCUTZL1 / kz_cm[Layer - 1] : 0; // For LMR memories
+			  constexpr float comparison_value = (Layer) ? trklet::VMROUTERCUTZL1L3L5 / kz_cm[Layer - 1] : 0;
+			  constexpr float comparison_valueLMR = (Layer) ? trklet::VMROUTERCUTZL1 / kz_cm[Layer - 1] : 0; // For LMR memories
 				passRZCut = !(comparison_rz > comparison_value);
 				passRZSpecialCut = !(comparison_rz < comparison_valueLMR);
 			} else if (Layer == 2) {
-				constexpr float comparison_value = (Layer) ? VMROUTERCUTZL2 / kz_cm[Layer - 1] : 0;
+			  constexpr float comparison_value = (Layer) ? trklet::VMROUTERCUTZL2 / kz_cm[Layer - 1] : 0;
 				passRZCut = !(comparison_rz < comparison_value);
 			} else if (Layer == 3 || Layer == 5) {
-				constexpr float comparison_value = (Layer) ? VMROUTERCUTZL1L3L5 / kz_cm[Layer - 1] : 0;
+			  constexpr float comparison_value = (Layer) ? trklet::VMROUTERCUTZL1L3L5 / kz_cm[Layer - 1] : 0;
 				passRZCut = !(comparison_rz > comparison_value);
 			} else if (Disk == 1 || Disk == 3) {
-				constexpr float comparison_value = VMROUTERCUTRD1D3 / kr;
-				constexpr float comparison_value2 = 2 * N_DISK; // 2*int(N_DSS_MOD) in emulation
+			  constexpr float comparison_value = trklet::VMROUTERCUTRD1D3 / kr;
+			  constexpr float comparison_value2 = 2 * trklet::N_DISK; // 2*int(N_DSS_MOD) in emulation
 				passRZCut = !(comparison_rz > comparison_value) && !(comparison_rz < comparison_value2);
 			}
 
@@ -340,7 +341,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 				constexpr unsigned int phicutmax = (Layer == 1) ? 4 : 6; // I have no idea what these numbers are, see emulation
 				constexpr unsigned int phicutmin = (Layer == 1) ? 4 : 2;
 
-				constexpr unsigned int nbitsall = (Layer) ? nbitsallstubs[Layer - 1] : nbitsallstubs[N_LAYER + Disk - 1]; // Number of bits for the number of Alltub memories in a layer/disk
+				constexpr unsigned int nbitsall = (Layer) ? nbitsallstubs[Layer - 1] : nbitsallstubs[trklet::N_LAYER + Disk - 1]; // Number of bits for the number of Alltub memories in a layer/disk
 
 				auto iphipos = phicorr.range(phicorr.length() - nbitsall - 1, phicorr.length() - (nbitsall + phiRegSize)); // Top three bits after the allstub bits
 				unsigned int inner_mem_index = 0; // Keeps track of which allstub inner memory to write to
@@ -376,7 +377,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-				edm::LogVerbatim("FWHLS") << std::endl << "Allstub Inner: " << std::hex
+				edm::LogVerbatim("L1trackHLS") << std::endl << "Allstub Inner: " << std::hex
 						<< allstubinner.raw() << std::dec << std::endl;
 #endif // DEBUG
 
@@ -399,7 +400,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-		edm::LogVerbatim("FWHLS") << "ME stub " << std::hex << stubME.raw() << std::dec
+		edm::LogVerbatim("L1trackHLS") << "ME stub " << std::hex << stubME.raw() << std::dec
 				<< "       to slot " << slotME << std::endl;
 #endif // DEBUG
 		// End ME memories
@@ -425,7 +426,7 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 // For debugging
 #if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
-			edm::LogVerbatim("FWHLS") << "TEOuter stub " << std::hex << stubTEO.raw()
+			edm::LogVerbatim("L1trackHLS") << "TEOuter stub " << std::hex << stubTEO.raw()
 					<< std::dec << "       to slot " << slotTE << std::endl;
 #endif // DEBUG
 

--- a/TrackletAlgorithm/VMRouterCMTop.h
+++ b/TrackletAlgorithm/VMRouterCMTop.h
@@ -28,7 +28,7 @@ constexpr phiRegions phiRegion = phiRegions::A; // Which AllStub/PhiRegion
 ///////////////////////////////////////////////
 // Values that don't need manual changing
 
-constexpr TF::layerDisk layerdisk = static_cast<TF::layerDisk>((kLAYER) ? kLAYER-1 : N_LAYER+kDISK-1);
+constexpr TF::layerDisk layerdisk = static_cast<TF::layerDisk>((kLAYER) ? kLAYER-1 : trklet::N_LAYER+kDISK-1);
 
 // Number of inputs
 constexpr int numInputs = getNumInputs<layerdisk, phiRegion>(); // Number of input memories, EXCLUDING DISK2S

--- a/emData/generate_VMR.py
+++ b/emData/generate_VMR.py
@@ -415,7 +415,7 @@ def writeTopHeader(vmr_specific_name, vmr):
 ///////////////////////////////////////////////
 // Variables that don't need changing
 
-constexpr TF::layerDisk layerdisk = static_cast<TF::layerDisk>((kLAYER) ? kLAYER-1 : N_LAYER+kDISK-1);
+constexpr TF::layerDisk layerdisk = static_cast<TF::layerDisk>((kLAYER) ? kLAYER-1 : trklet::N_LAYER+kDISK-1);
 
 // Number of inputs
 constexpr int numInputs = getNumInputs<layerdisk, phiRegion>(); // Number of input memories, EXCLUDING DISK2S

--- a/emData/generate_VMRCM.py
+++ b/emData/generate_VMRCM.py
@@ -324,7 +324,7 @@ def writeTopHeader(vmr_specific_name, vmr):
 ///////////////////////////////////////////////
 // Values that don't need manual changing
 
-constexpr TF::layerDisk layerdisk = static_cast<TF::layerDisk>((kLAYER) ? kLAYER-1 : N_LAYER+kDISK-1);
+constexpr TF::layerDisk layerdisk = static_cast<TF::layerDisk>((kLAYER) ? kLAYER-1 : trklet::N_LAYER+kDISK-1);
 
 // Number of inputs
 constexpr int numInputs = getNumInputs<layerdisk, phiRegion>(); // Number of input memories, EXCLUDING DISK2S


### PR DESCRIPTION
Replaced cout statements with message logger. Created DummyMessageLogger that couts statements using the same syntax as the logger. DummyMessageLogger.h or MessageLogger.h is conditionally compiled depending on whether running in CMSSW or not but print syntax remains the same.