### PR TITLE
Reduce some VHDL top-level simulation errors

### DIFF
--- a/IntegrationTests/IRVMR/hdl/SectorProcessor.vhd
+++ b/IntegrationTests/IRVMR/hdl/SectorProcessor.vhd
@@ -209,7 +209,13 @@ begin
   end generate VMSTE_22_loop;
 
 
-  VMR_start <= '1' when IR_done = '1';
+  LATCH_IR: entity work.CreateStartSignal
+    port map (
+      clk   => clk,
+      reset => reset,
+      done  => IR_done,
+      start => VMR_start
+  );
 
   IR_PS10G_3_A : entity work.IR_PS10G_3_A
     port map (

--- a/IntegrationTests/IRVMR/hdl/SectorProcessorFull.vhd
+++ b/IntegrationTests/IRVMR/hdl/SectorProcessorFull.vhd
@@ -209,7 +209,13 @@ begin
   end generate VMSTE_22_loop;
 
 
-  VMR_start <= '1' when IR_done = '1';
+  LATCH_IR: entity work.CreateStartSignal
+    port map (
+      clk   => clk,
+      reset => reset,
+      done  => IR_done,
+      start => VMR_start
+  );
 
   IR_PS10G_3_A : entity work.IR_PS10G_3_A
     port map (

--- a/IntegrationTests/IRVMR/tb/tb_tf_top.vhd
+++ b/IntegrationTests/IRVMR/tb/tb_tf_top.vhd
@@ -46,7 +46,7 @@ architecture behaviour of tb_tf_top is
 
   -- Paths of data files specified relative to Vivado project's xsim directory.
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-  constant memPrintsDir          : string := "../../../../../MemPrints/";
+  constant memPrintsDir         : string := "../../../../../MemPrints/";
   constant dataOutDir           : string := "../../../../../dataOut/";
 
   -- File directories and the start of the file names that memories have in common

--- a/IntegrationTests/IRVMR/tb/tb_tf_top.vhd
+++ b/IntegrationTests/IRVMR/tb/tb_tf_top.vhd
@@ -46,12 +46,12 @@ architecture behaviour of tb_tf_top is
 
   -- Paths of data files specified relative to Vivado project's xsim directory.
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-  constant memPrintDir          : string := "../../../../../MemPrints/";
+  constant memPrintsDir          : string := "../../../../../MemPrints/";
   constant dataOutDir           : string := "../../../../../dataOut/";
 
   -- File directories and the start of the file names that memories have in common
   -- Input files
-  constant FILE_IN_DL           : string := memPrintDir&"InputStubs/Link_DL_";
+  constant FILE_IN_DL           : string := memPrintsDir&"InputStubs/Link_DL_";
   -- Output files
   constant FILE_OUT_IL_36       : string := dataOutDir&"IL_";
   constant FILE_OUT_AS_36       : string := dataOutDir&"AS_";
@@ -149,7 +149,7 @@ begin
     variable v_line : line; -- Line for debug
   begin
 
-    if START_FIRST_LINK= '1' then
+    if START_FIRST_LINK = '1' then
       if rising_edge(CLK) then
         if (CLK_COUNT < MAX_ENTRIES) then
           CLK_COUNT := CLK_COUNT + 1;

--- a/IntegrationTests/IRVMR/tb/tb_tf_top.vhd
+++ b/IntegrationTests/IRVMR/tb/tb_tf_top.vhd
@@ -46,12 +46,12 @@ architecture behaviour of tb_tf_top is
 
   -- Paths of data files specified relative to Vivado project's xsim directory.
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-  constant emDataDir            : string := "../../../../../MemPrints/";
+  constant memPrintDir          : string := "../../../../../MemPrints/";
   constant dataOutDir           : string := "../../../../../dataOut/";
 
   -- File directories and the start of the file names that memories have in common
   -- Input files
-  constant FILE_IN_DL           : string := emDataDir&"InputStubs/Link_DL_";
+  constant FILE_IN_DL           : string := memPrintDir&"InputStubs/Link_DL_";
   -- Output files
   constant FILE_OUT_IL_36       : string := dataOutDir&"IL_";
   constant FILE_OUT_AS_36       : string := dataOutDir&"AS_";

--- a/IntegrationTests/PRMEMC/hdl/SectorProcessor.vhd
+++ b/IntegrationTests/PRMEMC/hdl/SectorProcessor.vhd
@@ -280,7 +280,13 @@ begin
   end generate FM_52_loop;
 
 
-  ME_start <= '1' when PR_done = '1';
+  LATCH_PR: entity work.CreateStartSignal
+    port map (
+      clk   => clk,
+      reset => reset,
+      done  => PR_done,
+      start => ME_start
+  );
 
   PR_L3PHIC : entity work.PR_L3PHIC
     port map (
@@ -371,7 +377,13 @@ begin
       vmprojout_7_dataarray_data_V_d0        => VMPROJ_24_mem_AV_din(L3PHIC24)
   );
 
-  MC_start <= '1' when ME_done = '1';
+  LATCH_ME: entity work.CreateStartSignal
+    port map (
+      clk   => clk,
+      reset => reset,
+      done  => ME_done,
+      start => MC_start
+  );
 
   ME_L3PHIC17 : entity work.ME_L3PHIC
     port map (

--- a/IntegrationTests/PRMEMC/hdl/SectorProcessorFull.vhd
+++ b/IntegrationTests/PRMEMC/hdl/SectorProcessorFull.vhd
@@ -280,7 +280,13 @@ begin
   end generate FM_52_loop;
 
 
-  ME_start <= '1' when PR_done = '1';
+  LATCH_PR: entity work.CreateStartSignal
+    port map (
+      clk   => clk,
+      reset => reset,
+      done  => PR_done,
+      start => ME_start
+  );
 
   PR_L3PHIC : entity work.PR_L3PHIC
     port map (
@@ -371,7 +377,13 @@ begin
       vmprojout_7_dataarray_data_V_d0        => VMPROJ_24_mem_AV_din(L3PHIC24)
   );
 
-  MC_start <= '1' when ME_done = '1';
+  LATCH_ME: entity work.CreateStartSignal
+    port map (
+      clk   => clk,
+      reset => reset,
+      done  => ME_done,
+      start => MC_start
+  );
 
   ME_L3PHIC17 : entity work.ME_L3PHIC
     port map (

--- a/IntegrationTests/PRMEMC/tb/tb_tf_top.vhd
+++ b/IntegrationTests/PRMEMC/tb/tb_tf_top.vhd
@@ -48,14 +48,14 @@ architecture behaviour of tb_tf_top is
 
   -- Paths of data files specified relative to Vivado project's xsim directory.
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-  constant memPrintDir          : string := "../../../../../MemPrints/";
+  constant memPrintsDir          : string := "../../../../../MemPrints/";
   constant dataOutDir           : string := "../../../../../dataOut/";
 
   -- File directories and the start of the file names that memories have in common
   -- Input files
-  constant FILE_IN_AS           : string := memPrintDir&"Stubs/AllStubs_AS_";
-  constant FILE_IN_VMSME        : string := memPrintDir&"VMStubsME/VMStubs_VMSME_";
-  constant FILE_IN_TPROJ        : string := memPrintDir&"TrackletProjections/TrackletProjections_TPROJ_";
+  constant FILE_IN_AS           : string := memPrintsDir&"Stubs/AllStubs_AS_";
+  constant FILE_IN_VMSME        : string := memPrintsDir&"VMStubsME/VMStubs_VMSME_";
+  constant FILE_IN_TPROJ        : string := memPrintsDir&"TrackletProjections/TrackletProjections_TPROJ_";
   -- Output files
   constant FILE_OUT_VMPROJ_24   : string := dataOutDir&"VMPROJ_";
   constant FILE_OUT_AP_60       : string := dataOutDir&"AP_";
@@ -199,7 +199,7 @@ begin
     variable v_line : line; -- Line for debug
   begin
 
-    if START_FIRST_WRITE= '1' then
+    if START_FIRST_WRITE = '1' then
       if rising_edge(CLK) then
         if (CLK_COUNT < MAX_ENTRIES) then
           CLK_COUNT := CLK_COUNT + 1;

--- a/IntegrationTests/PRMEMC/tb/tb_tf_top.vhd
+++ b/IntegrationTests/PRMEMC/tb/tb_tf_top.vhd
@@ -48,7 +48,7 @@ architecture behaviour of tb_tf_top is
 
   -- Paths of data files specified relative to Vivado project's xsim directory.
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-  constant memPrintsDir          : string := "../../../../../MemPrints/";
+  constant memPrintsDir         : string := "../../../../../MemPrints/";
   constant dataOutDir           : string := "../../../../../dataOut/";
 
   -- File directories and the start of the file names that memories have in common

--- a/IntegrationTests/PRMEMC/tb/tb_tf_top.vhd
+++ b/IntegrationTests/PRMEMC/tb/tb_tf_top.vhd
@@ -48,14 +48,14 @@ architecture behaviour of tb_tf_top is
 
   -- Paths of data files specified relative to Vivado project's xsim directory.
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-  constant emDataDir            : string := "../../../../../MemPrints/";
+  constant memPrintDir          : string := "../../../../../MemPrints/";
   constant dataOutDir           : string := "../../../../../dataOut/";
 
   -- File directories and the start of the file names that memories have in common
   -- Input files
-  constant FILE_IN_AS           : string := emDataDir&"Stubs/AllStubs_AS_";
-  constant FILE_IN_VMSME        : string := emDataDir&"VMStubsME/VMStubs_VMSME_";
-  constant FILE_IN_TPROJ        : string := emDataDir&"TrackletProjections/TrackletProjections_TPROJ_";
+  constant FILE_IN_AS           : string := memPrintDir&"Stubs/AllStubs_AS_";
+  constant FILE_IN_VMSME        : string := memPrintDir&"VMStubsME/VMStubs_VMSME_";
+  constant FILE_IN_TPROJ        : string := memPrintDir&"TrackletProjections/TrackletProjections_TPROJ_";
   -- Output files
   constant FILE_OUT_VMPROJ_24   : string := dataOutDir&"VMPROJ_";
   constant FILE_OUT_AP_60       : string := dataOutDir&"AP_";

--- a/IntegrationTests/ReducedConfig/IRtoTB/tb/tb_tf_top.vhd
+++ b/IntegrationTests/ReducedConfig/IRtoTB/tb/tb_tf_top.vhd
@@ -46,12 +46,12 @@ architecture behaviour of tb_tf_top is
 
   -- Paths of data files specified relative to Vivado project's xsim directory.
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-  constant memPrintDir          : string := "../../../../../MemPrints/";
+  constant memPrintsDir         : string := "../../../../../MemPrints/";
   constant dataOutDir           : string := "../../../../../dataOut/";
 
   -- File directories and the start of the file names that memories have in common
   -- Input files
-  constant FILE_IN_DL           : string := memPrintDir&"InputStubs/Link_DL_";
+  constant FILE_IN_DL           : string := memPrintsDir&"InputStubs/Link_DL_";
   -- Output files
   constant FILE_OUT_IL_36       : string := dataOutDir&"IL_";
   constant FILE_OUT_AS_36       : string := dataOutDir&"AS_";

--- a/IntegrationTests/ReducedConfig/IRtoTB/tb/tb_tf_top.vhd
+++ b/IntegrationTests/ReducedConfig/IRtoTB/tb/tb_tf_top.vhd
@@ -46,12 +46,12 @@ architecture behaviour of tb_tf_top is
 
   -- Paths of data files specified relative to Vivado project's xsim directory.
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-  constant emDataDir            : string := "../../../../../MemPrints/";
+  constant memPrintDir          : string := "../../../../../MemPrints/";
   constant dataOutDir           : string := "../../../../../dataOut/";
 
   -- File directories and the start of the file names that memories have in common
   -- Input files
-  constant FILE_IN_DL           : string := emDataDir&"InputStubs/Link_DL_";
+  constant FILE_IN_DL           : string := memPrintDir&"InputStubs/Link_DL_";
   -- Output files
   constant FILE_OUT_IL_36       : string := dataOutDir&"IL_";
   constant FILE_OUT_AS_36       : string := dataOutDir&"AS_";
@@ -216,7 +216,7 @@ begin
     variable v_line : line; -- Line for debug
   begin
 
-    if START_FIRST_LINK= '1' then
+    if START_FIRST_LINK = '1' then
       if rising_edge(CLK) then
         if (CLK_COUNT < MAX_ENTRIES) then
           CLK_COUNT := CLK_COUNT + 1;

--- a/IntegrationTests/TETC/hdl/SectorProcessor.vhd
+++ b/IntegrationTests/TETC/hdl/SectorProcessor.vhd
@@ -419,7 +419,13 @@ begin
       dout      => TE_L1PHIC12_L2PHIB10_bendoutertable_dout
   );
 
-  TC_start <= '1' when TE_done = '1';
+  LATCH_TE: entity work.CreateStartSignal
+    port map (
+      clk   => clk,
+      reset => reset,
+      done  => TE_done,
+      start => TC_start
+  );
 
   TE_L1PHIC12_L2PHIB10 : entity work.TE_L1L2
     port map (

--- a/IntegrationTests/TETC/hdl/SectorProcessorFull.vhd
+++ b/IntegrationTests/TETC/hdl/SectorProcessorFull.vhd
@@ -419,7 +419,13 @@ begin
       dout      => TE_L1PHIC12_L2PHIB10_bendoutertable_dout
   );
 
-  TC_start <= '1' when TE_done = '1';
+  LATCH_TE: entity work.CreateStartSignal
+    port map (
+      clk   => clk,
+      reset => reset,
+      done  => TE_done,
+      start => TC_start
+  );
 
   TE_L1PHIC12_L2PHIB10 : entity work.TE_L1L2
     port map (

--- a/IntegrationTests/TETC/tb/tb_tf_top.vhd
+++ b/IntegrationTests/TETC/tb/tb_tf_top.vhd
@@ -47,7 +47,7 @@ architecture behaviour of tb_tf_top is
 
   -- Paths of data files specified relative to Vivado project's xsim directory.
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-  constant memPrintsDir          : string := "../../../../../MemPrints/";
+  constant memPrintsDir         : string := "../../../../../MemPrints/";
   constant dataOutDir           : string := "../../../../../dataOut/";
 
   -- File directories and the start of the file names that memories have in common

--- a/IntegrationTests/TETC/tb/tb_tf_top.vhd
+++ b/IntegrationTests/TETC/tb/tb_tf_top.vhd
@@ -47,13 +47,13 @@ architecture behaviour of tb_tf_top is
 
   -- Paths of data files specified relative to Vivado project's xsim directory.
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-  constant emDataDir            : string := "../../../../../MemPrints/";
+  constant memPrintDir          : string := "../../../../../MemPrints/";
   constant dataOutDir           : string := "../../../../../dataOut/";
 
   -- File directories and the start of the file names that memories have in common
   -- Input files
-  constant FILE_IN_AS           : string := emDataDir&"Stubs/AllStubs_AS_";
-  constant FILE_IN_VMSTE        : string := emDataDir&"VMStubsTE/VMStubs_VMSTE_";
+  constant FILE_IN_AS           : string := memPrintDir&"Stubs/AllStubs_AS_";
+  constant FILE_IN_VMSTE        : string := memPrintDir&"VMStubsTE/VMStubs_VMSTE_";
   -- Output files
   constant FILE_OUT_SP_14       : string := dataOutDir&"SP_";
   constant FILE_OUT_TPROJ_60    : string := dataOutDir&"TPROJ_";

--- a/IntegrationTests/TETC/tb/tb_tf_top.vhd
+++ b/IntegrationTests/TETC/tb/tb_tf_top.vhd
@@ -47,13 +47,13 @@ architecture behaviour of tb_tf_top is
 
   -- Paths of data files specified relative to Vivado project's xsim directory.
   -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-  constant memPrintDir          : string := "../../../../../MemPrints/";
+  constant memPrintsDir          : string := "../../../../../MemPrints/";
   constant dataOutDir           : string := "../../../../../dataOut/";
 
   -- File directories and the start of the file names that memories have in common
   -- Input files
-  constant FILE_IN_AS           : string := memPrintDir&"Stubs/AllStubs_AS_";
-  constant FILE_IN_VMSTE        : string := memPrintDir&"VMStubsTE/VMStubs_VMSTE_";
+  constant FILE_IN_AS           : string := memPrintsDir&"Stubs/AllStubs_AS_";
+  constant FILE_IN_VMSTE        : string := memPrintsDir&"VMStubsTE/VMStubs_VMSTE_";
   -- Output files
   constant FILE_OUT_SP_14       : string := dataOutDir&"SP_";
   constant FILE_OUT_TPROJ_60    : string := dataOutDir&"TPROJ_";
@@ -200,7 +200,7 @@ begin
     variable v_line : line; -- Line for debug
   begin
 
-    if START_FIRST_WRITE= '1' then
+    if START_FIRST_WRITE = '1' then
       if rising_edge(CLK) then
         if (CLK_COUNT < MAX_ENTRIES) then
           CLK_COUNT := CLK_COUNT + 1;

--- a/IntegrationTests/common/script/CompareMemPrintsFW.py
+++ b/IntegrationTests/common/script/CompareMemPrintsFW.py
@@ -262,6 +262,7 @@ def comparePredefined(args):
     if args.save:
       print("Summary of memories with errors")
       print("=================================")
+      sys.stdout.flush()
       os.system('\grep "Bad events: [1-9]" dataOut/*cmp.txt')
 
     print("\n Accumulated number of errors =",ret_sum)

--- a/TrackletAlgorithm/Constants.h
+++ b/TrackletAlgorithm/Constants.h
@@ -38,7 +38,7 @@ namespace module {
 // N.B.: actual STL maps are not allowed in HLS, so this is an emulation of
 // that container as a constexpr function.
 constexpr unsigned kMaxProcOffset(const module::type m) {
-  return (m == module::VMR ? 0 :
+  return (m == module::VMR ? 1 :
          (m == module::TE ? 0 :
          (m == module::TC ? 0 :
          (m == module::PR ? 0 :

--- a/TrackletAlgorithm/MatchEngine.h
+++ b/TrackletAlgorithm/MatchEngine.h
@@ -301,6 +301,9 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 			  istub = 0;
 			  tail_readindex++;
 			}
+			else if(istep == kMaxProc - kMaxProcOffset(module::ME) - 1){ // The last loop iteration
+				istub = 0; // Reset stub index for next bx, needed for VHDL top-level Vivado simulation
+			}
 			else {
 			  istub++;
 			}

--- a/TrackletAlgorithm/MatchEngine.h
+++ b/TrackletAlgorithm/MatchEngine.h
@@ -301,8 +301,8 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 			  istub = 0;
 			  tail_readindex++;
 			}
-			else if(istep == kMaxProc - kMaxProcOffset(module::ME) - 1){ // The last loop iteration
-				istub = 0; // Reset stub index for next bx, needed for VHDL top-level Vivado simulation
+			else if (istep == kMaxProc - kMaxProcOffset(module::ME) - 1) { // The last loop iteration
+				istub = 0; // Reset stub index for next bx. Needed for VHDL top-level Vivado simulation
 			}
 			else {
 			  istub++;


### PR DESCRIPTION
Addresses some of the problems with resetting read/write addresses when running modules with the VHDL top-level in Vivado simulation (i.e. not Vivado HLS) mentioned in issue https://github.com/cms-L1TK/firmware-hls/issues/188. 

- Reduces errors in PRMEMC chain from 3 to 1. 

- Reduces errors in e.g. VMR_L2PHIC (not tested by default in CI). The remaining errors are due to missing stubs due to sacrificing the first loop iteration to clear the write address counters. Will do a PR to the emulation to include this change in the number of stubs the VMR can process.

- Updated SectorProcessor*.vhd & tb_tf_top.vhd using latest version of scripts for IR-TB & PR-ME-MC chains