### PR TITLE
Use python3 for all generate scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,15 @@ stages: # ---------------------------------------------------------------------
   before_script:
     - source $VIVADO_PATH_SH
 
+.job_template: &template_static-check-python
+  tags:
+    - xilinx-tools
+  stage: lint
+  before_script:
+    - which python3
+    - python3 --version
+    - python3 -m pylint --version
+
 .job_template: &template_quality-check
   needs: ["download"]
   tags:
@@ -96,18 +105,16 @@ stages: # ---------------------------------------------------------------------
     
 # Jobs ------------------------------------------------------------------------
 # Lint ------------
-lint:
-  tags:
-    - xilinx-tools
-  stage: lint
-  before_script:
-    - which python3
-    - python3 --version
-    - python3 -m pylint --version
+py3check:
+  <<: *template_static-check-python
   script:
     # If changes need to be made you might refer to: https://portingguide.readthedocs.io/en/latest/tools.html#automated-fixer-python-modernize
     - python3 -m pylint --py3k emData/*.py # Check for python3 compatibility
-    - python3 -m pylint --exit-zero emData/*.py # Static code checker
+lint:
+  <<: *template_static-check-python
+  allow_failure: true
+  script:
+    - python3 -m pylint emData/*.py # Static code checker
 # Download ------------
 download:
   tags:
@@ -239,7 +246,7 @@ ME-vivado-hls-build:
 ME-vitis-hls-build:
   <<: *template_hls-build
   needs: ["download", "ME-quality-check"]
-  allow_failure: true # FIXME: remove after avitis updated to 2021.1 and confirmed that pre-synthesis failure is gone.
+  allow_failure: true # FIXME: remove after vitis updated to 2021.1 and confirmed that pre-synthesis failure is gone.
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2020.2"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
   CLANG_TIDY_COMP_OPTIONS: '-std=c++11 -I../TrackletAlgorithm -I../TestBenches -I/nfs/data41/software/Xilinx/Vivado/${VIVADO_VERSION}/include'
 
 stages: # ---------------------------------------------------------------------
+  - lint
   - download
   - quality-check
   - hls-build
@@ -21,6 +22,7 @@ stages: # ---------------------------------------------------------------------
     - source $VIVADO_PATH_SH
 
 .job_template: &template_quality-check
+  needs: ["download"]
   tags:
     - xilinx-tools
   stage: quality-check
@@ -93,6 +95,19 @@ stages: # ---------------------------------------------------------------------
     expire_in: 1 week
     
 # Jobs ------------------------------------------------------------------------
+# Lint ------------
+lint:
+  tags:
+    - xilinx-tools
+  stage: lint
+  before_script:
+    - which python3
+    - python3 --version
+    - python3 -m pylint --version
+  script:
+    # If changes need to be made you might refer to: https://portingguide.readthedocs.io/en/latest/tools.html#automated-fixer-python-modernize
+    - python3 -m pylint --py3k emData/*.py # Check for python3 compatibility
+    - python3 -m pylint emData/*.py # Static code checker
 # Download ------------
 download:
   tags:
@@ -167,54 +182,63 @@ TB-quality-check:
 # HLS builds ---------------
 IR-vivado-hls-build:
   <<: *template_hls-build
+  needs: ["download", "IR-quality-check"]
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "IR"
 VMR-vivado-hls-build:
   <<: *template_hls-build
+  needs: ["download", "VMR-quality-check"]
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "VMR"
 VMRCM-vivado-hls-build:
   <<: *template_hls-build
+  needs: ["download", "VMRCM-quality-check"]
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "VMRCM"
 TE-vivado-hls-build:
   <<: *template_hls-build
+  needs: ["download", "TE-quality-check"]
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "TE"
 TC-vivado-hls-build:
   <<: *template_hls-build
+  needs: ["download", "TC-quality-check"]
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "TC"
 TP-vivado-hls-build:
   <<: *template_hls-build
+  needs: ["download", "TP-quality-check"]
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "TP"
 PR-vivado-hls-build:
   <<: *template_hls-build
+  needs: ["download", "PR-quality-check"]
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "PR"
 ME-vivado-hls-build:
   <<: *template_hls-build
+  needs: ["download", "ME-quality-check"]
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "ME"
 ME-vitis-hls-build:
   <<: *template_hls-build
+  needs: ["download", "ME-quality-check"]
   allow_failure: true # FIXME: remove after avitis updated to 2021.1 and confirmed that pre-synthesis failure is gone.
   variables:
     EXECUTABLE: 'vivado_hls'
@@ -223,12 +247,14 @@ ME-vitis-hls-build:
     PROJ_NAME: "ME"
 MC-vivado-hls-build:
   <<: *template_hls-build
+  needs: ["download", "MC-quality-check"]
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "MC"
 MP-vivado-hls-build:
   <<: *template_hls-build
+  needs: ["download", "MP-quality-check"]
   allow_failure: true # FIXME: remove after all errors are fixed
   variables:
     EXECUTABLE: 'vivado_hls'
@@ -236,6 +262,7 @@ MP-vivado-hls-build:
     PROJ_NAME: "MP"
 TB-hls-build:
   <<: *template_hls-build
+  needs: ["download", "TB-quality-check"]
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"
@@ -246,7 +273,7 @@ topPRMEMC-sim:
   variables:
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "PRMEMC"
-  dependencies: # needed to avoid interference from ME-vitis-hls-build
+  needs: # needed to avoid interference from ME-vitis-hls-build
     - download
     - PR-vivado-hls-build
     - ME-vivado-hls-build
@@ -256,7 +283,7 @@ topIRVMR-sim:
   variables:
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "IRVMR"
-  dependencies:
+  needs:
     - download
     - IR-vivado-hls-build
     - VMR-vivado-hls-build
@@ -267,7 +294,7 @@ topPRMEMC-check-results:
   variables:
     VIVADO_VERSION: "2019.2" # Vivado not needed but it is parth of the path that is called
     PROJ_NAME: "PRMEMC"
-  dependencies:
+  needs:
     - download
     - PR-vivado-hls-build
     - ME-vivado-hls-build
@@ -279,7 +306,7 @@ topIRVMR-check-results:
   variables:
     VIVADO_VERSION: "2019.2" # Vivado not needed but it is parth of the path that is called
     PROJ_NAME: "IRVMR"
-  dependencies:
+  needs:
     - download
     - IR-vivado-hls-build
     - VMR-vivado-hls-build
@@ -290,7 +317,7 @@ topPRMEMC-synth:
   variables:
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "PRMEMC"
-  dependencies:
+  needs:
     - PR-vivado-hls-build
     - ME-vivado-hls-build
     - MC-vivado-hls-build
@@ -301,7 +328,7 @@ topIRVMR-synth:
   variables:
     VIVADO_VERSION: "2019.2"
     PROJ_NAME: "IRVMR"
-  dependencies:
+  needs:
     - IR-vivado-hls-build
     - VMR-vivado-hls-build
     - topIRVMR-sim

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,6 +120,7 @@ download:
   tags:
     - xilinx-tools
   stage: download
+  needs: ["py3check", "lint"]
   script:
     - cd emData
     - ./download.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ lint:
   script:
     # If changes need to be made you might refer to: https://portingguide.readthedocs.io/en/latest/tools.html#automated-fixer-python-modernize
     - python3 -m pylint --py3k emData/*.py # Check for python3 compatibility
-    - python3 -m pylint emData/*.py # Static code checker
+    - python3 -m pylint --exit-zero emData/*.py # Static code checker
 # Download ------------
 download:
   tags:

--- a/.pylintrc
+++ b/.pylintrc
@@ -159,7 +159,8 @@ disable=print-statement,
 		missing-module-docstring,
 		missing-class-docstring,
 		missing-function-docstring,
-		no-else-return
+		no-else-return,
+		no-else-continue
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -564,7 +565,7 @@ max-attributes=7
 max-bool-expr=5
 
 # Maximum number of branch for function / method body.
-max-branches=12
+max-branches=20 # Default: 12
 
 # Maximum number of locals for function / method body.
 max-locals=15

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,634 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths.
+ignore-paths=
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+		# Disabled the following packages in addition to the default settings
+		line-too-long,
+		unspecified-encoding,
+		missing-module-docstring,
+		missing-class-docstring,
+		missing-function-docstring,
+		no-else-return
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=no
+
+# Signatures are removed from the similarity computation
+ignore-signatures=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the 'python-enchant' package.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear and the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=camelCase # Default: UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=camelCase # Default: snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=any # default: snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# List of qualified class names to ignore when countint class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/emData/download.sh
+++ b/emData/download.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 #### fw_synch_210611 ####
 # Standard configuration

--- a/emData/generate_IR.py
+++ b/emData/generate_IR.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import, print_function
 import re
@@ -24,6 +24,7 @@ def getNmemsPerIR(wiresFiles='./LUTs/wires.dat') :
       if re.search(dtcName, line, re.IGNORECASE) and ("neg" in dtcName) == ("neg" in line) : 
           irLines.append(line)
     nMemories.append(len(irLines))
+  dtcNames, nMemories = (list(t) for t in zip(*sorted(zip(dtcNames, nMemories))))
   return zip(dtcNames, nMemories)
 
 # generate TopLevel declaration template 

--- a/emData/generate_IR.py
+++ b/emData/generate_IR.py
@@ -4,141 +4,137 @@ from __future__ import absolute_import, print_function
 import re
 import os
 
-# return number of memories filled by each IR 
-def getNmemsPerIR(wiresFiles='./LUTs/wires.dat') : 
-  dtcNames=[]
-  lines=[]
-  for line in open(wiresFiles,'r') : 
-    my_regex = 'output=> IR_'
-    if re.search(my_regex, line, re.IGNORECASE):
-      dtcNames.append(line.split()[0].split('DL_')[1])
-    my_regex = 'input=> IR_'
-    if re.search(my_regex, line, re.IGNORECASE):
-      lines.append(line)
-  lines =list(set(lines))
-  dtcNames = list(set(dtcNames))
-  nMemories = [] 
-  for idx, dtcName in enumerate(dtcNames):
-    irLines=[]
-    for line in lines : 
-      if re.search(dtcName, line, re.IGNORECASE) and ("neg" in dtcName) == ("neg" in line) : 
-          irLines.append(line)
-    nMemories.append(len(irLines))
-  dtcNames, nMemories = (list(t) for t in zip(*sorted(zip(dtcNames, nMemories))))
-  return zip(dtcNames, nMemories)
+# return number of memories filled by each IR
+def getNmemsPerIR(wiresFiles='./LUTs/wires.dat'):
+    dtcNames=[]
+    lines=[]
+    for line in open(wiresFiles,'r'):
+        my_regex = 'output=> IR_'
+        if re.search(my_regex, line, re.IGNORECASE):
+            dtcNames.append(line.split()[0].split('DL_')[1])
+        my_regex = 'input=> IR_'
+        if re.search(my_regex, line, re.IGNORECASE):
+            lines.append(line)
+    lines =list(set(lines))
+    dtcNames = list(set(dtcNames))
+    nMemories = []
+    for dtcName in dtcNames:
+        irLines=[]
+        for line in lines:
+            if re.search(dtcName, line, re.IGNORECASE) and ("neg" in dtcName) == ("neg" in line):
+                irLines.append(line)
+        nMemories.append(len(irLines))
+    dtcNames, nMemories = (list(t) for t in zip(*sorted(zip(dtcNames, nMemories))))
+    return zip(dtcNames, nMemories)
 
-# generate TopLevel declaration template 
-def createDefinitionsTemplate() : 
-  fileName='DefinitionsTemplate.dat'
-  f = open(fileName,'w')
-  f.write("\n"
-        "void InputRouterTop_IR_{LinkName}(\n"
-        "    const BXType bx\n"
-        "    , const ap_uint<kLINKMAPwidth> hLinkWord // input link LUT \n"
-        "    , const ap_uint<kBINMAPwidth> hPhBnWord  // n phi bins LUT \n"
-        "    , ap_uint<kNBits_DTC> hInputStubs[kMaxStubsFromLink]//input stubs \n"
-        "    , BXType & bx_o // output bx  \n"
-        "    , DTCStubMemory hOutputStubs[cNMemories_IR_{LinkName}])"
-        "\n{{\n"
-        "     #pragma HLS clock domain = slow_clock\n"
-        "     #pragma HLS stream variable = hInputStubs depth = 1\n"
-        "     #pragma HLS interface register port = bx_o\n"
-        "     InputRouter<cNMemories_IR_{LinkName}>( bx\n"
-        "       , hLinkWord\n"
-        "       , hPhBnWord\n"
-        "       , hInputStubs\n"
-        "       , bx_o\n"
-        "       , hOutputStubs);\n"
-        "}}\n"
-        )
-  f.close()
-  return fileName
+# generate TopLevel declaration template
+def createDefinitionsTemplate():
+    fileName='DefinitionsTemplate.dat'
+    with open(fileName,'w') as f:
+        f.write("\n"
+              "void InputRouterTop_IR_{LinkName}(\n"
+              "    const BXType bx\n"
+              "    , const ap_uint<kLINKMAPwidth> hLinkWord // input link LUT \n"
+              "    , const ap_uint<kBINMAPwidth> hPhBnWord  // n phi bins LUT \n"
+              "    , ap_uint<kNBits_DTC> hInputStubs[kMaxStubsFromLink]//input stubs \n"
+              "    , BXType & bx_o // output bx  \n"
+              "    , DTCStubMemory hOutputStubs[cNMemories_IR_{LinkName}])"
+              "\n{{\n"
+              "     #pragma HLS clock domain = slow_clock\n"
+              "     #pragma HLS stream variable = hInputStubs depth = 1\n"
+              "     #pragma HLS interface register port = bx_o\n"
+              "     InputRouter<cNMemories_IR_{LinkName}>( bx\n"
+              "       , hLinkWord\n"
+              "       , hPhBnWord\n"
+              "       , hInputStubs\n"
+              "       , bx_o\n"
+              "       , hOutputStubs);\n"
+              "}}\n"
+              )
+    return fileName
 
-# generate TopLevel declaration template 
-def createDeclarationTemplate() : 
-  fileName = 'DeclarationsTemplate.dat'
-  f = open(fileName,'w')
-  f.write("\n"
-        "void InputRouterTop_IR_{LinkName}(\n"
-        "    const BXType bx\n"
-        "    , const ap_uint<kLINKMAPwidth> hLinkWord // input link LUT \n"
-        "    , const ap_uint<kBINMAPwidth> hPhBnWord  // n phi bins LUT \n"
-        "    , ap_uint<kNBits_DTC> hInputStubs[kMaxStubsFromLink]//input stubs \n"
-        "    , BXType & bx_o // output bx  \n"
-        "    , DTCStubMemory hOutputStubs[cNMemories_IR_{LinkName}]"
-        ");\n")
-  f.close()
-  return fileName
+# generate TopLevel declaration template
+def createDeclarationTemplate():
+    fileName = 'DeclarationsTemplate.dat'
+    with open(fileName,'w') as f:
+        f.write("\n"
+              "void InputRouterTop_IR_{LinkName}(\n"
+              "    const BXType bx\n"
+              "    , const ap_uint<kLINKMAPwidth> hLinkWord // input link LUT \n"
+              "    , const ap_uint<kBINMAPwidth> hPhBnWord  // n phi bins LUT \n"
+              "    , ap_uint<kNBits_DTC> hInputStubs[kMaxStubsFromLink]//input stubs \n"
+              "    , BXType & bx_o // output bx  \n"
+              "    , DTCStubMemory hOutputStubs[cNMemories_IR_{LinkName}]"
+              ");\n")
+    return fileName
 
-# generate TopLevel parameters template 
-def createParametersTemplate() : 
-  fileName = 'ParametersTemplate.dat'
-  f = open(fileName,'w')
-  f.write("\n"
-        "constexpr unsigned int cNMemories_IR_{LinkName} = {Noutputs};\n")
-  f.close()
-  return fileName
+# generate TopLevel parameters template
+def createParametersTemplate():
+    fileName = 'ParametersTemplate.dat'
+    with open(fileName,'w') as f:
+        f.write("\n"
+            "constexpr unsigned int cNMemories_IR_{LinkName} = {Noutputs};\n")
+    return fileName
 
 # generate all TopLevel parameters InputRouter_parameters.h
-def createParameters(wiresFiles='./LUTs/wires.dat') : 
-  IRs = getNmemsPerIR(wiresFiles)
-  templateName = createParametersTemplate()
-  file = open('../TrackletAlgorithm/InputRouter_parameters.h', 'w') 
-  file.write('#ifndef TrackletAlgorithm_InputRouter_parameters_h\n')
-  file.write('#define TrackletAlgorithm_InputRouter_parameters_h\n')
-  for dtcName, nMemories in IRs : 
-    d = {}
-    d['LinkName'] = "DTC_" + dtcName
-    d['Noutputs'] = str(nMemories)
-    with open(templateName, 'r') as ftemp:
-      templateString = ftemp.read()
-    file.write(templateString.format(**d))
-  file.write('#endif\n')
-  file.close()
-  os.remove(templateName)
-
+def createParameters(wiresFiles='./LUTs/wires.dat'):
+    IRs = getNmemsPerIR(wiresFiles)
+    templateName = createParametersTemplate()
+    file = open('../TrackletAlgorithm/InputRouter_parameters.h', 'w')
+    file.write('#ifndef TrackletAlgorithm_InputRouter_parameters_h\n')
+    file.write('#define TrackletAlgorithm_InputRouter_parameters_h\n')
+    for dtcName, nMemories in IRs:
+        d = {}
+        d['LinkName'] = "DTC_" + dtcName
+        d['Noutputs'] = str(nMemories)
+        with open(templateName, 'r') as ftemp:
+            templateString = ftemp.read()
+        file.write(templateString.format(**d))
+    file.write('#endif\n')
+    file.close()
+    os.remove(templateName)
 
 # generate all TopLevel declarations InputRouterTop.cc
-def createDeclarations(wiresFiles='./LUTs/wires.dat') : 
-  IRs = getNmemsPerIR(wiresFiles)
-  templateName = createDeclarationTemplate()
-  file = open('../TrackletAlgorithm/InputRouterTop.h', 'w') 
-  file.write('#ifndef TrackletAlgorithm_InputRouterTop_h\n')
-  file.write('#define TrackletAlgorithm_InputRouterTop_h\n')
-  file.write('#include \"InputRouter.h\"\n')
-  file.write('#include \"InputRouter_parameters.h\"\n')
-  for dtcName, nMemories in IRs : 
-    d = {}
-    d['LinkName'] = "DTC_" + dtcName
-    with open(templateName, 'r') as ftemp:
-      templateString = ftemp.read()
-    file.write(templateString.format(**d))
-  file.write('#endif\n')
-  file.close()
-  os.remove(templateName)
+def createDeclarations(wiresFiles='./LUTs/wires.dat'):
+    IRs = getNmemsPerIR(wiresFiles)
+    templateName = createDeclarationTemplate()
+    file = open('../TrackletAlgorithm/InputRouterTop.h', 'w')
+    file.write('#ifndef TrackletAlgorithm_InputRouterTop_h\n')
+    file.write('#define TrackletAlgorithm_InputRouterTop_h\n')
+    file.write('#include \"InputRouter.h\"\n')
+    file.write('#include \"InputRouter_parameters.h\"\n')
+    for dtcName, _ in IRs:
+        d = {}
+        d['LinkName'] = "DTC_" + dtcName
+        with open(templateName, 'r') as ftemp:
+            templateString = ftemp.read()
+        file.write(templateString.format(**d))
+    file.write('#endif\n')
+    file.close()
+    os.remove(templateName)
 
-# generate all TopLevel definitions InputRouterTop.h 
-def createDefinitions(wiresFiles='./LUTs/wires.dat') : 
-  IRs = getNmemsPerIR(wiresFiles)
-  templateName = createDefinitionsTemplate()
-  file = open('../TrackletAlgorithm/InputRouterTop.cc', 'w') 
-  file.write('#include \"InputRouterTop.h\"\n')
-  for dtcName, nMemories in IRs : 
-    d = {}
-    d['LinkName'] = "DTC_" + dtcName
-    with open(templateName, 'r') as ftemp:
-      templateString = ftemp.read()
-    file.write(templateString.format(**d))
-  file.close()
-  os.remove(templateName)
+# generate all TopLevel definitions InputRouterTop.h
+def createDefinitions(wiresFiles='./LUTs/wires.dat'):
+    IRs = getNmemsPerIR(wiresFiles)
+    templateName = createDefinitionsTemplate()
+    file = open('../TrackletAlgorithm/InputRouterTop.cc', 'w')
+    file.write('#include \"InputRouterTop.h\"\n')
+    for dtcName, _ in IRs:
+        d = {}
+        d['LinkName'] = "DTC_" + dtcName
+        with open(templateName, 'r') as ftemp:
+            templateString = ftemp.read()
+        file.write(templateString.format(**d))
+    file.close()
+    os.remove(templateName)
 
 wiresFile = './LUTs/wires.dat'
 # create InputRouter_parameters.h :
-# contains constants that define number of output memories per link 
+# contains constants that define number of output memories per link
 createParameters(wiresFile)
-# create InputRouterTop.h 
-# declaration of top level function for each instance of the IR 
+# create InputRouterTop.h
+# declaration of top level function for each instance of the IR
 createDeclarations(wiresFile)
 # create InputRouterTop.cc
-# definition of top level function for each instance of the IR 
+# definition of top level function for each instance of the IR
 createDefinitions(wiresFile)

--- a/emData/generate_MC.py
+++ b/emData/generate_MC.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This script generates MatchCalculator_parameters.h,
 # MatchCalculatorTop.h, and MatchCalculatorTop.cc in the

--- a/emData/generate_MC.py
+++ b/emData/generate_MC.py
@@ -6,24 +6,34 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-import os,sys, re
+import os
+import re
+import sys
 
 TF_index = ['L1L2', 'L2L3', 'L3L4', 'L5L6', 'D1D2', 'D3D4', 'L1D1', 'L2D1']
 TF_index = {k:v for v,k in enumerate(TF_index)}
 
 def ASRegion(region):
-  if region in ['L1', 'L2', 'L3']: return 'BARRELPS'
-  elif region in ['L4', 'L5', 'L6']: return 'BARREL2S'
-  else: return 'DISK'
+    if region in ['L1', 'L2', 'L3']:
+        return 'BARRELPS'
+    elif region in ['L4', 'L5', 'L6']:
+        return 'BARREL2S'
+    else:
+        return 'DISK'
 
 def APRegion(region):
-  if region in ['L1', 'L2', 'L3']: return 'BARRELPS'
-  elif region in ['L4', 'L5', 'L6']: return 'BARREL2S'
-  else: return 'DISK'
+    if region in ['L1', 'L2', 'L3']:
+        return 'BARRELPS'
+    elif region in ['L4', 'L5', 'L6']:
+        return 'BARREL2S'
+    else:
+        return 'DISK'
 
 def FMRegion(region):
-  if region in ['L1', 'L2', 'L3', 'L4', 'L5', 'L6']: return 'BARREL'
-  else: return 'DISK'
+    if region in ['L1', 'L2', 'L3', 'L4', 'L5', 'L6']:
+        return 'BARREL'
+    else:
+        return 'DISK'
 
 if len(sys.argv) < 2:
     print("Usage: " + sys.argv[0] + " WIRES_FILE")
@@ -32,159 +42,156 @@ wiresFileName = sys.argv[1]
 
 # First, parse the wires file and store the memory names associated with MCs in
 # dictionaries with the MC names as keys.
-wiresFile = open(wiresFileName)
-CMMems = {}
-FMMems = {}
-for line in wiresFile:
-    # Only barrel-only seeds are supported right now.
-    if "MC_D" in line: continue # No disks for now
-    line = line.rstrip()
-    mcName = re.sub(r".*MC_(......).*", r"MC_\1", line)
-    memName = line.split()[0]
-    if memName.startswith("CM_"):
-        if mcName not in CMMems:
-            CMMems[mcName] = []
-        CMMems[mcName].append(memName)
-    if memName.startswith("FM_"):
-        FM = re.sub(r"FM_(....)_......", r"\1", memName)
-        if mcName not in FMMems:
-            FMMems[mcName] = []
-        FMMems[mcName].append(FM)
-wiresFile.close()
+with open(wiresFileName) as wiresFile:
+    CMMems = {}
+    FMMems = {}
+    for line in wiresFile:
+        # Only barrel-only seeds are supported right now.
+        if "MC_D" in line:
+            continue # No disks for now
+        line = line.rstrip()
+        mcName = re.sub(r".*MC_(......).*", r"MC_\1", line)
+        memName = line.split()[0]
+        if memName.startswith("CM_"):
+            if mcName not in CMMems:
+                CMMems[mcName] = []
+            CMMems[mcName].append(memName)
+        if memName.startswith("FM_"):
+            FM = re.sub(r"FM_(....)_......", r"\1", memName)
+            if mcName not in FMMems:
+                FMMems[mcName] = []
+            FMMems[mcName].append(FM)
 
 # Open and print out preambles for the parameters and top files.
 dirname = os.path.dirname(os.path.realpath('__file__'))
-parametersFile = open(os.path.join(dirname, "../TrackletAlgorithm/MatchCalculator_parameters.h"), "w")
-parametersFile.write(
-    "#ifndef TrackletAlgorithm_MatchCalculator_parameters_h\n"
-    "#define TrackletAlgorithm_MatchCalculator_parameters_h\n"
-    "\n"
-    "// This file contains numbers of memories and bit masks that are specific to\n"
-    "// each MatchCalculator and that come directly from the wiring.\n"
-    "//\n"
-    "// The validity of each of the barrel CM memories is determined by\n"
-    "// FMMask. The bits of this mask, from least significant to most\n"
-    "// significant, represent the memories in the order they are passed to\n"
-    "// MatchCalculator; e.g., the LSB corresponds to\n"
-    "// TF::L1L2. If a bit is set, the corresponding memory is\n"
-    "// valid, if it is not, the corresponding memory is not valid.\n"
-)
-topHeaderFile = open(os.path.join(dirname, "../TrackletAlgorithm/MatchCalculatorTop.h"), "w")
-topHeaderFile.write(
-    "#ifndef TrackletAlgorithm_MatchCalculatorTop_h\n"
-    "#define TrackletAlgorithm_MatchCalculatorTop_h\n"
-    "\n"
-    "#include \"MatchCalculator.h\"\n"
-    "\n"
-)
-topFile = open(os.path.join(dirname, "../TrackletAlgorithm/MatchCalculatorTop.cc"), "w")
-topFile.write(
-    "#include \"MatchCalculatorTop.h\"\n"
-    "\n"
-    "////////////////////////////////////////////////////////////////////////////////\n"
-    "// Top functions for various MatchCalculators (MC). For each iteration of\n"
-    "// the main processing loop, a MC retrieves an array of Candidate Matches,\n"
-    "// and computes Full Matches from each.\n"
-    "////////////////////////////////////////////////////////////////////////////////\n"
-)
+with open(os.path.join(dirname, "../TrackletAlgorithm/MatchCalculator_parameters.h"), "w") as parametersFile, \
+     open(os.path.join(dirname, "../TrackletAlgorithm/MatchCalculatorTop.h"), "w") as topHeaderFile, \
+     open(os.path.join(dirname, "../TrackletAlgorithm/MatchCalculatorTop.cc"), "w") as topFile:
+    parametersFile.write(
+        "#ifndef TrackletAlgorithm_MatchCalculator_parameters_h\n"
+        "#define TrackletAlgorithm_MatchCalculator_parameters_h\n"
+        "\n"
+        "// This file contains numbers of memories and bit masks that are specific to\n"
+        "// each MatchCalculator and that come directly from the wiring.\n"
+        "//\n"
+        "// The validity of each of the barrel CM memories is determined by\n"
+        "// FMMask. The bits of this mask, from least significant to most\n"
+        "// significant, represent the memories in the order they are passed to\n"
+        "// MatchCalculator; e.g., the LSB corresponds to\n"
+        "// TF::L1L2. If a bit is set, the corresponding memory is\n"
+        "// valid, if it is not, the corresponding memory is not valid.\n"
+    )
+    topHeaderFile.write(
+        "#ifndef TrackletAlgorithm_MatchCalculatorTop_h\n"
+        "#define TrackletAlgorithm_MatchCalculatorTop_h\n"
+        "\n"
+        "#include \"MatchCalculator.h\"\n"
+        "\n"
+    )
+    topFile.write(
+        "#include \"MatchCalculatorTop.h\"\n"
+        "\n"
+        "////////////////////////////////////////////////////////////////////////////////\n"
+        "// Top functions for various MatchCalculators (MC). For each iteration of\n"
+        "// the main processing loop, a MC retrieves an array of Candidate Matches,\n"
+        "// and computes Full Matches from each.\n"
+        "////////////////////////////////////////////////////////////////////////////////\n"
+    )
 
-# Calculate parameters and print out parameters and top function for each MC.
-for mcName in sorted(CMMems.keys()):
-    seed = re.sub(r"MC_(..)....", r"\1", mcName)
-    iMC = re.sub(r"MC_.....(.)", r"\1", mcName)
+    # Calculate parameters and print out parameters and top function for each MC.
+    for mcName in sorted(CMMems.keys()):
+        seed = re.sub(r"MC_(..)....", r"\1", mcName)
+        iMC = re.sub(r"MC_.....(.)", r"\1", mcName)
 
-    # numbers of memories
-    nCMMem = len(CMMems[mcName])
-    nFMMem = 8#FIXME after TBHelper is added to the test bench len(FMMems[tpName])
-    FMMask = 0
-    for FM in FMMems[mcName]:
-        FMMask = FMMask | (1 << TF_index[FM])
+        # numbers of memories
+        nCMMem = len(CMMems[mcName])
+        nFMMem = 8#FIXME after TBHelper is added to the test bench len(FMMems[tpName])
+        FMMask = 0
+        for FM in FMMems[mcName]:
+            FMMask = FMMask | (1 << TF_index[FM])
 
-    # Print out parameters for this MC.
+        # Print out parameters for this MC.
+        parametersFile.write(
+            "\n"
+            "// magic numbers for " + mcName + "\n"
+            "template<> constexpr uint32_t FMMask<TF::" + seed + ", MC::" + iMC + ">() {\n"
+            "  return 0x%X;\n"
+            "}\n" % FMMask
+        )
+
+        # Print out prototype for top function for this MC.
+        topHeaderFile.write(
+            "\n"
+            "constexpr int " + seed + "PHI" + iMC + "maxMatchCopies(" + str(nCMMem) + ");\n"
+            "constexpr int " + seed + "PHI" + iMC + "maxFullMatchCopies(" + str(nFMMem) + ");\n"
+            "\n"
+            "void MatchCalculator_" + seed + "PHI" + iMC + "(\n"
+            "    const BXType bx,\n"
+            "    const CandidateMatchMemory match[" + seed + "PHI" + iMC + "maxMatchCopies],\n"
+            "    const AllStubMemory<" + ASRegion(seed) + ">* allstub,\n"
+            "    const AllProjectionMemory<" + APRegion(seed) + ">* allproj,\n"
+            "    BXType& bx_o,\n"
+            "    FullMatchMemory<" + FMRegion(seed) + "> fullmatch[" + seed + "PHI" + iMC + "maxFullMatchCopies]\n"
+            ");\n"
+        )
+
+        # Print out definition of top function for this MC.
+        topFile.write(
+            "\n"
+            "void MatchCalculator_" + seed + "PHI" + iMC + "(\n"
+            "    const BXType bx,\n"
+            "    const CandidateMatchMemory match[" + seed + "PHI" + iMC + "maxMatchCopies],\n"
+            "    const AllStubMemory<" + ASRegion(seed) + ">* allstub,\n"
+            "    const AllProjectionMemory<" + APRegion(seed) + ">* allproj,\n"
+            "    BXType& bx_o,\n"
+            "    FullMatchMemory<" + FMRegion(seed) + "> fullmatch[" + seed + "PHI" + iMC + "maxFullMatchCopies]\n"
+            ") {\n"
+            "#pragma HLS inline off\n"
+            "#pragma HLS interface register port=bx_o\n"
+        )
+        if nCMMem == 1:
+            topFile.write("#pragma HLS resource variable=match.get_mem() latency=2\n")
+        else:
+            for i in range(nCMMem):
+                topFile.write("#pragma HLS resource variable=match[" + str(i) + "].get_mem() latency=2\n")
+        topFile.write(
+            "#pragma HLS resource variable=allstub->get_mem() latency=2\n"
+            "#pragma HLS resource variable=allproj->get_mem() latency=2\n"
+            "\n"
+            "MC_" + seed + "PHI" + iMC + ": MatchCalculator<"
+            "" + ASRegion(seed) + ", " + APRegion(seed) + ", " + FMRegion(seed) + ", " + str(len(TF_index)) + ", " + str(len(TF_index)) + ",\n"
+            " TF::" + seed + ", "
+            "TF::" + "D1" + ", "
+            "MC::" + iMC + "> (\n"
+            "    bx,\n"
+            "    match,\n"
+            "    allstub,\n"
+            "    allproj,\n"
+            "    bx_o,\n"
+            "    fullmatch\n"
+            "  );\n"
+            "}\n"
+        )
+
+    # Print out endifs and close files.
     parametersFile.write(
         "\n"
-        "// magic numbers for " + mcName + "\n"
-        "template<> constexpr uint32_t FMMask<TF::" + seed + ", MC::" + iMC + ">() {\n"
-        "  return 0x%X;\n"
-        "}\n" % FMMask
+        "// return mask bit AND mask\n"
+        "template<TF::layerDisk Layer, MC::imc PHI, TF::seed Seed> constexpr bool FMMask() {\n"
+        "  return FMMask<Layer, PHI>() & (1<<Seed);\n"
+        "}\n\n"
+        "template<TF::layerDisk Layer, MC::imc PHI, TF::seed Seed>\n"
+        "static const ap_uint<1 << Seed> FMCount() {\n"
+        "  ap_uint<1<<Seed> bits(-1);\n"
+        "  return __builtin_popcount(bits & FMMask<Layer, PHI>())-1;\n"
+        "}\n\n"
+        "#endif\n"
     )
-
-    # Print out prototype for top function for this MC.
     topHeaderFile.write(
         "\n"
-        "constexpr int " + seed + "PHI" + iMC + "maxMatchCopies(" + str(nCMMem) + ");\n"
-        "constexpr int " + seed + "PHI" + iMC + "maxFullMatchCopies(" + str(nFMMem) + ");\n"
-        "\n"
-        "void MatchCalculator_" + seed + "PHI" + iMC + "(\n"
-        "    const BXType bx,\n"
-        "    const CandidateMatchMemory match[" + seed + "PHI" + iMC + "maxMatchCopies],\n"
-        "    const AllStubMemory<" + ASRegion(seed) + ">* allstub,\n"
-        "    const AllProjectionMemory<" + APRegion(seed) + ">* allproj,\n"
-        "    BXType& bx_o,\n"
-        "    FullMatchMemory<" + FMRegion(seed) + "> fullmatch[" + seed + "PHI" + iMC + "maxFullMatchCopies]\n"
-        ");\n"
+        "#endif\n"
     )
-
-    # Print out definition of top function for this MC.
     topFile.write(
         "\n"
-        "void MatchCalculator_" + seed + "PHI" + iMC + "(\n"
-        "    const BXType bx,\n"
-        "    const CandidateMatchMemory match[" + seed + "PHI" + iMC + "maxMatchCopies],\n"
-        "    const AllStubMemory<" + ASRegion(seed) + ">* allstub,\n"
-        "    const AllProjectionMemory<" + APRegion(seed) + ">* allproj,\n"
-        "    BXType& bx_o,\n"
-        "    FullMatchMemory<" + FMRegion(seed) + "> fullmatch[" + seed + "PHI" + iMC + "maxFullMatchCopies]\n"
-        ") {\n"
-        "#pragma HLS inline off\n"
-        "#pragma HLS interface register port=bx_o\n"
+        "////////////////////////////////////////////////////////////////////////////////\n"
     )
-    if nCMMem == 1:
-        topFile.write("#pragma HLS resource variable=match.get_mem() latency=2\n")
-    else:
-        for i in range(nCMMem):
-            topFile.write("#pragma HLS resource variable=match[" + str(i) + "].get_mem() latency=2\n")
-    topFile.write(
-        "#pragma HLS resource variable=allstub->get_mem() latency=2\n"
-        "#pragma HLS resource variable=allproj->get_mem() latency=2\n"
-        "\n"
-        "MC_" + seed + "PHI" + iMC + ": MatchCalculator<"
-        "" + ASRegion(seed) + ", " + APRegion(seed) + ", " + FMRegion(seed) + ", " + str(len(TF_index)) + ", " + str(len(TF_index)) + ",\n"
-        " TF::" + seed + ", "
-        "TF::" + "D1" + ", "
-        "MC::" + iMC + "> (\n"
-        "    bx,\n"
-        "    match,\n"
-        "    allstub,\n"
-        "    allproj,\n"
-        "    bx_o,\n"
-        "    fullmatch\n"
-        "  );\n"
-        "}\n"
-    )
-
-# Print out endifs and close files.
-parametersFile.write(
-    "\n"
-    "// return mask bit AND mask\n"
-    "template<TF::layerDisk Layer, MC::imc PHI, TF::seed Seed> constexpr bool FMMask() {\n"
-    "  return FMMask<Layer, PHI>() & (1<<Seed);\n"
-    "}\n\n"
-    "template<TF::layerDisk Layer, MC::imc PHI, TF::seed Seed>\n"
-    "static const ap_uint<1 << Seed> FMCount() {\n"
-    "  ap_uint<1<<Seed> bits(-1);\n"
-    "  return __builtin_popcount(bits & FMMask<Layer, PHI>())-1;\n"
-    "}\n\n"
-    "#endif\n"
-)
-parametersFile.close()
-topHeaderFile.write(
-    "\n"
-    "#endif\n"
-)
-topHeaderFile.close()
-topFile.write(
-    "\n"
-    "////////////////////////////////////////////////////////////////////////////////\n"
-)
-topFile.close()

--- a/emData/generate_ME.py
+++ b/emData/generate_ME.py
@@ -2,85 +2,50 @@
 
 from __future__ import print_function
 import argparse
-from enum import Enum
-import os
 import pprint
 import re
 import sys
 
-def parseWiresFile(wiresFileName):
-    wiresFile = open(wiresFileName)
-    vmsmeStubInMems = {}
-    vmprojProjInMems = {}
-    cmMatchoutMems = {}
-    for line in wiresFile:
-        line = line.rstrip()
-        meName = re.sub(r".*ME_([L|D].(?:PHI).[0-9]{1,2}).*", r"ME_\1", line)
-        memName = line.split()[0]
-        if memName.startswith("VMSME_"):
-            if meName not in vmsmeStubInMems:
-                vmsmeStubInMems[meName] = []
-            vmsmeStubInMems[meName].append(memName)
-        if memName.startswith("VMPROJ_"):
-            if meName not in vmprojProjInMems:
-                vmprojProjInMems[meName] = []
-            vmprojProjInMems[meName].append(memName)
-        if memName.startswith("CM_"):
-            if meName not in cmMatchoutMems:
-                cmMatchoutMems[meName] = []
-            cmMatchoutMems[meName].append(memName)
-    wiresFile.close()
-    return (vmsmeStubInMems, vmprojProjInMems, cmMatchoutMems)
-
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="This script generates MatchEngineTop.h and MatchEngineTop.cc \
-in the TrackletAlgorithm/ directory. Currently supports all MEs in all layers/disks.",
-                                     epilog="")
-    parser.add_argument("-d", "--debug", action="store_true", help="Shows some extra information in order to debug this program (default=%(default)s)")
-    parser.add_argument("-g", "--grep", default="", type=str, nargs='+', help="Comma separated list of patterns to select for (default = %(default)s). Watch for dangling commas!")
-    parser.add_argument("-ild", "--iLayerDisk", choices=[1,2,3,4,5,6], nargs='+', type=int, help="Select the region for which to generate the top functions (default=%(default)s)")
-    parser.add_argument("-ld", "--layerDisk", choices=["layer","disk","both"], default="both", help="Select the region for which to generate the top functions (default=%(default)s)")
-    parser.add_argument("-o", "--outputDirectory", metavar="DIR", default="../TrackletAlgorithm/", type=str, help="The directory in which to write the output files (default=%(default)s)")
-    parser.add_argument("-s", "--sparse", action="store_true", help="Only generate one module per layer/disk (default=%(default)s)")
-    parser.add_argument("-v", "--vgrep", default="", type=str, nargs='+', help="Comma separated list of patterns to ignore (default = %(default)s). Watch for dangling commas!")
-    parser.add_argument("-V", "--verbose", action="store_true", help="Prints out extra information while running (default=%(default)s)")
-    parser.add_argument("-w", "--wiresFileName", metavar="WIRES_FILE", default="LUTs/wires.dat", type=str, help="Name and directory of the configuration file for wiring (default = %(default)s)")
-    parser.add_argument("--version", action='version', version='%(prog)s v0.1b')
-    args = parser.parse_args()
-
-    if args.layerDisk == "disk" and 6 in args.iLayerDisk:
-        print("WARNING: You have selected to only print top functions for the disks, but you have also selected a 6th disk layer."
-              " Remember, there are only 5 disk. Don't worry, this is a filter and won't have a detrimental effect.")
-
-    if len(args.grep) > 0:
-        args.grep.sort()
-        print("Will select for the patterns:")
-        print(*['\t' + s for s in args.grep], sep = "\n")
-
-    if len(args.vgrep) > 0:
-        args.vgrep.sort()
-        print("Will veto MEs with the patterns:")
-        print(*['\t' + s for s in args.vgrep], sep = "\n")
-
-    if(args.debug):
-         print('Number of arguments:', len(sys.argv), 'arguments.')
-         print('Argument List:', str(sys.argv))
-         print("Argument", args)
-
-    # First, parse the wires file and store the memory names associated with MEs in
-    # dictionaries with the ME names as keys.
-    vmsmeStubInMems, vmprojProjInMems, cmMatchoutMems = parseWiresFile(args.wiresFileName)
-    if args.debug:
+def checkMemories(debug, vmsmeStubInMems, vmprojProjInMems, cmMatchoutMems):
+    if debug:
         pprint.pprint(vmsmeStubInMems, depth=2, width=60)
         pprint.pprint(vmprojProjInMems, depth=2, width=60)
         pprint.pprint(cmMatchoutMems, depth=2, width=60)
-        exit(0)
+        sys.exit(0)
     assert len(vmsmeStubInMems) == len(vmprojProjInMems) == len(cmMatchoutMems), "The length of the module lists are not the same for the VMSME, VMPROJ, and CM!"
     for meName in sorted(vmprojProjInMems.keys()):
         assert len(vmsmeStubInMems[meName]) == len(vmprojProjInMems[meName]) == len(cmMatchoutMems[meName]), "The length of the modules for %s are not the same for the VMSME, VMPROJ, and CM!" % (meName)
 
-    # Open and print out preambles for the top files.
-    topHeaderFile = open(args.outputDirectory + "/MatchEngineTop.h", "w")
+def getPrefixSpacing(funcName):
+    spacing = len("void " + funcName + "(")
+    prefix = ("\t" * (spacing // 4)) + (" " * (spacing % 4))
+    return prefix
+
+def parseWiresFile(wiresFileName):
+    with open(wiresFileName) as wiresFile:
+        vmsmeStubInMems = {}
+        vmprojProjInMems = {}
+        cmMatchoutMems = {}
+        for line in wiresFile:
+            line = line.rstrip()
+            meName = re.sub(r".*ME_([L|D].(?:PHI).[0-9]{1,2}).*", r"ME_\1", line)
+            memName = line.split()[0]
+            if memName.startswith("VMSME_"):
+                if meName not in vmsmeStubInMems:
+                    vmsmeStubInMems[meName] = []
+                vmsmeStubInMems[meName].append(memName)
+            if memName.startswith("VMPROJ_"):
+                if meName not in vmprojProjInMems:
+                    vmprojProjInMems[meName] = []
+                vmprojProjInMems[meName].append(memName)
+            if memName.startswith("CM_"):
+                if meName not in cmMatchoutMems:
+                    cmMatchoutMems[meName] = []
+                cmMatchoutMems[meName].append(memName)
+
+    return (vmsmeStubInMems, vmprojProjInMems, cmMatchoutMems)
+
+def writePreambles(topHeaderFile, topFile):
     topHeaderFile.write(
         "#ifndef TrackletAlgorithm_MatchEngineTop_h\n"
         "#define TrackletAlgorithm_MatchEngineTop_h\n"
@@ -88,84 +53,139 @@ in the TrackletAlgorithm/ directory. Currently supports all MEs in all layers/di
         "#include \"MatchEngine.h\"\n"
         "\n"
     )
-    topFile = open(args.outputDirectory + "/MatchEngineTop.cc", "w")
     topFile.write(
         "#include \"MatchEngineTop.h\"\n"
     )
 
-    # Calculate parameters and print out top function for each ME.
-    skipped_me = []
-    generatedLayerDisk = []
-    for meName in sorted(vmprojProjInMems.keys()):
-        if len(args.grep) > 0 and not any(re.search(pattern, meName) for pattern in args.grep):
-            skipped_me.append(meName)
-            continue
-        if len(args.vgrep) > 0 and any(re.search(pattern, meName) for pattern in args.vgrep):
-            skipped_me.append(meName)
-            continue
-
-        layerDisk = re.sub(r"ME_([L|D][0-9])(?:PHI).*", r"\1", meName)
-        iME = re.sub(r"ME_[L|D][0-9]((?:PHI).[0-9]{1,2})", r"\1", meName)
-        iLD = int(layerDisk[1:])
-        funcName = "MatchEngineTop_" + layerDisk + (iME if not args.sparse else "")
-        label = "ME_" + layerDisk + (iME if not args.sparse else "")
-
-
-        # To save time, only generate one module per layer/disk
-        if args.sparse and layerDisk in generatedLayerDisk:
-            continue
-        else:
-            generatedLayerDisk.append(layerDisk)
-
-        # Filter the top functions based on the arguments
-        if args.layerDisk != "both":
-            if args.layerDisk == "layer" and layerDisk[0] == "D":
-                continue
-            elif args.layerDisk == "disk" and layerDisk[0] == "L":
-                continue
-
-        if args.iLayerDisk != None and len(args.iLayerDisk) > 0 and iLD not in args.iLayerDisk:
-            continue
-
-        # Print out prototype for top function for this ME.
-        spacing = len("void " + funcName + "(")
-        prefix = ("\t" * (spacing // 4)) + (" " * (spacing % 4))
-        topHeaderFile.write(
-            "void " + funcName + "(const BXType bx, BXType& bx_o,\n"
-            + prefix + "const VMStubMEMemory<ModuleType<TF::" + layerDisk + ">(), NBitBin<TF::" + layerDisk + ">()>& inputStubData,\n"
-            + prefix + "const VMProjectionMemory<ProjectionType<TF::" + layerDisk + ">()>& inputProjectionData,\n"
-            + prefix + "CandidateMatchMemory& outputCandidateMatch);\n\n"
-        )
-
-        # Print out definition of top function for this TC.
-        topFile.write(
-            "\nvoid " + funcName + "(const BXType bx, BXType& bx_o,\n"
-            + prefix + "const VMStubMEMemory<ModuleType<TF::" + layerDisk + ">(), NBitBin<TF::" + layerDisk + ">()>& inputStubData,\n"
-            + prefix + "const VMProjectionMemory<ProjectionType<TF::" + layerDisk + ">()>& inputProjectionData,\n"
-            + prefix + "CandidateMatchMemory& outputCandidateMatch) {\n"
-            "\n"
-            "#ifdef  __VITIS_HLS__\n"
-            "\t// For use with Vitis >=2020.1\n"
-            "\t#pragma HLS LATENCY min=1 max=1\n"
-            "\t#pragma HLS interface ap_memory port=inputStubData->get_mem() latency=2\n"
-            "\t#pragma HLS interface ap_memory port=inputProjectionData->get_mem() latency=2\n"
-            "#else\n"
-            "\t#pragma HLS interface register port=bx_o\n"
-            "\t#pragma HLS resource variable=inputStubData->get_mem() latency=2\n"
-            "\t#pragma HLS resource variable=inputProjectionData->get_mem() latency=2\n"
-            "#endif\n"
-            "\n"
-            "\t" + label + ": MatchEngine<TF::" + layerDisk + ">(bx, bx_o, inputStubData, inputProjectionData, outputCandidateMatch);\n"
-            "}\n"
-        )
-
-    # Print out endifs and close files.
+def writeModuleToHeader(topHeaderFile, funcName, prefix, layerDisk):
     topHeaderFile.write(
-        "#endif\n"
+        "void " + funcName + "(const BXType bx, BXType& bx_o,\n"
+        + prefix + "const VMStubMEMemory<ModuleType<TF::" + layerDisk + ">(), NBitBin<TF::" + layerDisk + ">()>& inputStubData,\n"
+        + prefix + "const VMProjectionMemory<ProjectionType<TF::" + layerDisk + ">()>& inputProjectionData,\n"
+        + prefix + "CandidateMatchMemory& outputCandidateMatch);\n\n"
     )
-    topHeaderFile.close()
-    topFile.close()
+
+def writeModuleToImplementation(topFile, funcName, prefix, layerDisk, label):
+    topFile.write(
+        "\nvoid " + funcName + "(const BXType bx, BXType& bx_o,\n"
+        + prefix + "const VMStubMEMemory<ModuleType<TF::" + layerDisk + ">(), NBitBin<TF::" + layerDisk + ">()>& inputStubData,\n"
+        + prefix + "const VMProjectionMemory<ProjectionType<TF::" + layerDisk + ">()>& inputProjectionData,\n"
+        + prefix + "CandidateMatchMemory& outputCandidateMatch) {\n"
+        "\n"
+        "#ifdef  __VITIS_HLS__\n"
+        "\t// For use with Vitis >=2020.1\n"
+        "\t#pragma HLS LATENCY min=1 max=1\n"
+        "\t#pragma HLS interface ap_memory port=inputStubData->get_mem() latency=2\n"
+        "\t#pragma HLS interface ap_memory port=inputProjectionData->get_mem() latency=2\n"
+        "#else\n"
+        "\t#pragma HLS interface register port=bx_o\n"
+        "\t#pragma HLS resource variable=inputStubData->get_mem() latency=2\n"
+        "\t#pragma HLS resource variable=inputProjectionData->get_mem() latency=2\n"
+        "#endif\n"
+        "\n"
+        "\t" + label + ": MatchEngine<TF::" + layerDisk + ">(bx, bx_o, inputStubData, inputProjectionData, outputCandidateMatch);\n"
+        "}\n"
+    )
+
+def generateME(args = argparse.Namespace()):
+
+    # Perform some basic checks on the arguments.
+    if args.debug:
+        print('Number of arguments:', len(sys.argv), 'arguments.')
+        print('Argument List:', str(sys.argv))
+        print("Argument", args)
+
+    if args.layerDiskType == "disk" and 6 in args.iLayerDisk:
+        print("WARNING: You have selected to only print top functions for the disks, but you have also selected a 6th disk layer."
+              " Remember, there are only 5 disk. Don't worry, this is a filter and won't have a detrimental effect.")
+
+    if args.grep is not None:
+        args.grep.sort()
+        print("Will select for the patterns:")
+        print(*['\t' + s for s in args.grep], sep = "\n")
+
+    if args.vgrep is not None:
+        args.vgrep.sort()
+        print("Will veto MEs with the patterns:")
+        print(*['\t' + s for s in args.vgrep], sep = "\n")
+
+    # First, parse the wires file and store the memory names associated with MEs in
+    # dictionaries with the ME names as keys.
+    # Returned as a tuple of three lists
+    memoryTuple = parseWiresFile(args.wiresFileName)
+    checkMemories(args.debug, *memoryTuple)
+    _, vmprojProjInMems, _ = memoryTuple
+
+    # Open the output files.
+    with open(args.outputDirectory + "/MatchEngineTop.h", "w") as topHeaderFile, \
+         open(args.outputDirectory + "/MatchEngineTop.cc", "w") as topFile:
+
+        # Print out the preambles for the top files.
+        writePreambles(topHeaderFile, topFile)
+
+        # Calculate parameters and print out top function for each ME.
+        skipped_me = []
+        generatedLayerDisk = []
+        for meName in sorted(vmprojProjInMems.keys()):
+            if args.grep is not None and not any(re.search(pattern, meName) for pattern in args.grep):
+                skipped_me.append(meName)
+                continue
+            if args.vgrep is not None and any(re.search(pattern, meName) for pattern in args.vgrep):
+                skipped_me.append(meName)
+                continue
+
+            layerDisk = re.sub(r"ME_([L|D][0-9])(?:PHI).*", r"\1", meName)
+            iME = re.sub(r"ME_[L|D][0-9]((?:PHI).[0-9]{1,2})", r"\1", meName)
+            iLD = int(layerDisk[1:])
+            funcName = "MatchEngineTop_" + layerDisk + (iME if not args.sparse else "")
+            label = "ME_" + layerDisk + (iME if not args.sparse else "")
+
+
+            # To save time, only generate one module per layer/disk
+            if args.sparse and layerDisk in generatedLayerDisk:
+                continue
+            else:
+                generatedLayerDisk.append(layerDisk)
+
+            # Filter the top functions based on the arguments
+            if args.layerDiskType == "layer" and layerDisk[0] == "D":
+                continue
+            elif args.layerDiskType == "disk" and layerDisk[0] == "L":
+                continue
+
+            if args.iLayerDisk is not None and len(args.iLayerDisk) > 0 and iLD not in args.iLayerDisk:
+                continue
+
+            # Print out prototype for top function for this ME.
+            prefix = getPrefixSpacing(funcName)
+            writeModuleToHeader(topHeaderFile, funcName, prefix, layerDisk)
+
+            # Print out definition of top function for this ME.
+            writeModuleToImplementation(topFile, funcName, prefix, layerDisk, label)
+
+        # Print out endifs and close files.
+        topHeaderFile.write(
+            "#endif\n"
+        )
 
     if args.verbose:
         print("Skipped the following MEs due to the grep/vgrep patterns:")
         print(*['\t' + me for me in skipped_me], sep = "\n")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="This script generates MatchEngineTop.h and MatchEngineTop.cc \
+in the TrackletAlgorithm/ directory. Currently supports all MEs in all layers/disks.",
+                                     epilog="")
+    parser.add_argument("-d", "--debug", action="store_true", help="Shows some extra information in order to debug this program (default=%(default)s)")
+    parser.add_argument("-g", "--grep", default=None, type=str, nargs='+', help="Space separated list of patterns to select for (default = %(default)s)")
+    parser.add_argument("-ild", "--iLayerDisk", choices=[1,2,3,4,5,6], nargs='+', type=int, help="Select the region for which to generate the top functions (default=%(default)s)")
+    parser.add_argument("-ldt", "--layerDiskType", choices=["layer","disk","both"], default="both", help="Select the region for which to generate the top functions (default=%(default)s)")
+    parser.add_argument("-o", "--outputDirectory", metavar="DIR", default="../TrackletAlgorithm/", type=str, help="The directory in which to write the output files (default=%(default)s)")
+    parser.add_argument("-s", "--sparse", action="store_true", help="Only generate one module per layer/disk (default=%(default)s)")
+    parser.add_argument("-v", "--vgrep", default=None, type=str, nargs='+', help="Space separated list of patterns to ignore (default = %(default)s)")
+    parser.add_argument("-V", "--verbose", action="store_true", help="Prints out extra information while running (default=%(default)s)")
+    parser.add_argument("-w", "--wiresFileName", metavar="WIRES_FILE", default="LUTs/wires.dat", type=str, help="Name and directory of the configuration file for wiring (default = %(default)s)")
+    parser.add_argument("--version", action='version', version='%(prog)s v0.1b')
+    arguments = parser.parse_args()
+
+    generateME(arguments)

--- a/emData/generate_PR.py
+++ b/emData/generate_PR.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import absolute_import, print_function
 
 # Automatically generates ProjectionRouterTop.h, and ProjectionRouterTop.cc
@@ -10,6 +10,7 @@ def getListOfModules(wiresFileName):
     wiresFile.close()
     modulesToBuild = list(set(re.findall(r"PR_L\w+",wiresInfo))) # FIXME ProjectionRouterTop currently won't compile if DISK modules are included
     # modulesToBuild = list(set(re.findall(r"PR_\w+",wiresInfo))) # Use this one once DISK is working for ProjectionRouter
+    modulesToBuild.sort()
     return modulesToBuild
 
 def getNTProjAndNVMProj(module, wiresFileName):

--- a/emData/generate_PR.py
+++ b/emData/generate_PR.py
@@ -2,21 +2,21 @@
 from __future__ import absolute_import, print_function
 
 # Automatically generates ProjectionRouterTop.h, and ProjectionRouterTop.cc
-import sys, re, os
+import os
+import re
+import sys
 
 def getListOfModules(wiresFileName):
-    wiresFile = open(wiresFileName)
-    wiresInfo = wiresFile.read()
-    wiresFile.close()
+    with open(wiresFileName) as wiresFile:
+        wiresInfo = wiresFile.read()
     modulesToBuild = list(set(re.findall(r"PR_L\w+",wiresInfo))) # FIXME ProjectionRouterTop currently won't compile if DISK modules are included
     # modulesToBuild = list(set(re.findall(r"PR_\w+",wiresInfo))) # Use this one once DISK is working for ProjectionRouter
     modulesToBuild.sort()
     return modulesToBuild
 
 def getNTProjAndNVMProj(module, wiresFileName):
-    wiresFile = open(wiresFileName)
-    wiresInfo = wiresFile.read()
-    wiresFile.close()
+    with open(wiresFileName) as wiresFile:
+        wiresInfo = wiresFile.read()
     TProjCount = wiresInfo.count(module + ".projin")
     VMProjCount = wiresInfo.count(module + ".vmprojout")
     return TProjCount, VMProjCount
@@ -25,10 +25,10 @@ def getTProjAndVMProjRegions(module):
     if any(psword in module for psword in ["L1","L2","L3"]): TProjRegion = "BARRELPS"
     elif any(psword in module for psword in ["L4","L5","L6"]): TProjRegion = "BARREL2S"
     else: TProjRegion = "DISK"
-    
+
     if any(psword in module for psword in ["L1","L2","L3","L4","L5","L6"]): VMProjRegion = "BARREL"
     else: VMProjRegion = "DISK"
-    
+
     return TProjRegion, VMProjRegion
 
 def getLayerAndDisk(module):
@@ -59,14 +59,14 @@ def writeHeaderPostamble():
     strPostamble = ""
     strPostamble += "#endif\n"
     return strPostamble
- 
+
 def writeSourceModuleInstance(module, wiresFileName):
     TProjCount, VMProjCount = getNTProjAndNVMProj(module, wiresFileName)
     TProjRegion, VMProjRegion = getTProjAndVMProjRegions(module)
     layer, disk = getLayerAndDisk(module)
     strSource =  ""
     strSource += "void ProjectionRouterTop_" + module[3:] + "(BXType bx,\n"
-    strSource += "                         const TrackletProjectionMemory<" + TProjRegion + "> projin[" + str(TProjCount) + "],\n" 
+    strSource += "                         const TrackletProjectionMemory<" + TProjRegion + "> projin[" + str(TProjCount) + "],\n"
     strSource += "                         BXType& bx_o,\n"
     strSource += "                         AllProjectionMemory<" + TProjRegion + ">& allprojout,\n"
     strSource += "                         VMProjectionMemory<" + VMProjRegion + "> vmprojout[" + str(VMProjCount) + "])\n"
@@ -83,11 +83,11 @@ def writeSourceModuleInstance(module, wiresFileName):
     strSource += "    (bx, projin, bx_o, allprojout, vmprojout);\n"
     strSource += "}\n\n"
     return strSource
-    
+
 def writeSourcePreamble():
     strPreamble = ""
     strPreamble += "#include \"ProjectionRouterTop.h\"\n\n"
-    return strPreamble    
+    return strPreamble
 
 if len(sys.argv) < 2:
     print("Usage: " + sys.argv[0] + " WIRES_FILE")
@@ -105,10 +105,7 @@ for module in modulesToBuild:
 headerString += writeHeaderPostamble()
 
 dirname = os.path.dirname(os.path.realpath('__file__'))
-headerFile = open(os.path.join(dirname, "../TrackletAlgorithm/ProjectionRouterTop.h"), "w")
-headerFile.write(headerString)
-headerFile.close()
-sourceFile = open(os.path.join(dirname, "../TrackletAlgorithm/ProjectionRouterTop.cc"), "w")
-sourceFile.write(sourceString)
-sourceFile.close()
-
+with open(os.path.join(dirname, "../TrackletAlgorithm/ProjectionRouterTop.h"), "w") as headerFile:
+    headerFile.write(headerString)
+with open(os.path.join(dirname, "../TrackletAlgorithm/ProjectionRouterTop.cc"), "w") as sourceFile:
+    sourceFile.write(sourceString)

--- a/emData/generate_TB.py
+++ b/emData/generate_TB.py
@@ -3,7 +3,10 @@
 # This script generates TrackBuilderTop.h and TrackBuilderTop.cc in the
 # TrackletAlgorithm/ directory.
 
-import sys, re, os
+from __future__ import absolute_import
+import os
+import re
+import sys
 
 if len(sys.argv) < 2:
     print("Usage: " + sys.argv[0] + " WIRES_FILE")
@@ -12,122 +15,119 @@ wiresFileName = sys.argv[1]
 
 # First, parse the wires file and store the memory names associated with TBs in
 # dictionaries with the TB names as keys.
-wiresFile = open(wiresFileName)
-tparMems = {}
-barrelFMMems = {}
-diskFMMems = {}
-for line in wiresFile:
-    if " FT_" not in line:
-        continue
-    line = line.rstrip()
-    tbName = re.sub(r".*FT_(....).*", r"FT_\1", line)
-    seed = tbName.split("_")[1]
-    memName = line.split()[0]
-    if memName.startswith("TPAR"):
-        if tbName not in tparMems:
-            tparMems[tbName] = []
-        tparMems[tbName].append(memName)
-    if memName.startswith("FM"):
-        if tbName not in barrelFMMems:
-            barrelFMMems[tbName] = []
-        if tbName not in diskFMMems:
-            diskFMMems[tbName] = []
-        if memName.startswith("FM_" + seed + "_L"):
-            barrelFMMems[tbName].append(memName)
-        if memName.startswith("FM_" + seed + "_D"):
-            diskFMMems[tbName].append(memName)
-wiresFile.close()
+with open(wiresFileName, "r") as wiresFile:
+    tparMems = {}
+    barrelFMMems = {}
+    diskFMMems = {}
+    for line in wiresFile:
+        if " FT_" not in line:
+            continue
+        line = line.rstrip()
+        tbName = re.sub(r".*FT_(....).*", r"FT_\1", line)
+        seed = tbName.split("_")[1]
+        memName = line.split()[0]
+        if memName.startswith("TPAR"):
+            if tbName not in tparMems:
+                tparMems[tbName] = []
+            tparMems[tbName].append(memName)
+        if memName.startswith("FM"):
+            if tbName not in barrelFMMems:
+                barrelFMMems[tbName] = []
+            if tbName not in diskFMMems:
+                diskFMMems[tbName] = []
+            if memName.startswith("FM_" + seed + "_L"):
+                barrelFMMems[tbName].append(memName)
+            if memName.startswith("FM_" + seed + "_D"):
+                diskFMMems[tbName].append(memName)
 
 # Open and print out preambles for the top files.
 dirname = os.path.dirname(os.path.realpath('__file__'))
-topHeaderFile = open(os.path.join(dirname, "../TrackletAlgorithm/TrackBuilderTop.h"), "w")
-topHeaderFile.write(
-    "#ifndef TrackletAlgorithm_TrackBuilderTop_h\n"
-    "#define TrackletAlgorithm_TrackBuilderTop_h\n"
-    "\n"
-    "#include \"TrackBuilder.h\"\n"
-)
-topFile = open(os.path.join(dirname, "../TrackletAlgorithm/TrackBuilderTop.cc"), "w")
-topFile.write(
-    "#include \"TrackBuilderTop.h\"\n"
-)
+with open(os.path.join(dirname, "../TrackletAlgorithm/TrackBuilderTop.h"), "w") as topHeaderFile, \
+     open(os.path.join(dirname, "../TrackletAlgorithm/TrackBuilderTop.cc"), "w") as topFile:
+    topHeaderFile.write(
+        "#ifndef TrackletAlgorithm_TrackBuilderTop_h\n"
+        "#define TrackletAlgorithm_TrackBuilderTop_h\n"
+        "\n"
+        "#include \"TrackBuilder.h\"\n"
+    )
+    topFile.write(
+        "#include \"TrackBuilderTop.h\"\n"
+    )
 
-# Calculate parameters and print out top function for each TB.
-for tbName in sorted(tparMems.keys()):
-    seed = re.sub(r"FT_(....)", r"\1", tbName)
+    # Calculate parameters and print out top function for each TB.
+    for tbName in sorted(tparMems.keys()):
+        seed = re.sub(r"FT_(....)", r"\1", tbName)
 
-    # numbers of memories
-    nTPARMem = len(tparMems[tbName])
-    nBarrelFMMem = len(barrelFMMems[tbName])
-    nDiskFMMem = len(diskFMMems[tbName])
+        # numbers of memories
+        nTPARMem = len(tparMems[tbName])
+        nBarrelFMMem = len(barrelFMMems[tbName])
+        nDiskFMMem = len(diskFMMems[tbName])
 
-    # numbers of output stubs
-    nBarrelStubs = len(set([fm[0:10] for fm in barrelFMMems[tbName]]))
-    nDiskStubs = len(set([fm[0:10] for fm in diskFMMems[tbName]]))
+        # numbers of output stubs
+        nBarrelStubs = len({[fm[0:10] for fm in barrelFMMems[tbName]]})
+        nDiskStubs = len({[fm[0:10] for fm in diskFMMems[tbName]]})
 
-    # Print out prototype for top function for this TB.
+        # Print out prototype for top function for this TB.
+        topHeaderFile.write(
+            "\n"
+            "void TrackBuilder_" + seed + "(\n"
+            "    const BXType bx,\n"
+            "    const TrackletParameterMemory trackletParameters[],\n"
+            "    const FullMatchMemory<BARREL> barrelFullMatches[],\n"
+            "    const FullMatchMemory<DISK> diskFullMatches[],\n"
+            "    BXType &bx_o,\n"
+            "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::TrackWord trackWord[],\n"
+            "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::BarrelStubWord barrelStubWords[][kMaxProc],\n"
+            "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::DiskStubWord diskStubWords[][kMaxProc]\n"
+            ");\n"
+        )
+
+        # Print out definition of top function for this TB.
+        topFile.write(
+            "\n"
+            "void TrackBuilder_" + seed + "(\n"
+            "    const BXType bx,\n"
+            "    const TrackletParameterMemory trackletParameters[" + str(nTPARMem) + "],\n"
+            "    const FullMatchMemory<BARREL> barrelFullMatches[" + str(nBarrelFMMem) + "],\n"
+            "    const FullMatchMemory<DISK> diskFullMatches[" + str(nDiskFMMem) + "],\n"
+            "    BXType &bx_o,\n"
+            "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::TrackWord trackWord[kMaxProc],\n"
+            "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::BarrelStubWord barrelStubWords[" + str(nBarrelStubs) + "][kMaxProc],\n"
+            "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::DiskStubWord diskStubWords[" + str(nDiskStubs) + "][kMaxProc]\n"
+            ") {\n"
+            "#pragma HLS inline recursive\n"
+            "#pragma HLS array_partition variable=trackletParameters complete dim=1\n"
+            "#pragma HLS array_partition variable=barrelFullMatches complete dim=1\n"
+            "#pragma HLS array_partition variable=diskFullMatches complete dim=1\n"
+        )
+        for i in range(0, nTPARMem):
+            topFile.write("#pragma HLS resource variable=trackletParameters[" + str(i) + "].get_mem() latency=2\n")
+        for i in range(0, nBarrelFMMem):
+            topFile.write("#pragma HLS resource variable=barrelFullMatches[" + str(i) + "].get_mem() latency=2\n")
+        for i in range(0, nDiskFMMem):
+            topFile.write("#pragma HLS resource variable=diskFullMatches[" + str(i) + "].get_mem() latency=2\n")
+        topFile.write(
+            "#pragma HLS interface register port=bx_o\n"
+            "#pragma HLS array_partition variable=barrelStubWords complete dim=1\n"
+            "#pragma HLS array_partition variable=diskStubWords complete dim=1\n"
+            "#pragma HLS stream variable=trackWord depth=1 dim=1\n"
+            "#pragma HLS stream variable=barrelStubWords depth=1 dim=2\n"
+            "#pragma HLS stream variable=diskStubWords depth=1 dim=2\n"
+            "\n"
+            "TB_" + seed + ": TrackBuilder<" + str(nBarrelFMMem) + ", " + str(nDiskFMMem) + ", " + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">(\n"
+            "    bx,\n"
+            "    trackletParameters,\n"
+            "    barrelFullMatches,\n"
+            "    diskFullMatches,\n"
+            "    bx_o,\n"
+            "    trackWord,\n"
+            "    barrelStubWords,\n"
+            "    diskStubWords\n"
+            "  );\n"
+            "}\n"
+        )
+
     topHeaderFile.write(
         "\n"
-        "void TrackBuilder_" + seed + "(\n"
-        "    const BXType bx,\n"
-        "    const TrackletParameterMemory trackletParameters[],\n"
-        "    const FullMatchMemory<BARREL> barrelFullMatches[],\n"
-        "    const FullMatchMemory<DISK> diskFullMatches[],\n"
-        "    BXType &bx_o,\n"
-        "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::TrackWord trackWord[],\n"
-        "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::BarrelStubWord barrelStubWords[][kMaxProc],\n"
-        "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::DiskStubWord diskStubWords[][kMaxProc]\n"
-        ");\n"
+        "#endif\n"
     )
-
-    # Print out definition of top function for this TB.
-    topFile.write(
-        "\n"
-        "void TrackBuilder_" + seed + "(\n"
-        "    const BXType bx,\n"
-        "    const TrackletParameterMemory trackletParameters[" + str(nTPARMem) + "],\n"
-        "    const FullMatchMemory<BARREL> barrelFullMatches[" + str(nBarrelFMMem) + "],\n"
-        "    const FullMatchMemory<DISK> diskFullMatches[" + str(nDiskFMMem) + "],\n"
-        "    BXType &bx_o,\n"
-        "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::TrackWord trackWord[kMaxProc],\n"
-        "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::BarrelStubWord barrelStubWords[" + str(nBarrelStubs) + "][kMaxProc],\n"
-        "    TrackFit<" + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">::DiskStubWord diskStubWords[" + str(nDiskStubs) + "][kMaxProc]\n"
-        ") {\n"
-        "#pragma HLS inline recursive\n"
-        "#pragma HLS array_partition variable=trackletParameters complete dim=1\n"
-        "#pragma HLS array_partition variable=barrelFullMatches complete dim=1\n"
-        "#pragma HLS array_partition variable=diskFullMatches complete dim=1\n"
-    )
-    for i in range(0, nTPARMem):
-        topFile.write("#pragma HLS resource variable=trackletParameters[" + str(i) + "].get_mem() latency=2\n")
-    for i in range(0, nBarrelFMMem):
-        topFile.write("#pragma HLS resource variable=barrelFullMatches[" + str(i) + "].get_mem() latency=2\n")
-    for i in range(0, nDiskFMMem):
-        topFile.write("#pragma HLS resource variable=diskFullMatches[" + str(i) + "].get_mem() latency=2\n")
-    topFile.write(
-        "#pragma HLS interface register port=bx_o\n"
-        "#pragma HLS array_partition variable=barrelStubWords complete dim=1\n"
-        "#pragma HLS array_partition variable=diskStubWords complete dim=1\n"
-        "#pragma HLS stream variable=trackWord depth=1 dim=1\n"
-        "#pragma HLS stream variable=barrelStubWords depth=1 dim=2\n"
-        "#pragma HLS stream variable=diskStubWords depth=1 dim=2\n"
-        "\n"
-        "TB_" + seed + ": TrackBuilder<" + str(nBarrelFMMem) + ", " + str(nDiskFMMem) + ", " + str(nBarrelStubs) + ", " + str(nDiskStubs) + ">(\n"
-        "    bx,\n"
-        "    trackletParameters,\n"
-        "    barrelFullMatches,\n"
-        "    diskFullMatches,\n"
-        "    bx_o,\n"
-        "    trackWord,\n"
-        "    barrelStubWords,\n"
-        "    diskStubWords\n"
-        "  );\n"
-        "}\n"
-    )
-
-topHeaderFile.write(
-    "\n"
-    "#endif\n"
-)
-topHeaderFile.close()
-topFile.close()

--- a/emData/generate_TB.py
+++ b/emData/generate_TB.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This script generates TrackBuilderTop.h and TrackBuilderTop.cc in the
 # TrackletAlgorithm/ directory.

--- a/emData/generate_TB.py
+++ b/emData/generate_TB.py
@@ -64,8 +64,8 @@ with open(os.path.join(dirname, "../TrackletAlgorithm/TrackBuilderTop.h"), "w") 
         nDiskFMMem = len(diskFMMems[tbName])
 
         # numbers of output stubs
-        nBarrelStubs = len({[fm[0:10] for fm in barrelFMMems[tbName]]})
-        nDiskStubs = len({[fm[0:10] for fm in diskFMMems[tbName]]})
+        nBarrelStubs = len({fm[0:10] for fm in barrelFMMems[tbName]})
+        nDiskStubs = len({fm[0:10] for fm in diskFMMems[tbName]})
 
         # Print out prototype for top function for this TB.
         topHeaderFile.write(

--- a/emData/generate_TC.py
+++ b/emData/generate_TC.py
@@ -6,12 +6,14 @@
 # TC_L3L4A, TC_L3L4D, TC_L5L6A, and TC_L5L6D.
 
 from __future__ import absolute_import, print_function
-import sys, re, os
+import os
+import re
+import sys
 from enum import Enum
 
 # These enums must match those defined in
 # TrackletAlgorithm/TrackletCalculator.h.
-class projout_index_barrel(Enum):
+class ProjoutIndexBarrel(Enum):
     LIPHIA = 0
     L1PHIB = 1
     L1PHIC = 2
@@ -42,7 +44,7 @@ class projout_index_barrel(Enum):
     L6PHID = 27
     N_PROJOUT_BARREL = 28
 
-class projout_index_disk(Enum):
+class ProjoutIndexDisk(Enum):
     D1PHIA = 0
     D1PHIB = 1
     D1PHIC = 2
@@ -68,236 +70,232 @@ wiresFileName = sys.argv[1]
 
 # First, parse the wires file and store the memory names associated with TCs in
 # dictionaries with the TC names as keys.
-wiresFile = open(wiresFileName)
-asInnerMems = {}
-asOuterMems = {}
-spMems = {}
-tprojMems = {}
-for line in wiresFile:
-    # Only barrel-only seeds are supported right now. And for L3L4 and L5L6,
-    # only TC_L3L4A, TC_L3L4D, TC_L5L6A, and TC_L5L6D are supported because we
-    # currently assume the inner stubs and outer stubs each have up to two
-    # all-stubs memories associated with them. However, the other L3L4 and L5L6
-    # TCs have up to three.
-    if "TC_L1L2" not in line \
-      and "TC_L3L4A" not in line and "TC_L3L4D" not in line \
-      and "TC_L5L6A" not in line and "TC_L5L6D" not in line:
-        continue
-    line = line.rstrip()
-    tcName = re.sub(r".*TC_(.....).*", r"TC_\1", line)
-    memName = line.split()[0]
-    if memName.startswith("AS_L1") or memName.startswith("AS_L3") or memName.startswith("AS_L5"):
-        if tcName not in asInnerMems:
-            asInnerMems[tcName] = []
-        asInnerMems[tcName].append(memName)
-    if memName.startswith("AS_L2") or memName.startswith("AS_L4") or memName.startswith("AS_L6"):
-        if tcName not in asOuterMems:
-            asOuterMems[tcName] = []
-        asOuterMems[tcName].append(memName)
-    if memName.startswith("SP_"):
-        if tcName not in spMems:
-            spMems[tcName] = []
-        spMems[tcName].append(memName)
-    if memName.startswith("TPROJ_"):
-        if tcName not in tprojMems:
-            tprojMems[tcName] = []
-        tprojMems[tcName].append(memName)
-wiresFile.close()
+with open(wiresFileName, "r") as wiresFile:
+    asInnerMems = {}
+    asOuterMems = {}
+    spMems = {}
+    tprojMems = {}
+    for line in wiresFile:
+        # Only barrel-only seeds are supported right now. And for L3L4 and L5L6,
+        # only TC_L3L4A, TC_L3L4D, TC_L5L6A, and TC_L5L6D are supported because we
+        # currently assume the inner stubs and outer stubs each have up to two
+        # all-stubs memories associated with them. However, the other L3L4 and L5L6
+        # TCs have up to three.
+        if "TC_L1L2" not in line \
+          and "TC_L3L4A" not in line and "TC_L3L4D" not in line \
+          and "TC_L5L6A" not in line and "TC_L5L6D" not in line:
+            continue
+        line = line.rstrip()
+        tcName = re.sub(r".*TC_(.....).*", r"TC_\1", line)
+        memName = line.split()[0]
+        if memName.startswith("AS_L1") or memName.startswith("AS_L3") or memName.startswith("AS_L5"):
+            if tcName not in asInnerMems:
+                asInnerMems[tcName] = []
+            asInnerMems[tcName].append(memName)
+        if memName.startswith("AS_L2") or memName.startswith("AS_L4") or memName.startswith("AS_L6"):
+            if tcName not in asOuterMems:
+                asOuterMems[tcName] = []
+            asOuterMems[tcName].append(memName)
+        if memName.startswith("SP_"):
+            if tcName not in spMems:
+                spMems[tcName] = []
+            spMems[tcName].append(memName)
+        if memName.startswith("TPROJ_"):
+            if tcName not in tprojMems:
+                tprojMems[tcName] = []
+            tprojMems[tcName].append(memName)
 
 # Open and print out preambles for the parameters and top files.
 dirname = os.path.dirname(os.path.realpath('__file__'))
-parametersFile = open(os.path.join(dirname, "../TrackletAlgorithm/TrackletCalculator_parameters.h"), "w")
-parametersFile.write(
-    "#ifndef TrackletAlgorithm_TrackletCalculator_parameters_h\n"
-    "#define TrackletAlgorithm_TrackletCalculator_parameters_h\n"
-    "\n"
-    "// This file contains numbers of memories and bit masks that are specific to\n"
-    "// each TrackletCalculator and that come directly from the wiring.\n"
-    "//\n"
-    "// The specific inner all-stub memory that the indices in a given stub-pair\n"
-    "// memory correspond to is determined by ASInnerMask. The bits of this mask,\n"
-    "// from least significant to most significant, represent the stub-pair memories\n"
-    "// in the order they are passed to TrackletCalculator; e.g., the LSB\n"
-    "// corresponds to stubPairs[0]. The bit for a given stub-pair memory is the\n"
-    "// index (0 or 1) of the inner all-stub memory that should be used. Likewise,\n"
-    "// the specific outer all-stub memories are determined by ASOuterMask.\n"
-    "//\n"
-    "// The validity of each of the barrel TPROJ memories is determined by\n"
-    "// TPROJMaskBarrel. The bits of this mask, from least significant to most\n"
-    "// significant, represent the memories in the order they are passed to\n"
-    "// TrackletCalculator; e.g., the LSB corresponds to\n"
-    "// projout_barrel_ps[TC::L1PHIA]. If a bit is set, the corresponding memory is\n"
-    "// valid, if it is not, the corresponding memory is not valid. Likewise, the\n"
-    "// validity of each of the disk TPROJ memories is determined by TPROJMaskDisk\n"
-    "// in the same way.\n"
-)
-topHeaderFile = open(os.path.join(dirname, "../TrackletAlgorithm/TrackletCalculatorTop.h"), "w")
-topHeaderFile.write(
-    "#ifndef TrackletAlgorithm_TrackletCalculatorTop_h\n"
-    "#define TrackletAlgorithm_TrackletCalculatorTop_h\n"
-    "\n"
-    "#include \"TrackletCalculator.h\"\n"
-)
-topFile = open(os.path.join(dirname, "../TrackletAlgorithm/TrackletCalculatorTop.cc"), "w")
-topFile.write(
-    "#include \"TrackletCalculatorTop.h\"\n"
-    "\n"
-    "////////////////////////////////////////////////////////////////////////////////\n"
-    "// Top functions for various TrackletCalculators (TC). For each iteration of\n"
-    "// the main processing loop, a TC retrieves a pair of stub indices from one of\n"
-    "// the stub-pair memories, and in turn, these indices are used to retrieve one\n"
-    "// stub each from an inner and an outer all-stub memory. This pair of stubs is\n"
-    "// used to calculate a rough set of helix parameters, which are written to the\n"
-    "// tracklet-parameter memory if the tracklet passes cuts on rinv and z0. Rough\n"
-    "// projections to additional layers and disks are also calculated and are\n"
-    "// written to the appropriate tracklet-projection memories.\n"
-    "////////////////////////////////////////////////////////////////////////////////\n"
-)
-
-# Calculate parameters and print out parameters and top function for each TC.
-for tcName in sorted(asInnerMems.keys()):
-    seed = re.sub(r"TC_(....).", r"\1", tcName)
-    iTC = re.sub(r"TC_....(.)", r"\1", tcName)
-
-    # numbers of memories
-    nASMemInner = len(asInnerMems[tcName])
-    nASMemOuter = len(asOuterMems[tcName])
-    nSPMem = len(spMems[tcName])
-
-    # AS inner and outer masks
-    asInnerMask = 0
-    asOuterMask = 0
-    asInnerMems[tcName].sort()
-    asOuterMems[tcName].sort()
-    for i in range(0, len(spMems[tcName])):
-        innerPart = re.sub(r".*_(..PHI.).*_(..PHI.).*", r"\1", spMems[tcName][i])
-        outerPart = re.sub(r".*_(..PHI.).*_(..PHI.).*", r"\2", spMems[tcName][i])
-        innerIndex = -1
-        outerIndex = -1
-        for j in range(0, len(asInnerMems[tcName])):
-            if innerPart in asInnerMems[tcName][j]:
-                innerIndex = j
-                break
-        assert(innerIndex == 0 or innerIndex == 1)
-        asInnerMask = asInnerMask | (innerIndex << i)
-        for j in range(0, len(asOuterMems[tcName])):
-            if outerPart in asOuterMems[tcName][j]:
-                outerIndex = j
-                break
-        assert(outerIndex == 0 or outerIndex == 1)
-        asOuterMask = asOuterMask | (outerIndex << i)
-
-    # TPROJ masks for barrel and disks
-    tprojMaskBarrel = 0
-    for projout in projout_index_barrel:
-        projoutName = "TPROJ_" + seed + iTC + "_" + projout.name
-        projoutIndex = projout.value
-        if projoutName in tprojMems[tcName]:
-            tprojMaskBarrel = tprojMaskBarrel | (1 << projoutIndex)
-    tprojMaskDisk = 0
-    for projout in projout_index_disk:
-        projoutName = "TPROJ_" + seed + iTC + "_" + projout.name
-        projoutIndex = projout.value
-        if projoutName in tprojMems[tcName]:
-            tprojMaskDisk = tprojMaskDisk | (1 << projoutIndex)
-
-    # Print out parameters for this TC.
+with open(os.path.join(dirname, "../TrackletAlgorithm/TrackletCalculator_parameters.h"), "w") as parametersFile, \
+     open(os.path.join(dirname, "../TrackletAlgorithm/TrackletCalculatorTop.h"), "w") as topHeaderFile, \
+     open(os.path.join(dirname, "../TrackletAlgorithm/TrackletCalculatorTop.cc"), "w") as topFile:
     parametersFile.write(
-        ("\n"
-        "// magic numbers for " + tcName + "\n"
-        "template<> constexpr uint32_t ASInnerMask<TF::" + seed + ", TC::" + iTC + ">() {\n"
-        "  return 0x%X;\n"
-        "}\n"
-        "template<> constexpr uint32_t ASOuterMask<TF::" + seed + ", TC::" + iTC + ">() {\n"
-        "  return 0x%X;\n"
-        "}\n"
-        "template<> constexpr uint32_t TPROJMaskBarrel<TF::" + seed + ", TC::" + iTC + ">() {\n"
-        "  return 0x%X;\n"
-        "}\n"
-        "template<> constexpr uint32_t TPROJMaskDisk<TF::" + seed + ", TC::" + iTC + ">() {\n"
-        "  return 0x%X;\n"
-        "}\n")
-        % (asInnerMask, asOuterMask, tprojMaskBarrel, tprojMaskDisk)
+        "#ifndef TrackletAlgorithm_TrackletCalculator_parameters_h\n"
+        "#define TrackletAlgorithm_TrackletCalculator_parameters_h\n"
+        "\n"
+        "// This file contains numbers of memories and bit masks that are specific to\n"
+        "// each TrackletCalculator and that come directly from the wiring.\n"
+        "//\n"
+        "// The specific inner all-stub memory that the indices in a given stub-pair\n"
+        "// memory correspond to is determined by ASInnerMask. The bits of this mask,\n"
+        "// from least significant to most significant, represent the stub-pair memories\n"
+        "// in the order they are passed to TrackletCalculator; e.g., the LSB\n"
+        "// corresponds to stubPairs[0]. The bit for a given stub-pair memory is the\n"
+        "// index (0 or 1) of the inner all-stub memory that should be used. Likewise,\n"
+        "// the specific outer all-stub memories are determined by ASOuterMask.\n"
+        "//\n"
+        "// The validity of each of the barrel TPROJ memories is determined by\n"
+        "// TPROJMaskBarrel. The bits of this mask, from least significant to most\n"
+        "// significant, represent the memories in the order they are passed to\n"
+        "// TrackletCalculator; e.g., the LSB corresponds to\n"
+        "// projout_barrel_ps[TC::L1PHIA]. If a bit is set, the corresponding memory is\n"
+        "// valid, if it is not, the corresponding memory is not valid. Likewise, the\n"
+        "// validity of each of the disk TPROJ memories is determined by TPROJMaskDisk\n"
+        "// in the same way.\n"
+    )
+    topHeaderFile.write(
+        "#ifndef TrackletAlgorithm_TrackletCalculatorTop_h\n"
+        "#define TrackletAlgorithm_TrackletCalculatorTop_h\n"
+        "\n"
+        "#include \"TrackletCalculator.h\"\n"
+    )
+    topFile.write(
+        "#include \"TrackletCalculatorTop.h\"\n"
+        "\n"
+        "////////////////////////////////////////////////////////////////////////////////\n"
+        "// Top functions for various TrackletCalculators (TC). For each iteration of\n"
+        "// the main processing loop, a TC retrieves a pair of stub indices from one of\n"
+        "// the stub-pair memories, and in turn, these indices are used to retrieve one\n"
+        "// stub each from an inner and an outer all-stub memory. This pair of stubs is\n"
+        "// used to calculate a rough set of helix parameters, which are written to the\n"
+        "// tracklet-parameter memory if the tracklet passes cuts on rinv and z0. Rough\n"
+        "// projections to additional layers and disks are also calculated and are\n"
+        "// written to the appropriate tracklet-projection memories.\n"
+        "////////////////////////////////////////////////////////////////////////////////\n"
     )
 
-    # Print out prototype for top function for this TC.
+    # Calculate parameters and print out parameters and top function for each TC.
+    for tcName in sorted(asInnerMems.keys()):
+        seed = re.sub(r"TC_(....).", r"\1", tcName)
+        iTC = re.sub(r"TC_....(.)", r"\1", tcName)
+
+        # numbers of memories
+        nASMemInner = len(asInnerMems[tcName])
+        nASMemOuter = len(asOuterMems[tcName])
+        nSPMem = len(spMems[tcName])
+
+        # AS inner and outer masks
+        asInnerMask = 0
+        asOuterMask = 0
+        asInnerMems[tcName].sort()
+        asOuterMems[tcName].sort()
+        for i in range(0, len(spMems[tcName])):
+            innerPart = re.sub(r".*_(..PHI.).*_(..PHI.).*", r"\1", spMems[tcName][i])
+            outerPart = re.sub(r".*_(..PHI.).*_(..PHI.).*", r"\2", spMems[tcName][i])
+            innerIndex = -1
+            outerIndex = -1
+            for j in range(0, len(asInnerMems[tcName])):
+                if innerPart in asInnerMems[tcName][j]:
+                    innerIndex = j
+                    break
+            assert innerIndex in (0, 1)
+            asInnerMask = asInnerMask | (innerIndex << i)
+            for j in range(0, len(asOuterMems[tcName])):
+                if outerPart in asOuterMems[tcName][j]:
+                    outerIndex = j
+                    break
+            assert outerIndex in (0, 1)
+            asOuterMask = asOuterMask | (outerIndex << i)
+
+        # TPROJ masks for barrel and disks
+        tprojMaskBarrel = 0
+        for projout in ProjoutIndexBarrel:
+            projoutName = "TPROJ_" + seed + iTC + "_" + projout.name
+            projoutIndex = projout.value
+            if projoutName in tprojMems[tcName]:
+                tprojMaskBarrel = tprojMaskBarrel | (1 << projoutIndex)
+        tprojMaskDisk = 0
+        for projout in ProjoutIndexDisk:
+            projoutName = "TPROJ_" + seed + iTC + "_" + projout.name
+            projoutIndex = projout.value
+            if projoutName in tprojMems[tcName]:
+                tprojMaskDisk = tprojMaskDisk | (1 << projoutIndex)
+
+        # Print out parameters for this TC.
+        parametersFile.write(
+            ("\n"
+            "// magic numbers for " + tcName + "\n"
+            "template<> constexpr uint32_t ASInnerMask<TF::" + seed + ", TC::" + iTC + ">() {\n"
+            "  return 0x%X;\n"
+            "}\n"
+            "template<> constexpr uint32_t ASOuterMask<TF::" + seed + ", TC::" + iTC + ">() {\n"
+            "  return 0x%X;\n"
+            "}\n"
+            "template<> constexpr uint32_t TPROJMaskBarrel<TF::" + seed + ", TC::" + iTC + ">() {\n"
+            "  return 0x%X;\n"
+            "}\n"
+            "template<> constexpr uint32_t TPROJMaskDisk<TF::" + seed + ", TC::" + iTC + ">() {\n"
+            "  return 0x%X;\n"
+            "}\n")
+            % (asInnerMask, asOuterMask, tprojMaskBarrel, tprojMaskDisk)
+        )
+
+        # Print out prototype for top function for this TC.
+        topHeaderFile.write(
+            "\n"
+            "void TrackletCalculator_" + seed + iTC + "(\n"
+            "    const BXType bx,\n"
+            "    const AllStubMemory<InnerRegion<TF::" + seed + ">()> innerStubs[],\n"
+            "    const AllStubMemory<OuterRegion<TF::" + seed + ">()> outerStubs[],\n"
+            "    const StubPairMemory stubPairs[],\n"
+            "    BXType& bx_o,\n"
+            "    TrackletParameterMemory * trackletParameters,\n"
+            "    TrackletProjectionMemory<BARRELPS> projout_barrel_ps[],\n"
+            "    TrackletProjectionMemory<BARREL2S> projout_barrel_2s[],\n"
+            "    TrackletProjectionMemory<DISK> projout_disk[]\n"
+            ");\n"
+        )
+
+        # Print out definition of top function for this TC.
+        topFile.write(
+            "\n"
+            "void TrackletCalculator_" + seed + iTC + "(\n"
+            "    const BXType bx,\n"
+            "    const AllStubMemory<InnerRegion<TF::" + seed + ">()> innerStubs[" + str(nASMemInner) + "],\n"
+            "    const AllStubMemory<OuterRegion<TF::" + seed + ">()> outerStubs[" + str(nASMemOuter) + "],\n"
+            "    const StubPairMemory stubPairs[" + str(nSPMem) + "],\n"
+            "    BXType& bx_o,\n"
+            "    TrackletParameterMemory * trackletParameters,\n"
+            "    TrackletProjectionMemory<BARRELPS> projout_barrel_ps[TC::N_PROJOUT_BARRELPS],\n"
+            "    TrackletProjectionMemory<BARREL2S> projout_barrel_2s[TC::N_PROJOUT_BARREL2S],\n"
+            "    TrackletProjectionMemory<DISK> projout_disk[TC::N_PROJOUT_DISK]\n"
+            ") {\n"
+            "#pragma HLS inline recursive\n"
+            "#pragma HLS array_partition variable=innerStubs complete dim=1\n"
+            "#pragma HLS array_partition variable=outerStubs complete dim=1\n"
+            "#pragma HLS array_partition variable=stubPairs complete dim=1\n"
+        )
+        for i in range(0, nASMemInner):
+            topFile.write("#pragma HLS resource variable=innerStubs[" + str(i) + "].get_mem() latency=2\n")
+        for i in range(0, nASMemOuter):
+            topFile.write("#pragma HLS resource variable=outerStubs[" + str(i) + "].get_mem() latency=2\n")
+        for i in range(0, nSPMem):
+            topFile.write("#pragma HLS resource variable=stubPairs[" + str(i) + "].get_mem() latency=2\n")
+        topFile.write(
+            "#pragma HLS interface register port=bx_o\n"
+            "#pragma HLS array_partition variable=projout_barrel_ps complete dim=1\n"
+            "#pragma HLS array_partition variable=projout_barrel_2s complete dim=1\n"
+            "#pragma HLS array_partition variable=projout_disk complete dim=1\n"
+            "\n"
+            "TC_" + seed + iTC + ": TrackletCalculator<\n"
+            "  TF::" + seed + ",\n"
+            "  TC::" + iTC + ",\n"
+            "  " + str(nSPMem) + "\n"
+            " >(\n"
+            "    bx,\n"
+            "    innerStubs,\n"
+            "    outerStubs,\n"
+            "    stubPairs,\n"
+            "    bx_o,\n"
+            "    trackletParameters,\n"
+            "    projout_barrel_ps,\n"
+            "    projout_barrel_2s,\n"
+            "    projout_disk\n"
+            "  );\n"
+            "}\n"
+        )
+
+    # Print out endifs and close files.
+    parametersFile.write(
+        "\n"
+        "#endif\n"
+    )
     topHeaderFile.write(
         "\n"
-        "void TrackletCalculator_" + seed + iTC + "(\n"
-        "    const BXType bx,\n"
-        "    const AllStubMemory<InnerRegion<TF::" + seed + ">()> innerStubs[],\n"
-        "    const AllStubMemory<OuterRegion<TF::" + seed + ">()> outerStubs[],\n"
-        "    const StubPairMemory stubPairs[],\n"
-        "    BXType& bx_o,\n"
-        "    TrackletParameterMemory * trackletParameters,\n"
-        "    TrackletProjectionMemory<BARRELPS> projout_barrel_ps[],\n"
-        "    TrackletProjectionMemory<BARREL2S> projout_barrel_2s[],\n"
-        "    TrackletProjectionMemory<DISK> projout_disk[]\n"
-        ");\n"
+        "#endif\n"
     )
-
-    # Print out definition of top function for this TC.
     topFile.write(
         "\n"
-        "void TrackletCalculator_" + seed + iTC + "(\n"
-        "    const BXType bx,\n"
-        "    const AllStubMemory<InnerRegion<TF::" + seed + ">()> innerStubs[" + str(nASMemInner) + "],\n"
-        "    const AllStubMemory<OuterRegion<TF::" + seed + ">()> outerStubs[" + str(nASMemOuter) + "],\n"
-        "    const StubPairMemory stubPairs[" + str(nSPMem) + "],\n"
-        "    BXType& bx_o,\n"
-        "    TrackletParameterMemory * trackletParameters,\n"
-        "    TrackletProjectionMemory<BARRELPS> projout_barrel_ps[TC::N_PROJOUT_BARRELPS],\n"
-        "    TrackletProjectionMemory<BARREL2S> projout_barrel_2s[TC::N_PROJOUT_BARREL2S],\n"
-        "    TrackletProjectionMemory<DISK> projout_disk[TC::N_PROJOUT_DISK]\n"
-        ") {\n"
-        "#pragma HLS inline recursive\n"
-        "#pragma HLS array_partition variable=innerStubs complete dim=1\n"
-        "#pragma HLS array_partition variable=outerStubs complete dim=1\n"
-        "#pragma HLS array_partition variable=stubPairs complete dim=1\n"
+        "////////////////////////////////////////////////////////////////////////////////\n"
     )
-    for i in range(0, nASMemInner):
-        topFile.write("#pragma HLS resource variable=innerStubs[" + str(i) + "].get_mem() latency=2\n")
-    for i in range(0, nASMemOuter):
-        topFile.write("#pragma HLS resource variable=outerStubs[" + str(i) + "].get_mem() latency=2\n")
-    for i in range(0, nSPMem):
-        topFile.write("#pragma HLS resource variable=stubPairs[" + str(i) + "].get_mem() latency=2\n")
-    topFile.write(
-        "#pragma HLS interface register port=bx_o\n"
-        "#pragma HLS array_partition variable=projout_barrel_ps complete dim=1\n"
-        "#pragma HLS array_partition variable=projout_barrel_2s complete dim=1\n"
-        "#pragma HLS array_partition variable=projout_disk complete dim=1\n"
-        "\n"
-        "TC_" + seed + iTC + ": TrackletCalculator<\n"
-        "  TF::" + seed + ",\n"
-        "  TC::" + iTC + ",\n"
-        "  " + str(nSPMem) + "\n"
-        " >(\n"
-        "    bx,\n"
-        "    innerStubs,\n"
-        "    outerStubs,\n"
-        "    stubPairs,\n"
-        "    bx_o,\n"
-        "    trackletParameters,\n"
-        "    projout_barrel_ps,\n"
-        "    projout_barrel_2s,\n"
-        "    projout_disk\n"
-        "  );\n"
-        "}\n"
-    )
-
-# Print out endifs and close files.
-parametersFile.write(
-    "\n"
-    "#endif\n"
-)
-parametersFile.close()
-topHeaderFile.write(
-    "\n"
-    "#endif\n"
-)
-topHeaderFile.close()
-topFile.write(
-    "\n"
-    "////////////////////////////////////////////////////////////////////////////////\n"
-)
-topFile.close()

--- a/emData/generate_VMR.py
+++ b/emData/generate_VMR.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ## python 2/3 inter-compatibility
 from __future__ import absolute_import, print_function

--- a/emData/generate_VMRCM.py
+++ b/emData/generate_VMRCM.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ## python 2/3 inter-compatibility
 from __future__ import absolute_import, print_function


### PR DESCRIPTION
Switch to using python3 for all of the generate scripts. Python2 is deprecated and should no longer be used. This PR also adds some deterministic sorting to the PR and IR scripts so that they return the same module order every time. The other modules are not affected by this issue as far as I can tell.

This PR was tested by comparing the scripts generated with python2 and python3. All of them matched except for the ones without a deterministic order. For those I did my best to check by hand that specific modules matched.