### PR TITLE
VMRCM Disk Debug

### DIFF
--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -38,7 +38,8 @@ class MemoryTemplateBinnedCM{
   enum BitWidths {
     kNBxBins = 1<<NBIT_BX,
     kNSlots = 1<<NBIT_BIN,
-    kNMemDepth = 1<<NBIT_ADDR
+    kNMemDepth = 1<<NBIT_ADDR,
+    kNBitsRZBinCM = NBIT_BIN-kNbitsphibin
   };
 
   DataType dataarray_[NCOPY][kNBxBins][kNMemDepth];  // data array
@@ -56,9 +57,9 @@ class MemoryTemplateBinnedCM{
   unsigned int getNCopy() const {return NCOPY;}
 
   NEntryT getEntries(BunchXingT bx, ap_uint<NBIT_BIN> slot) const {
-    ap_uint<4> ibin;
-    ap_uint<3> ireg;
-    (ibin,ireg)=slot;
+    ap_uint<kNBitsRZBinCM> ibin;
+    ap_uint<kNbitsphibin> ireg;
+    (ireg,ibin)=slot;
     return nentries8_[bx][ibin].range(ireg*4+3,ireg*4);
   }
 
@@ -120,9 +121,9 @@ class MemoryTemplateBinnedCM{
       }
 
       #ifdef CMSSW_GIT_HASH
-      ap_uint<4> ibin;
-      ap_uint<3> ireg;
-      (ibin,ireg)=slot;
+      ap_uint<kNBitsRZBinCM> ibin;
+      ap_uint<kNbitsphibin> ireg;
+      (ireg,ibin)=slot;
       nentries8_[ibx][ibin].range(ireg*4+3,ireg*4)=nentry_ibx+1;
       binmask8_[ibx][ibin].set_bit(ireg,true);
       #endif
@@ -190,9 +191,9 @@ class MemoryTemplateBinnedCM{
 
     int slot = (int)strtol(split(line, ' ').front().c_str(), nullptr, base); // Convert string (in hexadecimal) to int
 
-    ap_uint<4> ibin;
-    ap_uint<3> ireg;
-    (ibin,ireg)=slot;
+    ap_uint<kNBitsRZBinCM> ibin;
+    ap_uint<kNbitsphibin> ireg;
+    (ireg,ibin)=slot;
     ap_uint<4> nentry_ibx = nentries8_[ibx][ibin].range(ireg*4+3,ireg*4);
     
     DataType data(datastr.c_str(), base);

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -56,7 +56,8 @@ class MemoryTemplateBinnedCM{
   unsigned int getNCopy() const {return NCOPY;}
 
   NEntryT getEntries(BunchXingT bx, ap_uint<NBIT_BIN> slot) const {
-    ap_uint<3> ibin,ireg;
+    ap_uint<4> ibin;
+    ap_uint<3> ireg;
     (ibin,ireg)=slot;
     return nentries8_[bx][ibin].range(ireg*4+3,ireg*4);
   }
@@ -119,8 +120,9 @@ class MemoryTemplateBinnedCM{
       }
 
       #ifdef CMSSW_GIT_HASH
-      ap_uint<3> ibin,ireg;
-      (ireg,ibin)=slot;
+      ap_uint<4> ibin;
+      ap_uint<3> ireg;
+      (ibin,ireg)=slot;
       nentries8_[ibx][ibin].range(ireg*4+3,ireg*4)=nentry_ibx+1;
       binmask8_[ibx][ibin].set_bit(ireg,true);
       #endif
@@ -188,8 +190,9 @@ class MemoryTemplateBinnedCM{
 
     int slot = (int)strtol(split(line, ' ').front().c_str(), nullptr, base); // Convert string (in hexadecimal) to int
 
-    ap_uint<3> ibin,ireg;
-    (ireg,ibin)=slot;
+    ap_uint<4> ibin;
+    ap_uint<3> ireg;
+    (ibin,ireg)=slot;
     ap_uint<4> nentry_ibx = nentries8_[ibx][ibin].range(ireg*4+3,ireg*4);
     
     DataType data(datastr.c_str(), base);

--- a/TrackletAlgorithm/VMRouterCM.h
+++ b/TrackletAlgorithm/VMRouterCM.h
@@ -29,10 +29,8 @@
 /////////////////////////////////////////
 // Constants
 
-// Number of bits used for the VMs for different layers and disks
-// E.g. 32 VMs would use 5 vmbits
-constexpr int nbitsvmlayer[6] = { 2, 3, 3, 3, 3, 3 };
-constexpr int nbitsvmdisk[5] = { 3, 2, 2, 2, 2 };
+// Number of bits used for the TE in disks
+constexpr int nbitsvmtedisk[trklet::N_DISK] = { 3, 3, 0, 3, 0 };
 
 // Number of most significant bits (MSBs) of z and r used for index in the LUTs
 constexpr int nbitsztablelayer = 7;
@@ -113,7 +111,7 @@ inline T createVMStub(const InputStub<InType> inputStub,
 	// Number of bits for table indices
 	constexpr int nbitsztable = (Layer) ? nbitsztablelayer : nbitsztabledisk; // Number of MSBs of z used in LUT table
 	constexpr int nbitsrtable = (Layer) ? nbitsrtablelayer : nbitsrtabledisk; // Number of MSBs of r used in LUT table
-	constexpr auto vmbits = (Layer) ? nbitsvmlayer[Layer-1] : nbitsvmdisk[Disk-1]; // Number of bits for standard VMs
+	constexpr auto vmbits = (Layer) ? nbits_vmmeall[Layer-1] : ((isMEStub) ? nbits_vmmeall[trklet::N_LAYER+Disk-1] : nbitsvmtedisk[Disk-1]); // Number of bits for standard VMs
 	constexpr unsigned int nbitsall = (Layer) ? nbitsallstubs[Layer-1] : nbitsallstubs[trklet::N_LAYER+Disk-1]; // Number of bits for the number of Alltub memories in a layer/disk
 
 	// Number of bits for the memory bins


### PR DESCRIPTION
TL;DR: fixed some bugs for the VMRCM in disk as that I hadn't noticed before.

Up until now, I hadn't been able to properly check the output of the VMRCM in the disks as the testvectors contained the stubs in a different order from what the HLS VMRCM was processing them in. So even though the VMRCM disk was running fine, it was not possible to compare them to the testvectors. Managed to get some new testvectors from Anders where they were in the correct order, and could therefore finally check the output from VMRCM in the disks. Noticed a few bugs related to some bit-widths that I have fixed in this PR.

I have not updated the testvectors in this PR, I guess that'll happen sometime in the future, so if someone wants to run it themselves (without failing the simulation as it currently does, and will continue to do until we have updated the testvectors) they'll have to use the following in `download.sh`:
```
# Combined modules
memprints_url_cm="https://aryd.web.cern.ch/aryd/MemPrints_Combined_211012.tgz"
luts_url_cm="https://aryd.web.cern.ch/aryd/LUTs_Combined_211012.tgz"
```