### PR TITLE
Vmr debug printout fix

### DIFF
--- a/TrackletAlgorithm/VMRouter.h
+++ b/TrackletAlgorithm/VMRouter.h
@@ -676,11 +676,10 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 				memoriesAS[n].write_mem(bx, allstub, i);
 			}
 
-// For debugging
-#ifndef __SYNTHESIS__
+#ifndef VMR_DEBUG
 			edm::LogVerbatim("L1trackHLS") << std::endl << "Stub index no. " << i << std::endl << "Out put stub: " << std::hex << allstub.raw() << std::dec
 					<< std::endl;
-#endif // DEBUG
+#endif // VMR_DEBUG
 
 
 		/////////////////////////////////////////////
@@ -699,8 +698,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 					createStubME<DISK2S, OutType, Layer, Disk>(stubDisk2S, i, negDisk, fineBinTable, phiCorrTable, ivmPlus, ivmMinus, bin) :
 					createStubME<InType, OutType, Layer, Disk>(stub, i, negDisk, fineBinTable, phiCorrTable, ivmPlus, ivmMinus, bin);;
 
-// For debugging
-#ifndef __SYNTHESIS__
+#ifndef VMR_DEBUG
 			edm::LogVerbatim("L1trackHLS") << "ME stub " << std::hex << stubME.raw() << std::endl;
 			edm::LogVerbatim("L1trackHLS") << "ivm Minus,Plus = " << std::dec << ivmMinus << " " << ivmPlus << " " << "\t0x"
 					<< std::setfill('0') << std::setw(4) << std::hex
@@ -711,7 +709,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 			if (!maskME[ivmMinus]) {
 				std::cerr << "Trying to write to non-existent memory for ivm = " << ivmMinus << std::endl;
 			}
-#endif // DEBUG
+#endif // VMR_DEBUG
 
 			// Write the ME stub to the correct memory.
 			// If stub is close to a border (ivmPlus != ivmMinus)
@@ -748,13 +746,12 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 			// Create the TE Inner stub to save
 			VMStubTEInner<OutType> stubTEI = createStubTEInner<InType, OutType, Layer, Disk>(stub, i, negDisk, rzbitsInnerTable, phiCorrTable, ivm, rzbits);
 
-// For debugging
-#ifndef __SYNTHESIS__
+#ifndef VMR_DEBUG
 			edm::LogVerbatim("L1trackHLS") << "TEInner stub " << std::hex << stubTEI.raw()
 					<< std::endl;
 			edm::LogVerbatim("L1trackHLS") << "ivm: " << std::dec << ivm <<std::endl
 					<< std::endl;
-#endif // DEBUG
+#endif // VMR_DEBUG
 
 			// Write the TE Inner stub to the correct memory
 			// Only if it has a valid rzbits/binlookup value, i.e. not -1,
@@ -788,12 +785,11 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 			// Create the TE Outer stub to save
 			VMStubTEOuter<OutType> stubTEO = createStubTEOuter<InType, OutType, Layer, Disk>(stub, i, negDisk, rzbitsOuterTable, phiCorrTable, ivm, bin);
 
-// For debugging
-#ifndef __SYNTHESIS__
+#ifndef VMR_DEBUG
 			edm::LogVerbatim("L1trackHLS") << "TEOuter stub " << std::hex << stubTEO.raw()
 					<< std::endl;
 			edm::LogVerbatim("L1trackHLS") << "    ivm: " << std::dec << ivm << "       to bin " << bin << std::endl;
-#endif // DEBUG
+#endif // VMR_DEBUG
 
 			// Write the TE Outer stub to the correct memory
 			// Only if it has a valid bend
@@ -832,13 +828,12 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 			// Create the TE Inner Overlap stub to save
 			VMStubTEInner<BARRELOL> stubOL = createStubTEOverlap<InType, Layer>(stub, i, rzbitsOverlapTable, phiCorrTable, ivm, rzbits);
 
-// For debugging
-#ifndef __SYNTHESIS__
+#ifndef VMR_DEBUG
 			edm::LogVerbatim("L1trackHLS") << "Overlap stub " << " " << std::hex
 					<< stubOL.raw() << std::endl;
 			edm::LogVerbatim("L1trackHLS") << "ivm: " << std::dec << ivm << std::endl
 					<< std::endl;
-#endif // DEBUG
+#endif // VMR_DEBUG
 
 			// Save stub to Overlap memories
 			if (maskOL[ivm] && (rzbits != -1)) {
@@ -856,12 +851,11 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 				}
 			}
 
-// For debugging
-#ifndef __SYNTHESIS__
+#ifndef VMR_DEBUG
 			else {
 			  edm::LogVerbatim("L1trackHLS") << "NO OVERLAP" << std::endl << std::endl;
 			}
-#endif // DEBUG
+#endif // VMR_DEBUG
 
 		} // End TE Overlap memories
 	} // Outside main loop

--- a/TrackletAlgorithm/VMRouter.h
+++ b/TrackletAlgorithm/VMRouter.h
@@ -676,7 +676,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 				memoriesAS[n].write_mem(bx, allstub, i);
 			}
 
-#ifndef VMR_DEBUG
+#ifdef VMR_DEBUG
 			edm::LogVerbatim("L1trackHLS") << std::endl << "Stub index no. " << i << std::endl << "Out put stub: " << std::hex << allstub.raw() << std::dec
 					<< std::endl;
 #endif // VMR_DEBUG
@@ -698,7 +698,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 					createStubME<DISK2S, OutType, Layer, Disk>(stubDisk2S, i, negDisk, fineBinTable, phiCorrTable, ivmPlus, ivmMinus, bin) :
 					createStubME<InType, OutType, Layer, Disk>(stub, i, negDisk, fineBinTable, phiCorrTable, ivmPlus, ivmMinus, bin);;
 
-#ifndef VMR_DEBUG
+#ifdef VMR_DEBUG
 			edm::LogVerbatim("L1trackHLS") << "ME stub " << std::hex << stubME.raw() << std::endl;
 			edm::LogVerbatim("L1trackHLS") << "ivm Minus,Plus = " << std::dec << ivmMinus << " " << ivmPlus << " " << "\t0x"
 					<< std::setfill('0') << std::setw(4) << std::hex
@@ -746,7 +746,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 			// Create the TE Inner stub to save
 			VMStubTEInner<OutType> stubTEI = createStubTEInner<InType, OutType, Layer, Disk>(stub, i, negDisk, rzbitsInnerTable, phiCorrTable, ivm, rzbits);
 
-#ifndef VMR_DEBUG
+#ifdef VMR_DEBUG
 			edm::LogVerbatim("L1trackHLS") << "TEInner stub " << std::hex << stubTEI.raw()
 					<< std::endl;
 			edm::LogVerbatim("L1trackHLS") << "ivm: " << std::dec << ivm <<std::endl
@@ -785,7 +785,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 			// Create the TE Outer stub to save
 			VMStubTEOuter<OutType> stubTEO = createStubTEOuter<InType, OutType, Layer, Disk>(stub, i, negDisk, rzbitsOuterTable, phiCorrTable, ivm, bin);
 
-#ifndef VMR_DEBUG
+#ifdef VMR_DEBUG
 			edm::LogVerbatim("L1trackHLS") << "TEOuter stub " << std::hex << stubTEO.raw()
 					<< std::endl;
 			edm::LogVerbatim("L1trackHLS") << "    ivm: " << std::dec << ivm << "       to bin " << bin << std::endl;
@@ -828,7 +828,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 			// Create the TE Inner Overlap stub to save
 			VMStubTEInner<BARRELOL> stubOL = createStubTEOverlap<InType, Layer>(stub, i, rzbitsOverlapTable, phiCorrTable, ivm, rzbits);
 
-#ifndef VMR_DEBUG
+#ifdef VMR_DEBUG
 			edm::LogVerbatim("L1trackHLS") << "Overlap stub " << " " << std::hex
 					<< stubOL.raw() << std::endl;
 			edm::LogVerbatim("L1trackHLS") << "ivm: " << std::dec << ivm << std::endl
@@ -851,7 +851,7 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 				}
 			}
 
-#ifndef VMR_DEBUG
+#ifdef VMR_DEBUG
 			else {
 			  edm::LogVerbatim("L1trackHLS") << "NO OVERLAP" << std::endl << std::endl;
 			}

--- a/TrackletAlgorithm/VMRouter.h
+++ b/TrackletAlgorithm/VMRouter.h
@@ -32,6 +32,7 @@
 #include "DummyMessageLogger.h"
 #endif
 #endif
+// #define VMR_DEBUG
 
 /////////////////////////////////////////
 // Constants
@@ -676,9 +677,8 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 				memoriesAS[n].write_mem(bx, allstub, i);
 			}
 
-#ifdef VMR_DEBUG
-			edm::LogVerbatim("L1trackHLS") << std::endl << "Stub index no. " << i << std::endl << "Out put stub: " << std::hex << allstub.raw() << std::dec
-					<< std::endl;
+#if !defined(__SYNTHESIS__) && defined(VMRCM_DEBUG)
+			edm::LogVerbatim("L1trackHLS") << std::endl << "Stub index no. " << i << std::endl << "Out put stub: " << std::hex << allstub.raw() << std::dec;
 #endif // VMR_DEBUG
 
 
@@ -698,11 +698,10 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 					createStubME<DISK2S, OutType, Layer, Disk>(stubDisk2S, i, negDisk, fineBinTable, phiCorrTable, ivmPlus, ivmMinus, bin) :
 					createStubME<InType, OutType, Layer, Disk>(stub, i, negDisk, fineBinTable, phiCorrTable, ivmPlus, ivmMinus, bin);;
 
-#ifdef VMR_DEBUG
-			edm::LogVerbatim("L1trackHLS") << "ME stub " << std::hex << stubME.raw() << std::endl;
+#if !defined(__SYNTHESIS__) && defined(VMRCM_DEBUG)
+			edm::LogVerbatim("L1trackHLS") << "ME stub " << std::hex << stubME.raw();
 			edm::LogVerbatim("L1trackHLS") << "ivm Minus,Plus = " << std::dec << ivmMinus << " " << ivmPlus << " " << "\t0x"
-					<< std::setfill('0') << std::setw(4) << std::hex
-					<< stubME.raw().to_int() << std::dec << ", to bin " << bin << std::endl;
+					<< std::setfill('0') << std::setw(4) << std::hex << stubME.raw().to_int() << std::dec << ", to bin " << bin;
 			if (!maskME[ivmPlus]) {
 				std::cerr << "Trying to write to non-existent memory for ivm = " << ivmPlus << std::endl;
 					}
@@ -746,11 +745,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 			// Create the TE Inner stub to save
 			VMStubTEInner<OutType> stubTEI = createStubTEInner<InType, OutType, Layer, Disk>(stub, i, negDisk, rzbitsInnerTable, phiCorrTable, ivm, rzbits);
 
-#ifdef VMR_DEBUG
-			edm::LogVerbatim("L1trackHLS") << "TEInner stub " << std::hex << stubTEI.raw()
-					<< std::endl;
-			edm::LogVerbatim("L1trackHLS") << "ivm: " << std::dec << ivm <<std::endl
-					<< std::endl;
+#if !defined(__SYNTHESIS__) && defined(VMRCM_DEBUG)
+			edm::LogVerbatim("L1trackHLS") << "TEInner stub " << std::hex << stubTEI.raw();
+			edm::LogVerbatim("L1trackHLS") << "ivm: " << std::dec << ivm;
 #endif // VMR_DEBUG
 
 			// Write the TE Inner stub to the correct memory
@@ -785,10 +782,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 			// Create the TE Outer stub to save
 			VMStubTEOuter<OutType> stubTEO = createStubTEOuter<InType, OutType, Layer, Disk>(stub, i, negDisk, rzbitsOuterTable, phiCorrTable, ivm, bin);
 
-#ifdef VMR_DEBUG
-			edm::LogVerbatim("L1trackHLS") << "TEOuter stub " << std::hex << stubTEO.raw()
-					<< std::endl;
-			edm::LogVerbatim("L1trackHLS") << "    ivm: " << std::dec << ivm << "       to bin " << bin << std::endl;
+#if !defined(__SYNTHESIS__) && defined(VMRCM_DEBUG)
+			edm::LogVerbatim("L1trackHLS") << "TEOuter stub " << std::hex << stubTEO.raw();
+			edm::LogVerbatim("L1trackHLS") << "    ivm: " << std::dec << ivm << "       to bin " << bin;
 #endif // VMR_DEBUG
 
 			// Write the TE Outer stub to the correct memory
@@ -828,11 +824,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 			// Create the TE Inner Overlap stub to save
 			VMStubTEInner<BARRELOL> stubOL = createStubTEOverlap<InType, Layer>(stub, i, rzbitsOverlapTable, phiCorrTable, ivm, rzbits);
 
-#ifdef VMR_DEBUG
-			edm::LogVerbatim("L1trackHLS") << "Overlap stub " << " " << std::hex
-					<< stubOL.raw() << std::endl;
-			edm::LogVerbatim("L1trackHLS") << "ivm: " << std::dec << ivm << std::endl
-					<< std::endl;
+#if !defined(__SYNTHESIS__) && defined(VMRCM_DEBUG)
+			edm::LogVerbatim("L1trackHLS") << "Overlap stub " << " " << std::hex << stubOL.raw();
+			edm::LogVerbatim("L1trackHLS") << "ivm: " << std::dec << ivm;
 #endif // VMR_DEBUG
 
 			// Save stub to Overlap memories
@@ -851,9 +845,9 @@ void VMRouter(const BXType bx, BXType& bx_o, const int fineBinTable[], const int
 				}
 			}
 
-#ifdef VMR_DEBUG
+#if !defined(__SYNTHESIS__) && defined(VMRCM_DEBUG)
 			else {
-			  edm::LogVerbatim("L1trackHLS") << "NO OVERLAP" << std::endl << std::endl;
+			  edm::LogVerbatim("L1trackHLS") << "NO OVERLAP";
 			}
 #endif // VMR_DEBUG
 

--- a/TrackletAlgorithm/VMRouterCM.h
+++ b/TrackletAlgorithm/VMRouterCM.h
@@ -285,12 +285,11 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 			memoriesAS[n].write_mem(bx, allstub, i);
 		}
 
-// For debugging
-#if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
+#ifdef VMRCM_DEBUG
 		edm::LogVerbatim("L1trackHLS") << std::endl << "Stub index no. " << i << std::endl
 				<< "Out put stub: " << std::hex << allstub.raw() << std::dec
 				<< std::endl;
-#endif // DEBUG
+#endif // VMRCM_DEBUG
 
 		////////////////////////////////////////
 		// AllStubInner memories
@@ -368,11 +367,10 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 					}
 				}
 
-// For debugging
-#if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
+#ifdef VMRCM_DEBUG
 				edm::LogVerbatim("L1trackHLS") << std::endl << "Allstub Inner: " << std::hex
 						<< allstubinner.raw() << std::dec << std::endl;
-#endif // DEBUG
+#endif // VMRCM_DEBUG
 
 			}
 		}
@@ -391,11 +389,10 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 		memoryME->write_mem(bx, slotME, stubME, addrCountME[slotME]);
 		addrCountME[slotME] += 1;
 
-// For debugging
-#if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
+#ifdef VMRCM_DEBUG
 		edm::LogVerbatim("L1trackHLS") << "ME stub " << std::hex << stubME.raw() << std::dec
 				<< "       to slot " << slotME << std::endl;
-#endif // DEBUG
+#endif // VMRCM_DEBUG
 		// End ME memories
 
 		////////////////////////////////////
@@ -417,11 +414,10 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 			}
 			addrCountTE[slotTE] += 1;
 
-// For debugging
-#if !(defined(__SYNTHESIS__) || defined(CMSSW_GIT_HASH))
+#ifdef VMRCM_DEBUG
 			edm::LogVerbatim("L1trackHLS") << "TEOuter stub " << std::hex << stubTEO.raw()
 					<< std::dec << "       to slot " << slotTE << std::endl;
-#endif // DEBUG
+#endif // VMRCM_DEBUG
 
 		} // End TE Outer memories
 

--- a/TrackletAlgorithm/VMRouterCM.h
+++ b/TrackletAlgorithm/VMRouterCM.h
@@ -26,6 +26,7 @@
 #include "DummyMessageLogger.h"
 #endif
 #endif
+// #define VMRCM_DEBUG
 
 /////////////////////////////////////////
 // Constants
@@ -285,10 +286,8 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 			memoriesAS[n].write_mem(bx, allstub, i);
 		}
 
-#ifdef VMRCM_DEBUG
-		edm::LogVerbatim("L1trackHLS") << std::endl << "Stub index no. " << i << std::endl
-				<< "Out put stub: " << std::hex << allstub.raw() << std::dec
-				<< std::endl;
+#if !defined(__SYNTHESIS__) && defined(VMRCM_DEBUG)
+		edm::LogVerbatim("L1trackHLS") << std::endl << "Stub index no. " << i << std::endl << "Out put stub: " << std::hex << allstub.raw() << std::dec;
 #endif // VMRCM_DEBUG
 
 		////////////////////////////////////////
@@ -367,9 +366,8 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 					}
 				}
 
-#ifdef VMRCM_DEBUG
-				edm::LogVerbatim("L1trackHLS") << std::endl << "Allstub Inner: " << std::hex
-						<< allstubinner.raw() << std::dec << std::endl;
+#if !defined(__SYNTHESIS__) && defined(VMRCM_DEBUG)
+				edm::LogVerbatim("L1trackHLS") << std::endl << "Allstub Inner: " << std::hex << allstubinner.raw() << std::dec;
 #endif // VMRCM_DEBUG
 
 			}
@@ -389,9 +387,8 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 		memoryME->write_mem(bx, slotME, stubME, addrCountME[slotME]);
 		addrCountME[slotME] += 1;
 
-#ifdef VMRCM_DEBUG
-		edm::LogVerbatim("L1trackHLS") << "ME stub " << std::hex << stubME.raw() << std::dec
-				<< "       to slot " << slotME << std::endl;
+#if !defined(__SYNTHESIS__) && defined(VMRCM_DEBUG)
+		edm::LogVerbatim("L1trackHLS") << "ME stub " << std::hex << stubME.raw() << std::dec << "       to slot " << slotME;
 #endif // VMRCM_DEBUG
 		// End ME memories
 
@@ -414,9 +411,8 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 			}
 			addrCountTE[slotTE] += 1;
 
-#ifdef VMRCM_DEBUG
-			edm::LogVerbatim("L1trackHLS") << "TEOuter stub " << std::hex << stubTEO.raw()
-					<< std::dec << "       to slot " << slotTE << std::endl;
+#if !defined(__SYNTHESIS__) && defined(VMRCM_DEBUG)
+			edm::LogVerbatim("L1trackHLS") << "TEOuter stub " << std::hex << stubTEO.raw() << std::dec << "       to slot " << slotTE;
 #endif // VMRCM_DEBUG
 
 		} // End TE Outer memories


### PR DESCRIPTION
Reduces the number of printouts when running CSim unless a VMR_DEBUG/VMRCM_DEBUG flag is specified, hopefully that will stop the CI from exceeding the job log output limit ( https://gitlab.cern.ch/cms-l1tk/firmware-hls/-/jobs/23421481) as discussed here https://github.com/cms-L1TK/firmware-hls/pull/241.