### PR TITLE
FileWriterFromRAM bug fixes

### DIFF
--- a/IntegrationTests/common/hdl/FileWriterFromRAM.vhd
+++ b/IntegrationTests/common/hdl/FileWriterFromRAM.vhd
@@ -52,6 +52,7 @@ begin
 procFile : process(CLK)
   variable INIT        : boolean := false; --! File not yet open
   variable FILE_STATUS : file_open_status;
+  variable CLOSE_FILE  : boolean := false; --! File is ready to be closed
   file     FILE_OUT    : text;   
   variable LINE_OUT    : line;                              
   variable BX_CNT      : integer := -1;  --! Event counter
@@ -96,14 +97,22 @@ begin
     if (DONE = '1') then   --! Signal present in single clk cycle when event first ready.
       BX_CNT := BX_CNT + 1;
       PAGE := BX_CNT mod NUM_PAGES;
-      DATA_CNT :=0;
+      DATA_CNT := 0;
 
       NENT := to_integer(unsigned(NENT_ARR(PAGE)));
 
       if (BX_CNT = MAX_EVENTS) then
-        -- All events processed, so close file.
-        file_close(FILE_OUT);
+        -- All events processed, so close file once all stubs has been written to file.
+        CLOSE_FILE := true;
       end if;
+    else 
+      -- update NENT as NENT_ARR might not have finished counting when DONE signal goes high (NENT would never be 108 otherwise)
+      NENT := to_integer(unsigned(NENT_ARR(PAGE)));
+    end if;
+
+    -- All events processed, so close file.
+    if (CLOSE_FILE and READ_EN_LATCH(0) = '0') then
+      file_close(FILE_OUT);
     end if;
 
     -- Launch memory read, if data remains to be read from current event.

--- a/IntegrationTests/common/hdl/FileWriterFromRAM.vhd
+++ b/IntegrationTests/common/hdl/FileWriterFromRAM.vhd
@@ -99,21 +99,19 @@ begin
       PAGE := BX_CNT mod NUM_PAGES;
       DATA_CNT := 0;
 
-      NENT := to_integer(unsigned(NENT_ARR(PAGE)));
-
       if (BX_CNT = MAX_EVENTS) then
-        -- All events processed, so close file once all stubs has been written to file.
+        -- All events processed, so close file once all stubs have been written to file.
         CLOSE_FILE := true;
       end if;
-    else 
-      -- update NENT as NENT_ARR might not have finished counting when DONE signal goes high (NENT would never be 108 otherwise)
-      NENT := to_integer(unsigned(NENT_ARR(PAGE)));
     end if;
 
     -- All events processed, so close file.
     if (CLOSE_FILE and READ_EN_LATCH(0) = '0') then
       file_close(FILE_OUT);
     end if;
+
+    -- update NENT every clock cycle as NENT_ARR might not have finished counting when DONE signal goes high (NENT would never be 108 otherwise)
+    NENT := to_integer(unsigned(NENT_ARR(PAGE)));
 
     -- Launch memory read, if data remains to be read from current event.
 


### PR DESCRIPTION
Fixed two bugs in FileWriterFromRAM.vhd that I noticed when I was debugging the VMR in Vivado:

1. NENT was at most 107, thus the 108th stub was never written to the output text files.
2. The output text file could be closed even if the latch wasn't empty, thus the last couple of stubs in the 100th event were never written to the files.

Unclear if FileWriterFromRAMBinned.vhd needs the same changes. Haven't looked into that yet.