### PR TITLE
Barrel-only TBs

### DIFF
--- a/TestBenches/TrackBuilder_test.cpp
+++ b/TestBenches/TrackBuilder_test.cpp
@@ -1,15 +1,8 @@
 // Test bench for TrackBuilder
 #include "TrackBuilderTop.h"
 
-#include <vector>
-#include <algorithm>
-#include <iterator>
-#include <cstring>
-#include <sstream>
-
 #include "Macros.h"
 #include "FileReadUtility.h"
-#include "Constants.h"
 
 const int nevents = 100;  //number of events to run
 

--- a/TestBenches/TrackBuilder_test.cpp
+++ b/TestBenches/TrackBuilder_test.cpp
@@ -76,7 +76,7 @@ void compareStubsWithFile<0>(int &err, ifstream &fout, const int pos, const Trac
 
 int main()
 {
-  TBHelper tb(std::string("FT/") + module_name[MODULE_]);
+  TBHelper tb(string("FT/") + module_name[MODULE_]);
 
   // error counts
   int err = 0;
@@ -85,9 +85,8 @@ int main()
   // open input files
   cout << "Open files..." << endl;
 
-  const string seed_name = string(module_name[MODULE_]).substr(3);
-  const string barrelFM_query = string("FullMatches_FM_") + string(seed_name) + string("_L*");
-  const string diskFM_query = string("FullMatches_FM_") + string(seed_name) + string("_D*");
+  const string barrelFM_query = "FullMatches_FM_*_L*";
+  const string diskFM_query = "FullMatches_FM_*_D*";
 
   auto &fin_tpar = tb.files("TrackletParameters*");
   auto &fin_barrelFM = tb.files(barrelFM_query);

--- a/TestBenches/TrackBuilder_test.cpp
+++ b/TestBenches/TrackBuilder_test.cpp
@@ -39,6 +39,12 @@ using namespace std;
 typedef TrackFit<kNBarrelStubs, kNDiskStubs> TrackFit_t;
 typedef TrackFitMemory<kNBarrelStubs, kNDiskStubs> TrackFitMemory_t;
 
+// Base assumed for input test vector files
+constexpr int InputBase = 16;
+// Base used for output of comparison results
+//   (only base 2 and base 16 are supported)
+constexpr int OutputBase = 16;
+
 template<int I>
 void setBarrelStubs(TrackFit_t &track, const TrackFit_t::BarrelStubWord stubWords[][kMaxProc], const unsigned i) {
   track.setBarrelStubWord<I>(stubWords[I][i]);
@@ -64,14 +70,14 @@ void compareStubsWithFile(int &err, ifstream &fout, const int pos, const TrackFi
   fout.clear(), fout.seekg(pos);
   stringstream ss("");
   ss << "\nStub " << (I) << " word";
-  err += compareMemWithFile<TrackFitMemory_t,16,16,TrackFit_t::kTFStubRZResidLSB(I),TrackFit_t::kTFStubValidMSB(I)>(tracksMem, fout, ievt, ss.str(), true);
+  err += compareMemWithFile<TrackFitMemory_t,InputBase,OutputBase,TrackFit_t::kTFStubRZResidLSB(I),TrackFit_t::kTFStubValidMSB(I)>(tracksMem, fout, ievt, ss.str(), true);
   compareStubsWithFile<I - 1>(err, fout, pos, tracksMem, ievt);
 }
 
 template<>
 void compareStubsWithFile<0>(int &err, ifstream &fout, const int pos, const TrackFitMemory_t &tracksMem, const unsigned ievt) {
   fout.clear(), fout.seekg(pos);
-  err += compareMemWithFile<TrackFitMemory_t,16,16,TrackFit_t::kTFStubRZResidLSB(0),TrackFit_t::kTFStubValidMSB(0)>(tracksMem, fout, ievt, "\nStub 0 word", true);
+  err += compareMemWithFile<TrackFitMemory_t,InputBase,OutputBase,TrackFit_t::kTFStubRZResidLSB(0),TrackFit_t::kTFStubValidMSB(0)>(tracksMem, fout, ievt, "\nStub 0 word", true);
 }
 
 int main()
@@ -107,8 +113,8 @@ int main()
 
   // output memories
   TrackFit_t::TrackWord trackWord[kMaxProc];
-  TrackFit_t::BarrelStubWord barrelStubWords[4][kMaxProc];
-  TrackFit_t::DiskStubWord diskStubWords[4][kMaxProc];
+  TrackFit_t::BarrelStubWord barrelStubWords[kNBarrelStubs][kMaxProc];
+  TrackFit_t::DiskStubWord diskStubWords[kNDiskStubs][kMaxProc];
   TrackFitMemory_t tracksMem;
 
   ///////////////////////////
@@ -120,10 +126,10 @@ int main()
     // Clear all output memories before starting.
     for (unsigned short i = 0; i < kMaxProc; i++) {
       trackWord[i] = TrackFit_t::TrackWord(0);
-      for (unsigned short j = 0; j < 4; j++) {
+      for (unsigned short j = 0; j < kNBarrelStubs; j++)
         barrelStubWords[j][i] = TrackFit_t::BarrelStubWord(0);
+      for (unsigned short j = 0; j < kNDiskStubs; j++)
         diskStubWords[j][i] = TrackFit_t::DiskStubWord(0);
-      }
     }
     tracksMem.clear();
 
@@ -163,7 +169,7 @@ int main()
     const auto &pos = fout_tracks.at(0).tellg();
 
     // compare the computed outputs with the expected ones
-    err += compareMemWithFile<TrackFitMemory_t,16,16,TrackFit_t::kTFHitMapLSB,TrackFit_t::kTFTrackValidMSB>(tracksMem, fout_tracks.at(0), ievt, "\nTrack word", true);
+    err += compareMemWithFile<TrackFitMemory_t,InputBase,OutputBase,TrackFit_t::kTFHitMapLSB,TrackFit_t::kTFTrackValidMSB>(tracksMem, fout_tracks.at(0), ievt, "\nTrack word", true);
     compareStubsWithFile<kNBarrelStubs + kNDiskStubs - 1>(err, fout_tracks.at(0), pos, tracksMem, ievt);
     cout << endl;
 

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -165,14 +165,23 @@ void TrackBuilder(
       nMatches += (barrel_stub_valid ? 1 : 0);
 
       static_assert(NFMPerLayer <= 8, "Number of FM memories per layer cannot exceed eight.");
-      const auto &barrel_stub = ((NFMPerLayer > 7 && barrel_valid[j * NFMPerLayer + 7]) ? barrel_fm[j * NFMPerLayer + 7][barrel_read_index[j * NFMPerLayer + 7]] :
-                                ((NFMPerLayer > 6 && barrel_valid[j * NFMPerLayer + 6]) ? barrel_fm[j * NFMPerLayer + 6][barrel_read_index[j * NFMPerLayer + 6]] :
-                                ((NFMPerLayer > 5 && barrel_valid[j * NFMPerLayer + 5]) ? barrel_fm[j * NFMPerLayer + 5][barrel_read_index[j * NFMPerLayer + 5]] :
-                                ((NFMPerLayer > 4 && barrel_valid[j * NFMPerLayer + 4]) ? barrel_fm[j * NFMPerLayer + 4][barrel_read_index[j * NFMPerLayer + 4]] :
-                                ((NFMPerLayer > 3 && barrel_valid[j * NFMPerLayer + 3]) ? barrel_fm[j * NFMPerLayer + 3][barrel_read_index[j * NFMPerLayer + 3]] :
-                                ((NFMPerLayer > 2 && barrel_valid[j * NFMPerLayer + 2]) ? barrel_fm[j * NFMPerLayer + 2][barrel_read_index[j * NFMPerLayer + 2]] :
-                                ((NFMPerLayer > 1 && barrel_valid[j * NFMPerLayer + 1]) ? barrel_fm[j * NFMPerLayer + 1][barrel_read_index[j * NFMPerLayer + 1]] :
-                                                                                          barrel_fm[j * NFMPerLayer][barrel_read_index[j * NFMPerLayer]])))))));
+      const auto &i_mem = ((NFMPerLayer > 7 && barrel_valid[j * NFMPerLayer + 7]) ? (j * NFMPerLayer + 7) :
+                          ((NFMPerLayer > 6 && barrel_valid[j * NFMPerLayer + 6]) ? (j * NFMPerLayer + 6) :
+                          ((NFMPerLayer > 5 && barrel_valid[j * NFMPerLayer + 5]) ? (j * NFMPerLayer + 5) :
+                          ((NFMPerLayer > 4 && barrel_valid[j * NFMPerLayer + 4]) ? (j * NFMPerLayer + 4) :
+                          ((NFMPerLayer > 3 && barrel_valid[j * NFMPerLayer + 3]) ? (j * NFMPerLayer + 3) :
+                          ((NFMPerLayer > 2 && barrel_valid[j * NFMPerLayer + 2]) ? (j * NFMPerLayer + 2) :
+                          ((NFMPerLayer > 1 && barrel_valid[j * NFMPerLayer + 1]) ? (j * NFMPerLayer + 1) :
+                                                                                    (j * NFMPerLayer))))))));
+      const auto &i_fm = ((NFMPerLayer > 7 && barrel_valid[j * NFMPerLayer + 7]) ? (barrel_read_index[j * NFMPerLayer + 7]) :
+                         ((NFMPerLayer > 6 && barrel_valid[j * NFMPerLayer + 6]) ? (barrel_read_index[j * NFMPerLayer + 6]) :
+                         ((NFMPerLayer > 5 && barrel_valid[j * NFMPerLayer + 5]) ? (barrel_read_index[j * NFMPerLayer + 5]) :
+                         ((NFMPerLayer > 4 && barrel_valid[j * NFMPerLayer + 4]) ? (barrel_read_index[j * NFMPerLayer + 4]) :
+                         ((NFMPerLayer > 3 && barrel_valid[j * NFMPerLayer + 3]) ? (barrel_read_index[j * NFMPerLayer + 3]) :
+                         ((NFMPerLayer > 2 && barrel_valid[j * NFMPerLayer + 2]) ? (barrel_read_index[j * NFMPerLayer + 2]) :
+                         ((NFMPerLayer > 1 && barrel_valid[j * NFMPerLayer + 1]) ? (barrel_read_index[j * NFMPerLayer + 1]) :
+                                                                                   (barrel_read_index[j * NFMPerLayer]))))))));
+      const auto &barrel_stub = barrel_fm[i_mem][i_fm];
 
       const auto &barrel_stub_index = (barrel_stub_valid ? barrel_stub.getStubIndex() : FullMatch<BARREL>::FMSTUBINDEX(0));
       const auto &barrel_stub_r = (barrel_stub_valid ? barrel_stub.getStubR() : FullMatch<BARREL>::FMSTUBR(0));
@@ -223,14 +232,23 @@ void TrackBuilder(
       nMatches += (disk_stub_valid ? 1 : 0);
 
       static_assert(NFMPerDisk <= 6, "Number of FM memories per disk cannot exceed six.");
-      const auto &disk_stub = ((NFMPerDisk > 7 && disk_valid[j * NFMPerDisk + 7]) ? disk_fm[j * NFMPerDisk + 7][disk_read_index[j * NFMPerDisk + 7]] :
-                              ((NFMPerDisk > 6 && disk_valid[j * NFMPerDisk + 6]) ? disk_fm[j * NFMPerDisk + 6][disk_read_index[j * NFMPerDisk + 6]] :
-                              ((NFMPerDisk > 5 && disk_valid[j * NFMPerDisk + 5]) ? disk_fm[j * NFMPerDisk + 5][disk_read_index[j * NFMPerDisk + 5]] :
-                              ((NFMPerDisk > 4 && disk_valid[j * NFMPerDisk + 4]) ? disk_fm[j * NFMPerDisk + 4][disk_read_index[j * NFMPerDisk + 4]] :
-                              ((NFMPerDisk > 3 && disk_valid[j * NFMPerDisk + 3]) ? disk_fm[j * NFMPerDisk + 3][disk_read_index[j * NFMPerDisk + 3]] :
-                              ((NFMPerDisk > 2 && disk_valid[j * NFMPerDisk + 2]) ? disk_fm[j * NFMPerDisk + 2][disk_read_index[j * NFMPerDisk + 2]] :
-                              ((NFMPerDisk > 1 && disk_valid[j * NFMPerDisk + 1]) ? disk_fm[j * NFMPerDisk + 1][disk_read_index[j * NFMPerDisk + 1]] :
-                                                                                    disk_fm[j * NFMPerDisk][disk_read_index[j * NFMPerDisk]])))))));
+      const auto &i_mem = ((NFMPerDisk > 7 && disk_valid[j * NFMPerDisk + 7]) ? (j * NFMPerDisk + 7) :
+                          ((NFMPerDisk > 6 && disk_valid[j * NFMPerDisk + 6]) ? (j * NFMPerDisk + 6) :
+                          ((NFMPerDisk > 5 && disk_valid[j * NFMPerDisk + 5]) ? (j * NFMPerDisk + 5) :
+                          ((NFMPerDisk > 4 && disk_valid[j * NFMPerDisk + 4]) ? (j * NFMPerDisk + 4) :
+                          ((NFMPerDisk > 3 && disk_valid[j * NFMPerDisk + 3]) ? (j * NFMPerDisk + 3) :
+                          ((NFMPerDisk > 2 && disk_valid[j * NFMPerDisk + 2]) ? (j * NFMPerDisk + 2) :
+                          ((NFMPerDisk > 1 && disk_valid[j * NFMPerDisk + 1]) ? (j * NFMPerDisk + 1) :
+                                                                                (j * NFMPerDisk))))))));
+      const auto &i_fm = ((NFMPerDisk > 7 && disk_valid[j * NFMPerDisk + 7]) ? (disk_read_index[j * NFMPerDisk + 7]) :
+                         ((NFMPerDisk > 6 && disk_valid[j * NFMPerDisk + 6]) ? (disk_read_index[j * NFMPerDisk + 6]) :
+                         ((NFMPerDisk > 5 && disk_valid[j * NFMPerDisk + 5]) ? (disk_read_index[j * NFMPerDisk + 5]) :
+                         ((NFMPerDisk > 4 && disk_valid[j * NFMPerDisk + 4]) ? (disk_read_index[j * NFMPerDisk + 4]) :
+                         ((NFMPerDisk > 3 && disk_valid[j * NFMPerDisk + 3]) ? (disk_read_index[j * NFMPerDisk + 3]) :
+                         ((NFMPerDisk > 2 && disk_valid[j * NFMPerDisk + 2]) ? (disk_read_index[j * NFMPerDisk + 2]) :
+                         ((NFMPerDisk > 1 && disk_valid[j * NFMPerDisk + 1]) ? (disk_read_index[j * NFMPerDisk + 1]) :
+                                                                               (disk_read_index[j * NFMPerDisk]))))))));
+      const auto &disk_stub = disk_fm[i_mem][i_fm];
 
       const auto &disk_stub_index = (disk_stub_valid ? disk_stub.getStubIndex() : FullMatch<DISK>::FMSTUBINDEX(0));
       const auto &disk_stub_r = (disk_stub_valid ? disk_stub.getStubR() : FullMatch<DISK>::FMSTUBR(0));

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -62,6 +62,12 @@ void TrackBuilder(
   ap_uint<kNBitsTBBuffer> disk_read_index[NFMDisk];
   ap_uint<kNBitsTBBuffer> barrel_write_index[NFMBarrel];
   ap_uint<kNBitsTBBuffer> disk_write_index[NFMDisk];
+#pragma HLS array_partition variable=barrel_mem_index complete dim=0
+#pragma HLS array_partition variable=disk_mem_index complete dim=0
+#pragma HLS array_partition variable=barrel_read_index complete dim=0
+#pragma HLS array_partition variable=disk_read_index complete dim=0
+#pragma HLS array_partition variable=barrel_write_index complete dim=0
+#pragma HLS array_partition variable=disk_write_index complete dim=0
 
   initialize_barrel_indices : for (short i = 0; i < NFMBarrel; i++) {
 #pragma HLS unroll

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -32,7 +32,6 @@ getFM(const BXType bx, const FullMatchMemory<RegionType> &fullMatches, const uns
 }
 
 // TrackBuilder top template function
-// !!! CURRENTLY ONLY TESTED FOR L1L2 !!!
 template<unsigned Seed, unsigned NFMBarrel, unsigned NFMDisk, unsigned NBarrelStubs, unsigned NDiskStubs, unsigned TPAROffset>
 void TrackBuilder(
     const BXType bx,

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -33,7 +33,7 @@ getFM(const BXType bx, const FullMatchMemory<RegionType> &fullMatches, const uns
 
 // TrackBuilder top template function
 // !!! CURRENTLY ONLY TESTED FOR L1L2 !!!
-template<unsigned NFMBarrel, unsigned NFMDisk, unsigned NBarrelStubs, unsigned NDiskStubs, unsigned TPAROffset>
+template<unsigned Seed, unsigned NFMBarrel, unsigned NFMDisk, unsigned NBarrelStubs, unsigned NDiskStubs, unsigned TPAROffset>
 void TrackBuilder(
     const BXType bx,
     const TrackletParameterMemory trackletParameters[],
@@ -45,9 +45,6 @@ void TrackBuilder(
     typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord diskStubWords[][kMaxProc]
 )
 {
-
-  constexpr unsigned NFMPerLayer = (NBarrelStubs > 0) ? (NFMBarrel / NBarrelStubs) : 0;
-  constexpr unsigned NFMPerDisk = (NDiskStubs > 0) ? (NFMDisk / NDiskStubs) : 0;
 
   // Circular buffers for each of the input full-match memories.
   FullMatch<BARREL> barrel_fm[NFMBarrel][1<<kNBitsTBBuffer];
@@ -143,7 +140,7 @@ void TrackBuilder(
 
     // Initialize a TrackFit object using the tracklet parameters associated
     // with the minimum tracklet ID.
-    const TCIDType &TCID = (min_id != kInvalidTrackletID) ? (min_id >> kNBits_MemAddr) : TrackletIDType(0);
+    const TCIDType &TCID = (min_id != kInvalidTrackletID) ? (min_id >> kNBits_MemAddr) : TrackletIDType(TPAROffset);
     TrackFit<NBarrelStubs, NDiskStubs> track(typename TrackFit<NBarrelStubs, NDiskStubs>::TFSEEDTYPE(TCID >> kNBitsITC));
     const IndexType &trackletIndex = (min_id != kInvalidTrackletID) ? (min_id & TrackletIDType(0x7F)) : TrackletIDType(0);
     const auto &tpar = trackletParameters[TCID - TPAROffset].read_mem(bx, trackletIndex);
@@ -157,30 +154,33 @@ void TrackBuilder(
     // object.
     ap_uint<3> nMatches = 0; // there can be up to eight matches (3 bits)
 
+    unsigned nFMCumulative = 0;
     barrel_stub_association : for (short j = 0; j < NBarrelStubs; j++) {
 
+      const unsigned nFM = ((Seed == TF::L2L3 || Seed == TF::L3L4 || Seed == TF::L5L6) && j == 0 ? 8 : 4);
+
       ap_uint<1> barrel_stub_valid = false;
-      barrel_stub_valid : for (short k = 0; k < NFMPerLayer; k++)
-        barrel_stub_valid = (barrel_stub_valid || barrel_valid[j * NFMPerLayer + k]);
+      barrel_stub_valid : for (short k = 0; k < nFM; k++)
+        barrel_stub_valid = (barrel_stub_valid || barrel_valid[nFMCumulative + k]);
       nMatches += (barrel_stub_valid ? 1 : 0);
 
-      static_assert(NFMPerLayer <= 8, "Number of FM memories per layer cannot exceed eight.");
-      const auto &i_mem = ((NFMPerLayer > 7 && barrel_valid[j * NFMPerLayer + 7]) ? (j * NFMPerLayer + 7) :
-                          ((NFMPerLayer > 6 && barrel_valid[j * NFMPerLayer + 6]) ? (j * NFMPerLayer + 6) :
-                          ((NFMPerLayer > 5 && barrel_valid[j * NFMPerLayer + 5]) ? (j * NFMPerLayer + 5) :
-                          ((NFMPerLayer > 4 && barrel_valid[j * NFMPerLayer + 4]) ? (j * NFMPerLayer + 4) :
-                          ((NFMPerLayer > 3 && barrel_valid[j * NFMPerLayer + 3]) ? (j * NFMPerLayer + 3) :
-                          ((NFMPerLayer > 2 && barrel_valid[j * NFMPerLayer + 2]) ? (j * NFMPerLayer + 2) :
-                          ((NFMPerLayer > 1 && barrel_valid[j * NFMPerLayer + 1]) ? (j * NFMPerLayer + 1) :
-                                                                                    (j * NFMPerLayer))))))));
-      const auto &i_fm = ((NFMPerLayer > 7 && barrel_valid[j * NFMPerLayer + 7]) ? (barrel_read_index[j * NFMPerLayer + 7]) :
-                         ((NFMPerLayer > 6 && barrel_valid[j * NFMPerLayer + 6]) ? (barrel_read_index[j * NFMPerLayer + 6]) :
-                         ((NFMPerLayer > 5 && barrel_valid[j * NFMPerLayer + 5]) ? (barrel_read_index[j * NFMPerLayer + 5]) :
-                         ((NFMPerLayer > 4 && barrel_valid[j * NFMPerLayer + 4]) ? (barrel_read_index[j * NFMPerLayer + 4]) :
-                         ((NFMPerLayer > 3 && barrel_valid[j * NFMPerLayer + 3]) ? (barrel_read_index[j * NFMPerLayer + 3]) :
-                         ((NFMPerLayer > 2 && barrel_valid[j * NFMPerLayer + 2]) ? (barrel_read_index[j * NFMPerLayer + 2]) :
-                         ((NFMPerLayer > 1 && barrel_valid[j * NFMPerLayer + 1]) ? (barrel_read_index[j * NFMPerLayer + 1]) :
-                                                                                   (barrel_read_index[j * NFMPerLayer]))))))));
+      const auto &i_mem = ((nFM > 7 && barrel_valid[nFMCumulative + 7]) ? (nFMCumulative + 7) :
+                          ((nFM > 6 && barrel_valid[nFMCumulative + 6]) ? (nFMCumulative + 6) :
+                          ((nFM > 5 && barrel_valid[nFMCumulative + 5]) ? (nFMCumulative + 5) :
+                          ((nFM > 4 && barrel_valid[nFMCumulative + 4]) ? (nFMCumulative + 4) :
+                          ((nFM > 3 && barrel_valid[nFMCumulative + 3]) ? (nFMCumulative + 3) :
+                          ((nFM > 2 && barrel_valid[nFMCumulative + 2]) ? (nFMCumulative + 2) :
+                          ((nFM > 1 && barrel_valid[nFMCumulative + 1]) ? (nFMCumulative + 1) :
+                                                                          (nFMCumulative))))))));
+      const auto &i_fm = ((nFM > 7 && barrel_valid[nFMCumulative + 7]) ? (barrel_read_index[nFMCumulative + 7]) :
+                         ((nFM > 6 && barrel_valid[nFMCumulative + 6]) ? (barrel_read_index[nFMCumulative + 6]) :
+                         ((nFM > 5 && barrel_valid[nFMCumulative + 5]) ? (barrel_read_index[nFMCumulative + 5]) :
+                         ((nFM > 4 && barrel_valid[nFMCumulative + 4]) ? (barrel_read_index[nFMCumulative + 4]) :
+                         ((nFM > 3 && barrel_valid[nFMCumulative + 3]) ? (barrel_read_index[nFMCumulative + 3]) :
+                         ((nFM > 2 && barrel_valid[nFMCumulative + 2]) ? (barrel_read_index[nFMCumulative + 2]) :
+                         ((nFM > 1 && barrel_valid[nFMCumulative + 1]) ? (barrel_read_index[nFMCumulative + 1]) :
+                                                                         (barrel_read_index[nFMCumulative]))))))));
+      nFMCumulative += nFM;
       const auto &barrel_stub = barrel_fm[i_mem][i_fm];
 
       const auto &barrel_stub_index = (barrel_stub_valid ? barrel_stub.getStubIndex() : FullMatch<BARREL>::FMSTUBINDEX(0));
@@ -226,28 +226,29 @@ void TrackBuilder(
 
     disk_stub_association : for (short j = 0; j < NDiskStubs; j++) {
 
+      const unsigned nFM = 4;
+
       ap_uint<1> disk_stub_valid = false;
-      disk_stub_valid : for (short k = 0; k < NFMPerDisk; k++)
-        disk_stub_valid = (disk_stub_valid || disk_valid[j * NFMPerDisk + k]);
+      disk_stub_valid : for (short k = 0; k < nFM; k++)
+        disk_stub_valid = (disk_stub_valid || disk_valid[j * nFM + k]);
       nMatches += (disk_stub_valid ? 1 : 0);
 
-      static_assert(NFMPerDisk <= 6, "Number of FM memories per disk cannot exceed six.");
-      const auto &i_mem = ((NFMPerDisk > 7 && disk_valid[j * NFMPerDisk + 7]) ? (j * NFMPerDisk + 7) :
-                          ((NFMPerDisk > 6 && disk_valid[j * NFMPerDisk + 6]) ? (j * NFMPerDisk + 6) :
-                          ((NFMPerDisk > 5 && disk_valid[j * NFMPerDisk + 5]) ? (j * NFMPerDisk + 5) :
-                          ((NFMPerDisk > 4 && disk_valid[j * NFMPerDisk + 4]) ? (j * NFMPerDisk + 4) :
-                          ((NFMPerDisk > 3 && disk_valid[j * NFMPerDisk + 3]) ? (j * NFMPerDisk + 3) :
-                          ((NFMPerDisk > 2 && disk_valid[j * NFMPerDisk + 2]) ? (j * NFMPerDisk + 2) :
-                          ((NFMPerDisk > 1 && disk_valid[j * NFMPerDisk + 1]) ? (j * NFMPerDisk + 1) :
-                                                                                (j * NFMPerDisk))))))));
-      const auto &i_fm = ((NFMPerDisk > 7 && disk_valid[j * NFMPerDisk + 7]) ? (disk_read_index[j * NFMPerDisk + 7]) :
-                         ((NFMPerDisk > 6 && disk_valid[j * NFMPerDisk + 6]) ? (disk_read_index[j * NFMPerDisk + 6]) :
-                         ((NFMPerDisk > 5 && disk_valid[j * NFMPerDisk + 5]) ? (disk_read_index[j * NFMPerDisk + 5]) :
-                         ((NFMPerDisk > 4 && disk_valid[j * NFMPerDisk + 4]) ? (disk_read_index[j * NFMPerDisk + 4]) :
-                         ((NFMPerDisk > 3 && disk_valid[j * NFMPerDisk + 3]) ? (disk_read_index[j * NFMPerDisk + 3]) :
-                         ((NFMPerDisk > 2 && disk_valid[j * NFMPerDisk + 2]) ? (disk_read_index[j * NFMPerDisk + 2]) :
-                         ((NFMPerDisk > 1 && disk_valid[j * NFMPerDisk + 1]) ? (disk_read_index[j * NFMPerDisk + 1]) :
-                                                                               (disk_read_index[j * NFMPerDisk]))))))));
+      const auto &i_mem = ((nFM > 7 && disk_valid[j * nFM + 7]) ? (j * nFM + 7) :
+                          ((nFM > 6 && disk_valid[j * nFM + 6]) ? (j * nFM + 6) :
+                          ((nFM > 5 && disk_valid[j * nFM + 5]) ? (j * nFM + 5) :
+                          ((nFM > 4 && disk_valid[j * nFM + 4]) ? (j * nFM + 4) :
+                          ((nFM > 3 && disk_valid[j * nFM + 3]) ? (j * nFM + 3) :
+                          ((nFM > 2 && disk_valid[j * nFM + 2]) ? (j * nFM + 2) :
+                          ((nFM > 1 && disk_valid[j * nFM + 1]) ? (j * nFM + 1) :
+                                                                  (j * nFM))))))));
+      const auto &i_fm = ((nFM > 7 && disk_valid[j * nFM + 7]) ? (disk_read_index[j * nFM + 7]) :
+                         ((nFM > 6 && disk_valid[j * nFM + 6]) ? (disk_read_index[j * nFM + 6]) :
+                         ((nFM > 5 && disk_valid[j * nFM + 5]) ? (disk_read_index[j * nFM + 5]) :
+                         ((nFM > 4 && disk_valid[j * nFM + 4]) ? (disk_read_index[j * nFM + 4]) :
+                         ((nFM > 3 && disk_valid[j * nFM + 3]) ? (disk_read_index[j * nFM + 3]) :
+                         ((nFM > 2 && disk_valid[j * nFM + 2]) ? (disk_read_index[j * nFM + 2]) :
+                         ((nFM > 1 && disk_valid[j * nFM + 1]) ? (disk_read_index[j * nFM + 1]) :
+                                                                 (disk_read_index[j * nFM]))))))));
       const auto &disk_stub = disk_fm[i_mem][i_fm];
 
       const auto &disk_stub_index = (disk_stub_valid ? disk_stub.getStubIndex() : FullMatch<DISK>::FMSTUBINDEX(0));
@@ -317,16 +318,16 @@ void TrackBuilder(
       disk_stub_words: for (short j = 0 ; j < NDiskStubs; j++) {
         switch (j) {
           case 0:
-            diskStubWords[j][nTracks] = track.template getStubValid<4>() ? track.template getDiskStubWord<4>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
             break;
           case 1:
-            diskStubWords[j][nTracks] = track.template getStubValid<5>() ? track.template getDiskStubWord<5>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 1>() ? track.template getDiskStubWord<NBarrelStubs + 1>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
             break;
           case 2:
-            diskStubWords[j][nTracks] = track.template getStubValid<6>() ? track.template getDiskStubWord<6>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 2>() ? track.template getDiskStubWord<NBarrelStubs + 2>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
             break;
           case 3:
-            diskStubWords[j][nTracks] = track.template getStubValid<7>() ? track.template getDiskStubWord<7>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 3>() ? track.template getDiskStubWord<NBarrelStubs + 3>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
             break;
         }
       }

--- a/TrackletAlgorithm/TrackFitMemory.h
+++ b/TrackletAlgorithm/TrackFitMemory.h
@@ -144,9 +144,10 @@ public:
   {}
 
   TrackFit(const TFSEEDTYPE seedtype) :
-    data_( ((((((0,seedtype),TFRINV(0)),TFPHI0(0)),TFZ0(0)),TFT(0)),TFHITMAP(0)) )
-
-  {}
+    data_(0)
+  {
+    setSeedType(seedtype);
+  }
 
   TrackFit()
   {}

--- a/emData/download.sh
+++ b/emData/download.sh
@@ -250,6 +250,9 @@ declare -a processing_modules=(
 
   # TrackBuilder (aka FitTrack)
   "FT_L1L2"
+  "FT_L2L3"
+  "FT_L3L4"
+  "FT_L5L6"
 
   # Tracklet Processor
   "TP_L1L2A" 

--- a/emData/generate_TB.py
+++ b/emData/generate_TB.py
@@ -88,8 +88,16 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
         tparOffset += (seedNumber << 4)
 
         # numbers of output stubs
-        nBarrelStubs = len({fm[0:10] for fm in barrelFMMems[tbName]})
+        barrelFMs = sorted([fm[0:10] for fm in barrelFMMems[tbName]])
+        nBarrelStubs = len(set(barrelFMs))
         nDiskStubs = len({fm[0:10] for fm in diskFMMems[tbName]})
+
+        # numbers of memories per stub
+        barrelFM0 = barrelFMs[0] if len(barrelFMs) > 0 else ""
+        nBarrelFMMemPerStub0 = barrelFMs.count(barrelFM0)
+        barrelFMs = [fm for fm in barrelFMs if fm != barrelFM0]
+        nBarrelFMMemPerStub = int(len(barrelFMs) / (nBarrelStubs - 1)) if nBarrelStubs > 1 else 0
+        nDiskFMMemPerStub = int(nDiskFMMem / nDiskStubs) if nDiskStubs > 0 else 0
 
         # Print out prototype for top function for this TB.
         topHeaderFile.write(
@@ -138,7 +146,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
             "#pragma HLS stream variable=barrelStubWords depth=1 dim=2\n"
             "#pragma HLS stream variable=diskStubWords depth=1 dim=2\n"
             "\n"
-            "TB_" + seed + ": TrackBuilder<TF::" + seed + ", " + str(nBarrelFMMem) + ", " + str(nDiskFMMem) + ", " + str(nBarrelStubs) + ", " + str(nDiskStubs) + ", " + str(tparOffset) + ">(\n"
+            "TB_" + seed + ": TrackBuilder<TF::" + seed + ", " + str(nBarrelFMMemPerStub0) + ", " + str(nBarrelFMMemPerStub) + ", " + str(nDiskFMMemPerStub) + ", " + str(nBarrelStubs) + ", " + str(nDiskStubs) + ", " + str(tparOffset) + ">(\n"
             "    bx,\n"
             "    trackletParameters,\n"
             "    barrelFullMatches,\n"

--- a/emData/generate_TB.py
+++ b/emData/generate_TB.py
@@ -59,6 +59,23 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
     # Calculate parameters and print out top function for each TB.
     for tbName in sorted(tparMems.keys()):
         seed = re.sub(r"FT_(....)", r"\1", tbName)
+        seedNumber = None
+        if seed == "L1L2":
+            seedNumber = 0
+        elif seed == "L2L3":
+            seedNumber = 1
+        elif seed == "L3L4":
+            seedNumber = 2
+        elif seed == "L5L6":
+            seedNumber = 3
+        elif seed == "D1D2":
+            seedNumber = 4
+        elif seed == "D3D4":
+            seedNumber = 5
+        elif seed == "L1D1":
+            seedNumber = 6
+        elif seed == "L2D1":
+            seedNumber = 7
 
         # numbers of memories
         nTPARMem = len(tparMems[tbName])
@@ -68,6 +85,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
         # offset for input TPAR memories
         firstTPAR = sorted(tparMems[tbName])[0]
         tparOffset = ord(firstTPAR[-1]) - ord('A')
+        tparOffset += (seedNumber << 4)
 
         # numbers of output stubs
         nBarrelStubs = len({fm[0:10] for fm in barrelFMMems[tbName]})
@@ -120,7 +138,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
             "#pragma HLS stream variable=barrelStubWords depth=1 dim=2\n"
             "#pragma HLS stream variable=diskStubWords depth=1 dim=2\n"
             "\n"
-            "TB_" + seed + ": TrackBuilder<" + str(nBarrelFMMem) + ", " + str(nDiskFMMem) + ", " + str(nBarrelStubs) + ", " + str(nDiskStubs) + ", " + str(tparOffset) + ">(\n"
+            "TB_" + seed + ": TrackBuilder<TF::" + seed + ", " + str(nBarrelFMMem) + ", " + str(nDiskFMMem) + ", " + str(nBarrelStubs) + ", " + str(nDiskStubs) + ", " + str(tparOffset) + ">(\n"
             "    bx,\n"
             "    trackletParameters,\n"
             "    barrelFullMatches,\n"

--- a/emData/generate_TB.py
+++ b/emData/generate_TB.py
@@ -15,6 +15,11 @@ parser.add_argument("-o", "--outputDirectory", metavar="DIR", default="../TopFun
 parser.add_argument("-w", "--wiresFileName", metavar="WIRES_FILE", default="LUTs/wires.dat", type=str, help="Name and directory of the configuration file for wiring (default = %(default)s)")
 arguments = parser.parse_args()
 
+# Keep in sync with
+# kTProjITCSize in TrackletAlgorithm/TrackletProjectionMemory.h and
+# kFMITCSize in TrackletAlgorithm/FullMatchMemory.h
+ITC_SIZE = 4
+
 # First, parse the wires file and store the memory names associated with TBs in
 # dictionaries with the TB names as keys.
 with open(arguments.wiresFileName, "r") as wiresFile:
@@ -85,7 +90,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
         # offset for input TPAR memories
         firstTPAR = sorted(tparMems[tbName])[0]
         tparOffset = ord(firstTPAR[-1]) - ord('A')
-        tparOffset += (seedNumber << 4)
+        tparOffset += (seedNumber << ITC_SIZE)
 
         # numbers of output stubs
         barrelFMs = sorted([fm[0:10] for fm in barrelFMMems[tbName]])

--- a/project/script_TB.tcl
+++ b/project/script_TB.tcl
@@ -6,28 +6,51 @@
 # get some information about the executable and environment
 source env_hls.tcl
 
+set modules_to_test {
+  {FT_L1L2}
+  {FT_L2L3}
+  {FT_L3L4}
+  {FT_L5L6}
+}
+# module_to_export must correspond to the default macros set at the top of the
+# test bench; otherwise, the C/RTL cosimulation will fail
+set module_to_export FT_L1L2
+
 # create new project (deleting any existing one of same name)
 open_project -reset trackBuilder
 
 # source files
 set CFLAGS {-std=c++11 -I../TrackletAlgorithm -I../TopFunctions}
-set_top TrackBuilder_L1L2
 add_files ../TopFunctions/TrackBuilderTop.cc -cflags "$CFLAGS"
 add_files -tb ../TestBenches/TrackBuilder_test.cpp -cflags "$CFLAGS"
-
-open_solution "solution1"
-
-# Define FPGA, clock frequency & common HLS settings.
-source settings_hls.tcl
 
 # data files
 add_files -tb ../emData/FT/
 
-csim_design -compiler gcc -mflags "-j8"
-csynth_design
-cosim_design
-export_design -format ip_catalog
-# Adding "-flow impl" runs full Vivado implementation, providing accurate resource use numbers (very slow).
-#export_design -format ip_catalog -flow impl
+foreach i $modules_to_test {
+  puts [join [list "======== TESTING " $i " ========"] ""]
+  set seed [string range $i 3 6]
+  set top_func [join [list "TrackBuilder_" $seed] ""]
+
+  # set macros for this module in CCFLAG environment variable
+  set ::env(CCFLAG) [join [list "-D \"SEED_=" $seed "_\" -D \"MODULE_=" $i "_\" -D \"TOP_FUNC_=" $top_func "\""] ""]
+
+  # run C-simulation for each module in modules_to_test
+  set_top $top_func
+  open_solution [join [list "solution_" $seed] ""]
+
+  # Define FPGA, clock frequency & common HLS settings.
+  source settings_hls.tcl
+  csim_design -mflags "-j8"
+
+  # only run C-synthesis, C/RTL cosimulation, and export for module_to_export
+  if { $i == $module_to_export } {
+    csynth_design
+    cosim_design
+    export_design -format ip_catalog
+    # Adding "-flow impl" runs full Vivado implementation, providing accurate resource use numbers (very slow).
+    #export_design -format ip_catalog -flow impl
+  }
+}
 
 exit


### PR DESCRIPTION
This PR generalizes the TrackBuilder to work for all barrel-only instances, which have been tested and pass the C-simulation. This also includes a few fixes that were preventing the design from being pipelined properly in the full configuration. 