### PR TITLE
Update MatchEngine so the disk modules will work

### DIFF
--- a/TestBenches/MatchEngine_test.cpp
+++ b/TestBenches/MatchEngine_test.cpp
@@ -37,7 +37,7 @@ int main() {
 
 	// Declare input memory arrays to be read from the emulation files
 	VMProjectionMemory<ProjectionType<kLayerDisk>()> inputvmprojs;
-	VMStubMEMemory<ModuleType<kLayerDisk>(), NBitBin<kLayerDisk>()> inputvmstubs;
+	VMStubMEMemory<ModuleType<kLayerDisk>(), NBitMemAddr<kLayerDisk>(), NBitBin<kLayerDisk>()> inputvmstubs;
 	//CandidateMatchMemory inputcandmatches;
 
 	// Declare output memory array to be filled by hls simulation
@@ -84,7 +84,7 @@ int main() {
 		outputcandmatches.clear();
 
 		writeMemFromFile<VMProjectionMemory<ProjectionType<kLayerDisk>()> >(inputvmprojs, fin_vmproj, ievt);
-		writeMemFromFile<VMStubMEMemory<ModuleType<kLayerDisk>(), NBitBin<kLayerDisk>()> >(inputvmstubs, fin_vmstub, ievt);
+		writeMemFromFile<VMStubMEMemory<ModuleType<kLayerDisk>(), NBitMemAddr<kLayerDisk>(), NBitBin<kLayerDisk>()> >(inputvmstubs, fin_vmstub, ievt);
 
 		//Set bunch crossing
 		BXType bx=ievt&0x7;

--- a/TestBenches/VMRouter_test.cpp
+++ b/TestBenches/VMRouter_test.cpp
@@ -105,7 +105,7 @@ int main() {
 
   // Output memories
   static AllStubMemory<outputType> memoriesAS[maxASCopies];
-  static VMStubMEMemory<outputType, nbitsbin> memoriesME[nvmME];
+  static VMStubMEMemory<outputType, nbitsmemaddr, nbitsbin> memoriesME[nvmME];
   static VMStubTEInnerMemory<outputType> memoriesTEI[nvmTEI][maxTEICopies];
   static VMStubTEInnerMemory<BARRELOL> memoriesOL[nvmOL][maxOLCopies];
   static VMStubTEOuterMemory<outputType> memoriesTEO[nvmTEO][maxTEOCopies];
@@ -186,7 +186,7 @@ int main() {
 
     // ME Memories
     for (unsigned int i = 0; i < nvmME; i++) {
-      err += compareBinnedMemWithFile<VMStubMEMemory<outputType, nbitsbin>>(memoriesME[i], fout_vmstubme[i], ievt, "VMStubME" + to_string(i), truncation);
+      err += compareBinnedMemWithFile<VMStubMEMemory<outputType, nbitsmemaddr, nbitsbin>>(memoriesME[i], fout_vmstubme[i], ievt, "VMStubME" + to_string(i), truncation);
     }
 
     // TE Inner Memories

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -85,7 +85,7 @@ public:
 	}
 	else {
 #ifndef __SYNTHESIS__
-edm::LogWarning("L1trackHLS") << "Warning out of range: adress within bin " << nentry_ibx << ", stub " << data.raw() << std::endl;
+edm::LogWarning("L1trackHLS") << "Warning out of range: adress within bin " << nentry_ibx << ", stub " << data.raw() << " (" << data.raw().to_string(2) << ")" << std::endl;
 #endif
 	  return false;
 	}

--- a/TrackletAlgorithm/VMRouter.h
+++ b/TrackletAlgorithm/VMRouter.h
@@ -572,8 +572,9 @@ inline VMStubTEInner<BARRELOL> createStubTEOverlap(const InputStub<InType> stub,
 // 		According to wiring script, there's two DISK2S and half the inputs are for negative disks.
 // Layer Disk - Specifies the layer or disk number
 // MAXCopies - The maximum number of copies of a memory type
+// NBitsMemAddr number of bits used to address the stubs
 // NBitsBin number of bits used for the bins in MEMemories
-template<regionType InType, regionType OutType, int Layer, int Disk, int nInputMems, int nInputDisk2SMems, int MaxAllCopies, int MaxTEICopies, int MaxOLCopies, int MaxTEOCopies, int NBitsBin, int BendCutTableSize>
+template<regionType InType, regionType OutType, int Layer, int Disk, int nInputMems, int nInputDisk2SMems, int MaxAllCopies, int MaxTEICopies, int MaxOLCopies, int MaxTEOCopies, int NBitsMemAddr, int NBitsBin, int BendCutTableSize>
 void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int phiCorrTable[],
 		// rzbitstables, aka binlookup in emulation
 		const int rzbitsInnerTable[], const int rzbitsOverlapTable[], const int rzbitsOuterTable[],
@@ -585,7 +586,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 		// AllStub memory
 		AllStubMemory<OutType> memoriesAS[],
 		// ME memories
-		const ap_uint<maskMEsize>& maskME, VMStubMEMemory<OutType, NBitsBin> memoriesME[],
+		const ap_uint<maskMEsize>& maskME, VMStubMEMemory<OutType, NBitsMemAddr, NBitsBin> memoriesME[],
 		// Inner TE memories, non-overlap
 		const ap_uint<maskTEIsize>& maskTEI, VMStubTEInnerMemory<OutType> memoriesTEI[][MaxTEICopies],
 		// TE Inner memories, overlap

--- a/TrackletAlgorithm/VMStubMEMemory.h
+++ b/TrackletAlgorithm/VMStubMEMemory.h
@@ -73,6 +73,7 @@ public:
 
   typedef ap_uint<VMStubMEBase<VMSMEType>::kVMSMEIndexSize> VMSMEID;
   typedef ap_uint<VMStubMEBase<VMSMEType>::kVMSMEBendSize> VMSMEBEND;
+  typedef ap_uint<VMStubMEBase<VMSMEType>::kVMSMEBendSize - 1> VMSMEBENDPSDISK;
   typedef ap_uint<VMStubMEBase<VMSMEType>::kVMSMEFineZSize> VMSMEFINEZ;
   typedef ap_uint<VMStubMEBase<VMSMEType>::kVMSMEFinePhiSize> VMSMEFINEPHI;
 
@@ -110,6 +111,10 @@ public:
 
   VMSMEBEND getBend() const {
     return data_.range(kVMSMEBendMSB,kVMSMEBendLSB);
+  }
+
+  VMSMEBENDPSDISK getBendPSDisk() const {
+    return data_.range(kVMSMEBendMSB - 1,kVMSMEBendLSB);
   }
 
   VMSMEFINEPHI getFinePhi() const {
@@ -153,6 +158,6 @@ private:
 };
 
 // Memory definition
-template<int VMSMEType, int NBIT_BIN> using VMStubMEMemory = MemoryTemplateBinned<VMStubME<VMSMEType>, 3, kNBits_MemAddr, NBIT_BIN>;
+template<int VMSMEType, int NBIT_MEMADDR, int NBIT_BIN> using VMStubMEMemory = MemoryTemplateBinned<VMStubME<VMSMEType>, 3, NBIT_MEMADDR, NBIT_BIN>;
 
 #endif

--- a/emData/generate_ME.py
+++ b/emData/generate_ME.py
@@ -60,7 +60,7 @@ def writePreambles(topHeaderFile, topFile):
 def writeModuleToHeader(topHeaderFile, funcName, prefix, layerDisk):
     topHeaderFile.write(
         "void " + funcName + "(const BXType bx, BXType& bx_o,\n"
-        + prefix + "const VMStubMEMemory<ModuleType<TF::" + layerDisk + ">(), NBitBin<TF::" + layerDisk + ">()>& inputStubData,\n"
+        + prefix + "const VMStubMEMemory<ModuleType<TF::" + layerDisk + ">(), NBitMemAddr<TF::" + layerDisk + ">(), NBitBin<TF::" + layerDisk + ">()>& inputStubData,\n"
         + prefix + "const VMProjectionMemory<ProjectionType<TF::" + layerDisk + ">()>& inputProjectionData,\n"
         + prefix + "CandidateMatchMemory& outputCandidateMatch);\n\n"
     )
@@ -68,7 +68,7 @@ def writeModuleToHeader(topHeaderFile, funcName, prefix, layerDisk):
 def writeModuleToImplementation(topFile, funcName, prefix, layerDisk, label):
     topFile.write(
         "\nvoid " + funcName + "(const BXType bx, BXType& bx_o,\n"
-        + prefix + "const VMStubMEMemory<ModuleType<TF::" + layerDisk + ">(), NBitBin<TF::" + layerDisk + ">()>& inputStubData,\n"
+        + prefix + "const VMStubMEMemory<ModuleType<TF::" + layerDisk + ">(), NBitMemAddr<TF::" + layerDisk + ">(), NBitBin<TF::" + layerDisk + ">()>& inputStubData,\n"
         + prefix + "const VMProjectionMemory<ProjectionType<TF::" + layerDisk + ">()>& inputProjectionData,\n"
         + prefix + "CandidateMatchMemory& outputCandidateMatch) {\n"
         "\n"

--- a/emData/generate_VMR.py
+++ b/emData/generate_VMR.py
@@ -433,7 +433,10 @@ constexpr int bendCutTableSize = getBendCutTableSize<layerdisk, phiRegion>(); //
 	constexpr int nvmOL = kLAYER == 1 ? nvmollayers[0] : (kLAYER == 2 ? nvmollayers[1] : 1); // TE Inner Overlap memories, can't use 0 when we don't have any OL memories
 	constexpr int nvmTEO = (kLAYER != 3) ? nvmtelayers[kLAYER-1] : nvmteextralayers[2]; // TE Outer memories
 
-	// Number of bits used for the bins in VMStubeME memories
+	// Number of bits used to address the stubs
+	constexpr int nbitsmemaddr = kNBits_MemAddr;
+
+	// Number of bits used for the bins in VMStubME memories
 	constexpr int nbitsbin = 3;
 
 	// What regionType the input/output is
@@ -447,7 +450,10 @@ constexpr int bendCutTableSize = getBendCutTableSize<layerdisk, phiRegion>(); //
 	constexpr int nvmOL = 1; // TE Inner Overlap memories, can't use 0 when we don't have any OL memories
 	constexpr int nvmTEO = nvmtedisks[kDISK-1]; // TE Outer memories
 
-	// Number of bits used for the bins in VMStubeME memories
+	// Number of bits used to address the stubs
+	constexpr int nbitsmemaddr = kNBits_MemAddr + 1;
+
+	// Number of bits used for the bins in VMStubME memories
 	constexpr int nbitsbin = 4;
 
 	// What regionType the input/output is
@@ -470,7 +476,7 @@ void %s(const BXType bx, BXType& bx_o,
 #endif
 	// Output memories
 	, AllStubMemory<outputType> memoriesAS[maxASCopies]
-	, VMStubMEMemory<outputType, nbitsbin> memoriesME[nvmME]
+	, VMStubMEMemory<outputType, nbitsmemaddr, nbitsbin> memoriesME[nvmME]
 #if kLAYER == 1 || kLAYER == 2 || kLAYER == 3 || kLAYER == 5 || kDISK == 1 || kDISK == 3
 	, VMStubTEInnerMemory<outputType> memoriesTEI[nvmTEI][maxTEICopies]
 #endif
@@ -516,7 +522,7 @@ void %s(const BXType bx, BXType& bx_o,
 #endif
 	// Output memories
 	, AllStubMemory<outputType> memoriesAS[maxASCopies]
-	, VMStubMEMemory<outputType, nbitsbin> memoriesME[nvmME]
+	, VMStubMEMemory<outputType, nbitsmemaddr, nbitsbin> memoriesME[nvmME]
 #if kLAYER == 1 || kLAYER == 2 || kLAYER == 3 || kLAYER == 5 || kDISK == 1 || kDISK == 3
 	, VMStubTEInnerMemory<outputType> memoriesTEI[nvmTEI][maxTEICopies]
 #endif
@@ -588,7 +594,7 @@ void %s(const BXType bx, BXType& bx_o,
 	/////////////////////////
 	// Main function
 
-	VMRouter<inputType, outputType, kLAYER, kDISK, numInputs, numInputsDisk2S, maxASCopies, maxTEICopies, maxOLCopies, maxTEOCopies, nbitsbin, bendCutTableSize>
+	VMRouter<inputType, outputType, kLAYER, kDISK, numInputs, numInputsDisk2S, maxASCopies, maxTEICopies, maxOLCopies, maxTEOCopies, nbitsmemaddr, nbitsbin, bendCutTableSize>
 	(bx, bx_o, fineBinTable, phiCorrTable,
 		rzBitsInnerTable, rzBitsOverlapTable, rzBitsOuterTable,
 		bendCutInnerTable, bendCutOverlapTable, bendCutOuterTable,

--- a/project/script_ME.tcl
+++ b/project/script_ME.tcl
@@ -8,7 +8,17 @@ source env_hls.tcl
 
 # the set of modules to test
 set modules_to_test {
+  {ME_L1PHIC12}
+  {ME_L2PHIC20}
   {ME_L3PHIC20}
+  {ME_L4PHIC20}
+  {ME_L5PHIC20}
+  {ME_L6PHIC20}
+  {ME_D1PHIC20}
+  {ME_D2PHIC12}
+  {ME_D3PHIC12}
+  {ME_D4PHIC12}
+  {ME_D5PHIC12}
 }
 
 # module_to_export must correspond to the default macros set at the top of the


### PR DESCRIPTION
These changes allow the disk modules to be successfully run. Needed to add an isPSmodule function for the disks and make sure there are enough read addresses for the disks. Also added some debugging information that I found useful.

This PR resolves the need for #187. It turns out that we already had enough information to test if a stub came from a PS module.

I have tested that the ME now works for at least one phi sector in every layer and disk.