### PR TITLE
Fix to TC/TP Barrel Seeds

### DIFF
--- a/TrackletAlgorithm/TrackletCalculator.h
+++ b/TrackletAlgorithm/TrackletCalculator.h
@@ -319,6 +319,9 @@ TC::barrelSeeding(const AllStub<InnerRegion<Seed>()> &innerStub, const AllStub<O
       valid_proj_disk[i] = false;
     if (rD[i] < floatToInt(rmindisk, krprojdisk) || rD[i] >= floatToInt(rmaxdisk, krprojdisk))
       valid_proj_disk[i] = false;
+    if (i==0 && valid_proj_disk[i] == true){
+    }
+
   }
 
 // Reject tracklets with too high a curvature or with too large a longitudinal
@@ -328,11 +331,10 @@ TC::barrelSeeding(const AllStub<InnerRegion<Seed>()> &innerStub, const AllStub<O
     success = false;
   if (abs(*z0) >= ((Seed == TF::L1L2) ? floatToInt(z0cut, kz0) : floatToInt(1.5 * z0cut, kz0)))
     success = false;
-
   const ap_int<TrackletParameters::kTParPhi0Size + 2> phicrit = *phi0 - (*rinv>>8)*ifactor;
   const bool keep = (phicrit > phicritmincut) && (phicrit < phicritmaxcut);
-  success = success && keep;
 
+  success = success && keep;
   return success;
 }
 
@@ -357,7 +359,7 @@ TC::addProj(const TrackletProjection<TProjType> &proj, const BXType bx, Tracklet
       proj_success = false;
   }
   else {
-    if (proj.getR() < floatToInt(rmindiskvm, krprojdisk) || proj.getR() >= floatToInt(rmaxdisk, krprojdisk))
+    if (abs(proj.getRZ()) < floatToInt(rmindiskvm, krprojdisk) || abs(proj.getRZ()) > floatToInt(rmaxdisk, krprojdisk))
       proj_success = false;
   }
 
@@ -384,7 +386,6 @@ TC::addProj(const TrackletProjection<TProjType> &proj, const BXType bx, Tracklet
     projout[6].write_mem(bx, proj, nproj[6]++);
   if (NProjOut > 7 && TPROJMask & (0x1 << 7) && success && proj_success && phi == 7)
     projout[7].write_mem(bx, proj, nproj[7]++);
-
   return (success && proj_success);
 }
 

--- a/TrackletAlgorithm/TrackletCalculator.h
+++ b/TrackletAlgorithm/TrackletCalculator.h
@@ -332,6 +332,7 @@ TC::barrelSeeding(const AllStub<InnerRegion<Seed>()> &innerStub, const AllStub<O
   const ap_int<TrackletParameters::kTParPhi0Size + 2> phicrit = *phi0 - (*rinv>>8)*ifactor;
   const bool keep = (phicrit > phicritmincut) && (phicrit < phicritmaxcut);
   success = success && keep;
+
   return success;
 }
 
@@ -383,6 +384,7 @@ TC::addProj(const TrackletProjection<TProjType> &proj, const BXType bx, Tracklet
     projout[6].write_mem(bx, proj, nproj[6]++);
   if (NProjOut > 7 && TPROJMask & (0x1 << 7) && success && proj_success && phi == 7)
     projout[7].write_mem(bx, proj, nproj[7]++);
+
   return (success && proj_success);
 }
 

--- a/TrackletAlgorithm/TrackletCalculator.h
+++ b/TrackletAlgorithm/TrackletCalculator.h
@@ -319,9 +319,6 @@ TC::barrelSeeding(const AllStub<InnerRegion<Seed>()> &innerStub, const AllStub<O
       valid_proj_disk[i] = false;
     if (rD[i] < floatToInt(rmindisk, krprojdisk) || rD[i] >= floatToInt(rmaxdisk, krprojdisk))
       valid_proj_disk[i] = false;
-    if (i==0 && valid_proj_disk[i] == true){
-    }
-
   }
 
 // Reject tracklets with too high a curvature or with too large a longitudinal
@@ -331,9 +328,9 @@ TC::barrelSeeding(const AllStub<InnerRegion<Seed>()> &innerStub, const AllStub<O
     success = false;
   if (abs(*z0) >= ((Seed == TF::L1L2) ? floatToInt(z0cut, kz0) : floatToInt(1.5 * z0cut, kz0)))
     success = false;
+
   const ap_int<TrackletParameters::kTParPhi0Size + 2> phicrit = *phi0 - (*rinv>>8)*ifactor;
   const bool keep = (phicrit > phicritmincut) && (phicrit < phicritmaxcut);
-
   success = success && keep;
   return success;
 }

--- a/TrackletAlgorithm/TrackletProcessor.h
+++ b/TrackletAlgorithm/TrackletProcessor.h
@@ -301,6 +301,7 @@ TC::barrelSeeding(const AllStub<InnerRegion> &innerStub, const AllStub<OuterRegi
     bool valid_phimax=phiD[i]<(1 << TrackletProjection<BARRELPS>::kTProjPhiSize) - 1;
     bool valid_r=rD[i] >= 342 && rD[i] < 2048;
     valid_proj_disk[i] = valid_t && valid_phimin && valid_phimax && valid_r;
+
   }
 
 // Reject tracklets with too high a curvature or with too large a longitudinal
@@ -311,6 +312,7 @@ TC::barrelSeeding(const AllStub<InnerRegion> &innerStub, const AllStub<OuterRegi
 
   const ap_int<TrackletParameters::kTParPhi0Size + 2> phicrit = *phi0 - (*rinv>>8)*ifactor;
   const bool keep = (phicrit > phicritmincut) && (phicrit < phicritmaxcut);
+
   return valid_rinv && valid_z0 && keep;
 }
 
@@ -362,6 +364,7 @@ TC::addProj(const TrackletProjection<TProjType> &proj, const BXType bx, Tracklet
     projout[6].write_mem(bx, proj, nproj[6]++);
   if (NProjOut > 7 && TPROJMask & (0x1 << 7) && success && proj_success && phi == 7)
     projout[7].write_mem(bx, proj, nproj[7]++);
+
   return (success && proj_success);
 }
 

--- a/TrackletAlgorithm/TrackletProcessor.h
+++ b/TrackletAlgorithm/TrackletProcessor.h
@@ -301,7 +301,6 @@ TC::barrelSeeding(const AllStub<InnerRegion> &innerStub, const AllStub<OuterRegi
     bool valid_phimax=phiD[i]<(1 << TrackletProjection<BARRELPS>::kTProjPhiSize) - 1;
     bool valid_r=rD[i] >= 342 && rD[i] < 2048;
     valid_proj_disk[i] = valid_t && valid_phimin && valid_phimax && valid_r;
-
   }
 
 // Reject tracklets with too high a curvature or with too large a longitudinal
@@ -312,7 +311,6 @@ TC::barrelSeeding(const AllStub<InnerRegion> &innerStub, const AllStub<OuterRegi
 
   const ap_int<TrackletParameters::kTParPhi0Size + 2> phicrit = *phi0 - (*rinv>>8)*ifactor;
   const bool keep = (phicrit > phicritmincut) && (phicrit < phicritmaxcut);
-
   return valid_rinv && valid_z0 && keep;
 }
 
@@ -337,7 +335,7 @@ TC::addProj(const TrackletProjection<TProjType> &proj, const BXType bx, Tracklet
       proj_success = false;
   }
   else {
-    if (proj.getR() < floatToInt(20.0, 2*kr) || proj.getR() >= floatToInt(120.0, 2*kr))
+    if (abs(proj.getRZ()) < floatToInt(rmindiskvm, krprojdisk)  || abs(proj.getRZ()) > floatToInt(rmaxdisk, krprojdisk))
       proj_success = false;
   }
   TC::Types::phiL phi = proj.getPhi() >> (TrackletProjection<TProjType>::kTProjPhiSize - 5);
@@ -364,7 +362,6 @@ TC::addProj(const TrackletProjection<TProjType> &proj, const BXType bx, Tracklet
     projout[6].write_mem(bx, proj, nproj[6]++);
   if (NProjOut > 7 && TPROJMask & (0x1 << 7) && success && proj_success && phi == 7)
     projout[7].write_mem(bx, proj, nproj[7]++);
-
   return (success && proj_success);
 }
 

--- a/project/script_TP.tcl
+++ b/project/script_TP.tcl
@@ -1,15 +1,34 @@
-# Script to generate project for TC
-#   vivado_hls -f script_TC.tcl
-#   vivado_hls -p trackletCalculator
+# Script to generate project for TP
+#   vivado_hls -f script_TP.tcl
+#   vivado_hls -p trackletProcessor
 # WARNING: this will wipe out the original project by the same name
 
 # get some information about the executable and environment
 source env_hls.tcl
 
 set modules_to_test {
+  {TP_L1L2A}
+  {TP_L1L2B}
   {TP_L1L2C}
-  {TP_L2L3C}
+  {TP_L1L2D}
+  {TP_L1L2E} 
+  {TP_L1L2F} 
+  {TP_L1L2G} 
+  {TP_L1L2H} 
+  {TP_L1L2I} 
+  {TP_L1L2J} 
+  {TP_L1L2K} 
+  {TP_L1L2L} 
+  {TP_L2L3A} 
+  {TP_L2L3B} 
+  {TP_L2L3C} 
+  {TP_L2L3D} 
+  {TP_L3L4A}
+  {TP_L3L4B}
   {TP_L3L4C}
+  {TP_L3L4D}
+  {TP_L5L6A}
+  {TP_L5L6B}
   {TP_L5L6C}
 }
 # module_to_export must correspond to the default macros set at the top of the


### PR DESCRIPTION
PR includes some small fixes to the cuts in the TC/TP, to fix several seeds( TC_L2L3D, TC_L3L4C, TC_L3L4D, TP_L2L3D)  failing in C-sim. Tcls are updated to run over all barrel only seeds and have been tested.