### PR TITLE
Changes For Future SW Emulation

### DIFF
--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -115,18 +115,10 @@ void writeMemFromFile(MemType& memory, std::ifstream& fin, int ievt, int base=16
       return;
     } else {
       if (split(line,' ').size()==4) {
-      #ifdef CMSSW_GIT_HASH
-       memory.write_mem(0, line, base);
-       #else
        memory.write_mem(ievt, line, base);
-       #endif
       } else {
 	const std::string datastr = split(line, ' ').back();
-	#ifdef CMSSW_GIT_HASH
-	memory.write_mem(0, datastr, base);
-	#else
 	memory.write_mem(ievt, datastr, base);
-	#endif
       }
     }	
   }
@@ -150,13 +142,8 @@ unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
   constexpr int msb = (LSB >= 0 && MSB >= LSB) ? MSB : MemType::getWidth() - 1;
 
   for (unsigned int i = 0; i < memory_ref.getDepth(); ++i) {
-    #ifdef CMSSW_GIT_HASH
-    auto data_ref = memory_ref.read_mem(0,i).raw();
-    auto data_com = memory.read_mem(0,i).raw();
-    #else
     auto data_ref = memory_ref.read_mem(ievt,i).raw().range(msb,lsb);
     auto data_com = memory.read_mem(ievt,i).raw().range(msb,lsb);
-    #endif
     if (i==0) {
       // If both reference and computed memories are completely empty, skip it
       if (data_com == 0 && data_ref == 0) break;
@@ -214,13 +201,8 @@ unsigned int compareBinnedMemWithFile(const MemType& memory,
   for (unsigned int j = 0; j < memory_ref.getNBins(); ++j ) {
     std::cout << "Bin " << std::dec << j << std::endl;
     for (unsigned int i = 0; i < memory_ref.getNEntryPerBin() ; ++i) {
-      #ifdef CMSSW_GIT_HASH
-      auto data_ref = memory_ref.read_mem(0,j,i).raw();
-      auto data_com = memory.read_mem(0,j,i).raw();
-      #else
       auto data_ref = memory_ref.read_mem(ievt,j,i).raw();
       auto data_com = memory.read_mem(ievt,j,i).raw();
-      #endif
       // If have reached the end of valid entries in both computed and reference, don't bother printing further
       if (data_com == 0 && data_ref == 0) continue;
 
@@ -276,13 +258,8 @@ unsigned int compareBinnedMemCMWithFile(const MemType& memory,
     for (unsigned int j = 0; j < memory_ref.getNBins(); ++j ) {
       std::cout << "Bin " << std::dec << j << std::endl;
       for (unsigned int i = 0; i < memory_ref.getNEntryPerBin() ; ++i) {
-        #ifdef CMSSW_GIT_HASH
-        auto data_ref = memory_ref.read_mem(k,0,j,i).raw();
-        auto data_com = memory.read_mem(k,0,j,i).raw();
-        #else
         auto data_ref = memory_ref.read_mem(k,ievt,j,i).raw();
         auto data_com = memory.read_mem(k,ievt,j,i).raw();
-        #endif
         // If have reached the end of valid entries in both computed and reference, don't bother printing further
         if (data_com == 0 && data_ref == 0) continue;
 

--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -115,18 +115,18 @@ void writeMemFromFile(MemType& memory, std::ifstream& fin, int ievt, int base=16
       return;
     } else {
       if (split(line,' ').size()==4) {
-       #ifdef CMSSW_GIT_HASH
+      #ifdef CMSSW_GIT_HASH
        memory.write_mem(0, line, base);
        #else
        memory.write_mem(ievt, line, base);
        #endif
       } else {
 	const std::string datastr = split(line, ' ').back();
-        #ifdef CMSSW_GIT_HASH
+	#ifdef CMSSW_GIT_HASH
 	memory.write_mem(0, datastr, base);
-        #else
-        memory.write_mem(ievt, datastr, base);
-        #endif
+	#else
+	memory.write_mem(ievt, datastr, base);
+	#endif
       }
     }	
   }

--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -115,10 +115,18 @@ void writeMemFromFile(MemType& memory, std::ifstream& fin, int ievt, int base=16
       return;
     } else {
       if (split(line,' ').size()==4) {
+       #ifdef CMSSW_GIT_HASH
+       memory.write_mem(0, line, base);
+       #else
        memory.write_mem(ievt, line, base);
+       #endif
       } else {
 	const std::string datastr = split(line, ' ').back();
-	memory.write_mem(ievt, datastr, base);
+        #ifdef CMSSW_GIT_HASH
+	memory.write_mem(0, datastr, base);
+        #else
+        memory.write_mem(ievt, datastr, base);
+        #endif
       }
     }	
   }
@@ -142,8 +150,13 @@ unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
   constexpr int msb = (LSB >= 0 && MSB >= LSB) ? MSB : MemType::getWidth() - 1;
 
   for (unsigned int i = 0; i < memory_ref.getDepth(); ++i) {
+    #ifdef CMSSW_GIT_HASH
+    auto data_ref = memory_ref.read_mem(0,i).raw();
+    auto data_com = memory.read_mem(0,i).raw();
+    #else
     auto data_ref = memory_ref.read_mem(ievt,i).raw().range(msb,lsb);
     auto data_com = memory.read_mem(ievt,i).raw().range(msb,lsb);
+    #endif
     if (i==0) {
       // If both reference and computed memories are completely empty, skip it
       if (data_com == 0 && data_ref == 0) break;
@@ -201,9 +214,13 @@ unsigned int compareBinnedMemWithFile(const MemType& memory,
   for (unsigned int j = 0; j < memory_ref.getNBins(); ++j ) {
     std::cout << "Bin " << std::dec << j << std::endl;
     for (unsigned int i = 0; i < memory_ref.getNEntryPerBin() ; ++i) {
+      #ifdef CMSSW_GIT_HASH
+      auto data_ref = memory_ref.read_mem(0,j,i).raw();
+      auto data_com = memory.read_mem(0,j,i).raw();
+      #else
       auto data_ref = memory_ref.read_mem(ievt,j,i).raw();
       auto data_com = memory.read_mem(ievt,j,i).raw();
-
+      #endif
       // If have reached the end of valid entries in both computed and reference, don't bother printing further
       if (data_com == 0 && data_ref == 0) continue;
 
@@ -259,9 +276,13 @@ unsigned int compareBinnedMemCMWithFile(const MemType& memory,
     for (unsigned int j = 0; j < memory_ref.getNBins(); ++j ) {
       std::cout << "Bin " << std::dec << j << std::endl;
       for (unsigned int i = 0; i < memory_ref.getNEntryPerBin() ; ++i) {
+        #ifdef CMSSW_GIT_HASH
+        auto data_ref = memory_ref.read_mem(k,0,j,i).raw();
+        auto data_com = memory.read_mem(k,0,j,i).raw();
+        #else
         auto data_ref = memory_ref.read_mem(k,ievt,j,i).raw();
         auto data_com = memory.read_mem(k,ievt,j,i).raw();
-
+        #endif
         // If have reached the end of valid entries in both computed and reference, don't bother printing further
         if (data_com == 0 && data_ref == 0) continue;
 

--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -203,6 +203,7 @@ unsigned int compareBinnedMemWithFile(const MemType& memory,
     for (unsigned int i = 0; i < memory_ref.getNEntryPerBin() ; ++i) {
       auto data_ref = memory_ref.read_mem(ievt,j,i).raw();
       auto data_com = memory.read_mem(ievt,j,i).raw();
+
       // If have reached the end of valid entries in both computed and reference, don't bother printing further
       if (data_com == 0 && data_ref == 0) continue;
 
@@ -260,6 +261,7 @@ unsigned int compareBinnedMemCMWithFile(const MemType& memory,
       for (unsigned int i = 0; i < memory_ref.getNEntryPerBin() ; ++i) {
         auto data_ref = memory_ref.read_mem(k,ievt,j,i).raw();
         auto data_com = memory.read_mem(k,ievt,j,i).raw();
+
         // If have reached the end of valid entries in both computed and reference, don't bother printing further
         if (data_com == 0 && data_ref == 0) continue;
 

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -170,13 +170,13 @@ public:
 #endif 
 
 #ifdef CMSSW_GIT_HASH
-  /*std::string name_;
+  std::string name_;
   void setName(std::string name) { name_ = name;}
   std::string const& getName() const { return name_;}
 
   unsigned int iSector_;
   void setSector(unsigned int iS) { iSector_ = iS;}
-  unsigned int getSector() const { return iSector_;}*/
+  unsigned int getSector() const { return iSector_;}
 #endif
 
 };

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -53,6 +53,7 @@ public:
   DataType read_mem(BunchXingT ibx, ap_uint<NBIT_ADDR> index) const
   {
 	// TODO: check if valid
+	if(!NBIT_BX) ibx = 0;
 	return dataarray_[ibx][index];
   }
 
@@ -60,6 +61,7 @@ public:
   bool write_mem(BunchXingT ibx, SpecType data, int addr_index)
   {
 #pragma HLS inline
+    if(!NBIT_BX) ibx = 0;
     static_assert(
       std::is_same<DataType, SpecType>::value
       || (std::is_same<DataType, AllStub<DISK> >::value && std::is_same<SpecType, AllStub<DISKPS> >::value)
@@ -72,6 +74,7 @@ public:
   bool write_mem(BunchXingT ibx, DataType data, int addr_index)
   {
 #pragma HLS inline
+    if(!NBIT_BX) ibx = 0;
     if (addr_index < (1<<NBIT_ADDR)) {
       dataarray_[ibx][addr_index] = data;
       
@@ -107,7 +110,8 @@ public:
 
   // write memory from text file
   bool write_mem(BunchXingT ibx, const char* datastr, int base=16)
-  {
+  { 
+        if(!NBIT_BX) ibx = 0;
 	DataType data(datastr, base);
 	int nent = nentries_[ibx]; 
 	bool success = write_mem(ibx, data, nent);
@@ -120,7 +124,8 @@ public:
 
   bool write_mem(BunchXingT ibx, const std::string datastr, int base=16)
   {
-	DataType data(datastr.c_str(), base);
+        if(!NBIT_BX) ibx = 0;
+        DataType data(datastr.c_str(), base);
 	int nent = nentries_[ibx];
 	bool success = write_mem(ibx, data, nent);
 
@@ -165,13 +170,13 @@ public:
 #endif 
 
 #ifdef CMSSW_GIT_HASH
-  std::string name_;
+  /*std::string name_;
   void setName(std::string name) { name_ = name;}
   std::string const& getName() const { return name_;}
 
   unsigned int iSector_;
   void setSector(unsigned int iS) { iSector_ = iS;}
-  unsigned int getSector() const { return iSector_;}
+  unsigned int getSector() const { return iSector_;}*/
 #endif
 
 };

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -59,6 +59,7 @@ public:
   DataType read_mem(BunchXingT ibx, ap_uint<NBIT_ADDR> index) const
   {
     // TODO: check if valid
+    if(!NBIT_BX) ibx = 0;
     return dataarray_[ibx][index];
   }
   
@@ -66,6 +67,7 @@ public:
 		    ap_uint<NBIT_ADDR> index) const
   {
     // TODO: check if valid
+    if(!NBIT_BX) ibx = 0;
     return dataarray_[ibx][(1<<(kNBitDataAddr))*slot+index];
   }
 
@@ -74,6 +76,7 @@ public:
 #pragma HLS inline
 	if (nentry_ibx < ((1<<kNBitDataAddr)-1)) { // Temporary "-1" to only allow 15 (7 for VMSME DISK) stubs per bin instead of 16 (8) to match emulation
 	  // write address for slot: 1<<(kNBitDataAddr) * slot + nentry_ibx
+	  if(!NBIT_BX) ibx = 0;
 	  dataarray_[ibx][(1<<(kNBitDataAddr))*slot+nentry_ibx] = data;
 	  #ifdef CMSSW_GIT_HASH
 	  nentries_[ibx][slot]++;
@@ -129,6 +132,7 @@ edm::LogWarning("L1trackHLS") << "Warning out of range: adress within bin " << n
   bool write_mem(BunchXingT bx, const std::string& line, int base=16)
   {
 
+    if(!NBIT_BX) ibx = 0;
     std::string datastr = split(line, ' ').back();
 
     int slot = (int)strtol(split(line, ' ').front().c_str(), nullptr, base); // Convert string (in hexadecimal) to int
@@ -181,13 +185,13 @@ edm::LogWarning("L1trackHLS") << "Warning out of range: adress within bin " << n
 #endif
 
 #ifdef CMSSW_GIT_HASH
-  std::string name_;
+  /*std::string name_;
   void setName(std::string name) { name_ = name;}
   std::string const& getName() const { return name_;}
 
   unsigned int iSector_;
   void setSector(unsigned int iS) { iSector_ = iS;}
-  unsigned int getSector() const { return iSector_;}
+  unsigned int getSector() const { return iSector_;}*/
 #endif
   
 };

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -185,13 +185,13 @@ edm::LogWarning("L1trackHLS") << "Warning out of range: adress within bin " << n
 #endif
 
 #ifdef CMSSW_GIT_HASH
-  /*std::string name_;
+  std::string name_;
   void setName(std::string name) { name_ = name;}
   std::string const& getName() const { return name_;}
 
   unsigned int iSector_;
   void setSector(unsigned int iS) { iSector_ = iS;}
-  unsigned int getSector() const { return iSector_;}*/
+  unsigned int getSector() const { return iSector_;}
 #endif
   
 };

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -132,7 +132,7 @@ edm::LogWarning("L1trackHLS") << "Warning out of range: adress within bin " << n
   bool write_mem(BunchXingT bx, const std::string& line, int base=16)
   {
 
-    if(!NBIT_BX) ibx = 0;
+    if(!NBIT_BX) bx = 0;
     std::string datastr = split(line, ' ').back();
 
     int slot = (int)strtol(split(line, ' ').front().c_str(), nullptr, base); // Convert string (in hexadecimal) to int

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -245,13 +245,13 @@ class MemoryTemplateBinnedCM{
 #endif
 
 #ifdef CMSSW_GIT_HASH
-  /*std::string name_;
+  std::string name_;
   void setName(std::string name) { name_ = name;}
   std::string const& getName() const { return name_;}
 
   unsigned int iSector_;
   void setSector(unsigned int iS) { iSector_ = iS;}
-  unsigned int getSector() const { return iSector_;}*/
+  unsigned int getSector() const { return iSector_;}
 #endif
   
 };

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -92,6 +92,7 @@ class MemoryTemplateBinnedCM{
   DataType read_mem(unsigned int icopy, BunchXingT ibx, ap_uint<NBIT_ADDR> index) const {
 #pragma HLS ARRAY_PARTITION variable=dataarray_ dim=1
     // TODO: check if valid
+    if(!NBIT_BX) ibx = 0;
     return dataarray_[icopy][ibx][index];
   }
   
@@ -99,6 +100,7 @@ class MemoryTemplateBinnedCM{
 		    ap_uint<NBIT_ADDR> index) const {
 #pragma HLS ARRAY_PARTITION variable=dataarray_ dim=1
     // TODO: check if valid
+    if(!NBIT_BX) ibx = 0;
     return dataarray_[icopy][ibx][getNEntryPerBin()*slot+index];
   }
   
@@ -106,7 +108,8 @@ class MemoryTemplateBinnedCM{
 #pragma HLS ARRAY_PARTITION variable=dataarray_ dim=1
 
 #pragma HLS inline
-
+    
+    if(!NBIT_BX) ibx = 0;
     if (nentry_ibx < getNEntryPerBin()-1) { // Max 15 stubs in each memory due to 4 bit nentries
       // write address for slot: getNEntryPerBin() * slot + nentry_ibx
   
@@ -180,6 +183,7 @@ class MemoryTemplateBinnedCM{
   bool write_mem(BunchXingT ibx, const std::string& line, int base=16)
   {
 
+    if(!NBIT_BX) ibx = 0;
     std::string datastr = split(line, ' ').back();
 
     int slot = (int)strtol(split(line, ' ').front().c_str(), nullptr, base); // Convert string (in hexadecimal) to int
@@ -241,13 +245,13 @@ class MemoryTemplateBinnedCM{
 #endif
 
 #ifdef CMSSW_GIT_HASH
-  std::string name_;
+  /*std::string name_;
   void setName(std::string name) { name_ = name;}
   std::string const& getName() const { return name_;}
 
   unsigned int iSector_;
   void setSector(unsigned int iS) { iSector_ = iS;}
-  unsigned int getSector() const { return iSector_;}
+  unsigned int getSector() const { return iSector_;}*/
 #endif
   
 };


### PR DESCRIPTION
Changes are made to FileReadUtility.h in order to work with the new CMSSW future SW emulation memory templates. Previous PR added templates to MemoryTemplate.h, MemoryTemplateBinned.h, etc to store all bunch crossings as the 0th. These fixes to FileReadUtility.h ensure that we always read/write using the 0th bunch crossing when using CMSSW.