### PR TITLE
Fixes needed to run in CMSSW future SW

### DIFF
--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -148,7 +148,8 @@ inline void step(const VMStubMECM<VMSMEType> stubmem[2][1024]) {
   }
   
   //Read stub memory and extract data fields
-  auto stubadd=(iphiSave,zbin,istubtmp);
+  auto stubtmp=(iphiSave,zbin);
+  auto stubadd=(stubtmp,istubtmp);
   stubdata__ = stubmem[bx_&1][stubadd];
   projbuffer__ = projbuffer_;
   projseq__ = projseq_;

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -651,7 +651,7 @@ void MatchProcessor(BXType bx,
 
     projseq0123tmp = Bit0123 ? projseq01tmp : projseq23tmp;
     
-    auto bestiMEU = (~Bit0123, Bit0123 ? ~Bit01 : ~Bit23 );
+    ap_uint<2> bestiMEU = (~Bit0123, Bit0123 ? ~Bit01 : ~Bit23 );
 
     ap_uint<1> hasMatch = !emptys[bestiMEU];
 


### PR DESCRIPTION
These two changes are needed to run in CMSSW future SW emulation.

MatchProcessor:

Auto changed to ap_uint<2>

MatchEngineUnit.h:

concatenation of 3 ap_uints changed to two lines of concatenation between 2 ap_uints.