### PR TITLE
Fixed gcc10 compilation error from unsigned int comparison

### DIFF
--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -114,7 +114,7 @@ class MemoryTemplateBinnedCM{
     if(!NBIT_BX) ibx = 0;
     if (nentry_ibx < getNEntryPerBin()-1) { // Max 15 stubs in each memory due to 4 bit nentries
       // write address for slot: getNEntryPerBin() * slot + nentry_ibx
-      writememloop: for (signed int icopy=0; icopy< (signed) NCOPY;icopy++) {
+      writememloop: for (signed int icopy=0; icopy< (signed) NCOPY;icopy++) { // Casting to signed int to avoid unsigned int comparison compilation error
 #pragma HLS unroll
         dataarray_[icopy][ibx][getNEntryPerBin()*slot+nentry_ibx] = data;
       }

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -115,13 +115,10 @@ class MemoryTemplateBinnedCM{
     if (nentry_ibx < getNEntryPerBin()-1) { // Max 15 stubs in each memory due to 4 bit nentries
       // write address for slot: getNEntryPerBin() * slot + nentry_ibx
   
-    writememloop:
-    if constexpr (NCOPY != 0) {
-      for (unsigned int icopy=0; icopy< NCOPY;icopy++) {
+    writememloop: for (signed int icopy=0; icopy< (signed) NCOPY;icopy++) {
 #pragma HLS unroll
     dataarray_[icopy][ibx][getNEntryPerBin()*slot+nentry_ibx] = data;
         }
-    }
       
       #ifdef CMSSW_GIT_HASH
       ap_uint<kNBitsRZBinCM> ibin;

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -114,11 +114,10 @@ class MemoryTemplateBinnedCM{
     if(!NBIT_BX) ibx = 0;
     if (nentry_ibx < getNEntryPerBin()-1) { // Max 15 stubs in each memory due to 4 bit nentries
       // write address for slot: getNEntryPerBin() * slot + nentry_ibx
-  
-    writememloop: for (signed int icopy=0; icopy< (signed) NCOPY;icopy++) {
+      writememloop: for (signed int icopy=0; icopy< (signed) NCOPY;icopy++) {
 #pragma HLS unroll
-    dataarray_[icopy][ibx][getNEntryPerBin()*slot+nentry_ibx] = data;
-        }
+        dataarray_[icopy][ibx][getNEntryPerBin()*slot+nentry_ibx] = data;
+      }
       
       #ifdef CMSSW_GIT_HASH
       ap_uint<kNBitsRZBinCM> ibin;

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -115,11 +115,14 @@ class MemoryTemplateBinnedCM{
     if (nentry_ibx < getNEntryPerBin()-1) { // Max 15 stubs in each memory due to 4 bit nentries
       // write address for slot: getNEntryPerBin() * slot + nentry_ibx
   
-    writememloop:for (unsigned int icopy=0;icopy<NCOPY;icopy++) {
+    writememloop:
+    if constexpr (NCOPY != 0) {
+      for (unsigned int icopy=0; icopy< NCOPY;icopy++) {
 #pragma HLS unroll
-	dataarray_[icopy][ibx][getNEntryPerBin()*slot+nentry_ibx] = data;
-      }
-
+    dataarray_[icopy][ibx][getNEntryPerBin()*slot+nentry_ibx] = data;
+        }
+    }
+      
       #ifdef CMSSW_GIT_HASH
       ap_uint<kNBitsRZBinCM> ibin;
       ap_uint<kNbitsphibin> ireg;


### PR DESCRIPTION
This pull request fixes a compilation error in gcc10 where an unsigned int is compared to be less than the NCOPY variable, which is 0 for layer 1, implying the comparison will always return false. A check is performed to ensure that the memories are only looped over and written if NCOPY != 0.