### PR TITLE
Added constants needed by future SW to Constants.h

### DIFF
--- a/TrackletAlgorithm/Constants.h
+++ b/TrackletAlgorithm/Constants.h
@@ -156,4 +156,9 @@ typedef ap_uint<kNBits_BX> BXType;  // temporary definition. need to be revisite
 constexpr unsigned kBRAMwidth = 36; 
 constexpr int kNBits_DTC = 39; 
 
+//Future SW constants
+constexpr int nRegionsL1 = 8;
+constexpr int nRegions = 4;
+constexpr int nBarrelPS = 3;
+
 #endif

--- a/TrackletAlgorithm/Constants.h
+++ b/TrackletAlgorithm/Constants.h
@@ -157,8 +157,6 @@ constexpr unsigned kBRAMwidth = 36;
 constexpr int kNBits_DTC = 39; 
 
 //Future SW constants
-constexpr int nRegionsL1 = 8;
-constexpr int nRegions = 4;
 constexpr int nBarrelPS = 3;
 
 #endif


### PR DESCRIPTION
Added three constants to TrackletAlgorithm/Constants.h

constexpr int nRegionsL1 = 8; number of regions in L1
constexpr int nRegions = 4; number of regions in other layers
constexpr int nBarrelPS = 3; number of barrel PS layers

These constants are needed to avoid hard coding template arguments in both the firmware_hls and the future SW