### PR TITLE
LUT path update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -474,6 +474,6 @@ topReducedCombined-synth:
     PROJ_NAME: "ReducedCombinedConfig"
   needs:
     - job: download
-    - job: topReducedCombinedConfig-sim
-    - job: topReducedCombinedConfig-check-results
+    - job: topReducedCombined-sim
+    - job: topReducedCombined-check-results
       artifacts: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -346,6 +346,23 @@ topIRtoTB-sim:
       artifacts: false
     - job: TB-vivado-hls-build
       artifacts: false
+topReducedCombined-sim:
+  <<: *template_topTF-sim
+  variables:
+    VIVADO_VERSION: "2019.2"
+    PROJ_NAME: "ReducedCombinedConfig"
+  needs:
+    - job: download
+    - job: IR-vivado-hls-build
+      artifacts: false
+    - job: VMRCM-vivado-hls-build
+      artifacts: false
+    - job: TP-vivado-hls-build
+      artifacts: false
+    - job: MP-vivado-hls-build
+      artifacts: false
+    - job: TB-vivado-hls-build
+      artifacts: false
 # Check FW results ---------------
 topPRMEMC-check-results:
   <<: *template_check-results
@@ -390,6 +407,15 @@ topIRtoTB-check-results:
   needs:
     - download
     - topIRtoTB-sim
+topReducedCombined-check-results:
+  <<: *template_check-results
+  allow_failure: true # FIXME: remove after all errors are fixed
+  variables:
+    VIVADO_VERSION: "2019.2" # Vivado not needed but it is part of the path that is called
+    PROJ_NAME: "ReducedCombinedConfig"
+  needs:
+    - download
+    - topReducedCombined-sim
 # FW synthesis ---------------
 topPRMEMC-synth:
   <<: *template_topTF-synth
@@ -440,4 +466,14 @@ topIRtoTB-synth:
     - job: download
     - job: topIRtoTB-sim
     - job: topIRtoTB-check-results
+      artifacts: false
+topReducedCombined-synth:
+  <<: *template_topTF-synth
+  variables:
+    VIVADO_VERSION: "2019.2"
+    PROJ_NAME: "ReducedCombinedConfig"
+  needs:
+    - job: download
+    - job: topReducedCombinedConfig-sim
+    - job: topReducedCombinedConfig-check-results
       artifacts: false

--- a/IntegrationTests/BarrelConfig/IRtoTB/script/makeProject.tcl
+++ b/IntegrationTests/BarrelConfig/IRtoTB/script/makeProject.tcl
@@ -183,6 +183,9 @@ remove_files -fileset sources_1 [glob common/hdl/latency_monitor.vhd]
 # Add HDL for TB
 add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]
 
+# Add utility files
+add_files -fileset utils_1 [glob ./pre.tcl]
+
 # Add constraints (clock etc.)
 add_files -fileset constrs_1 [glob common/hdl/constraints.xdc]
 

--- a/IntegrationTests/BarrelConfig/IRtoTB/script/pre.tcl
+++ b/IntegrationTests/BarrelConfig/IRtoTB/script/pre.tcl
@@ -1,0 +1,10 @@
+# Copy LUTs to xsim or synth_1 directory
+set cwd [file tail [pwd]]
+file delete -force ./LUTs
+if {$cwd == "xsim"} {
+  # xsim
+  file copy -force ../../../../../../../../../emData/LUTsReduced ./LUTs
+} else {
+  # synth_1
+  file copy -force ../../../../../../../emData/LUTsReduced ./LUTs
+}

--- a/IntegrationTests/BarrelConfig/IRtoTB/script/runSim.tcl
+++ b/IntegrationTests/BarrelConfig/IRtoTB/script/runSim.tcl
@@ -9,6 +9,9 @@ reset_simulation sim_1
 file delete -force dataOut/
 file mkdir dataOut/
 
+# Run pre.tcl if it exists
+set_property -name {xsim.compile.tcl.pre} -value [get_files pre.tcl -of [get_fileset utils_1]] -objects [get_filesets sim_1]
+
 # Launch Simulation
 launch_simulation
 

--- a/IntegrationTests/ReducedCombinedConfig/script/makeProject.tcl
+++ b/IntegrationTests/ReducedCombinedConfig/script/makeProject.tcl
@@ -49,6 +49,9 @@ remove_files -fileset sources_1 [glob common/hdl/latency_monitor.vhd]
 # Add HDL for TB
 add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]
 
+# Add utility files
+add_files -fileset utils_1 [glob ./pre.tcl]
+
 # Add constraints (clock etc.)
 add_files -fileset constrs_1 [glob common/hdl/constraints.xdc]
 

--- a/IntegrationTests/ReducedCombinedConfig/script/pre.tcl
+++ b/IntegrationTests/ReducedCombinedConfig/script/pre.tcl
@@ -1,0 +1,10 @@
+# Copy LUTs to xsim or synth_1 directory
+set cwd [file tail [pwd]]
+file delete -force ./LUTs
+if {$cwd == "xsim"} {
+  # xsim
+  file copy -force ../../../../../../../../emData/LUTsCMReduced ./LUTs
+} else {
+  # synth_1
+  file copy -force ../../../../../../emData/LUTsCMReduced ./LUTs
+}

--- a/IntegrationTests/ReducedCombinedConfig/script/runSim.tcl
+++ b/IntegrationTests/ReducedCombinedConfig/script/runSim.tcl
@@ -8,6 +8,9 @@ reset_simulation sim_1
 file delete -force dataOut/
 file mkdir dataOut/
 
+# Run pre.tcl if it exists
+set_property -name {xsim.compile.tcl.pre} -value [get_files pre.tcl -of [get_fileset utils_1]] -objects [get_filesets sim_1]
+
 # Launch Simulation
 launch_simulation
 

--- a/IntegrationTests/ReducedConfig/IRtoTB/script/makeProject.tcl
+++ b/IntegrationTests/ReducedConfig/IRtoTB/script/makeProject.tcl
@@ -62,6 +62,9 @@ remove_files -fileset sources_1 [glob common/hdl/latency_monitor.vhd]
 # Add HDL for TB
 add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]
 
+# Add utility files
+add_files -fileset utils_1 [glob ./pre.tcl]
+
 # Add constraints (clock etc.)
 add_files -fileset constrs_1 [glob common/hdl/constraints.xdc]
 

--- a/IntegrationTests/ReducedConfig/IRtoTB/script/pre.tcl
+++ b/IntegrationTests/ReducedConfig/IRtoTB/script/pre.tcl
@@ -1,0 +1,10 @@
+# Copy LUTs to xsim or synth_1 directory
+set cwd [file tail [pwd]]
+file delete -force ./LUTs
+if {$cwd == "xsim"} {
+  # xsim
+  file copy -force ../../../../../../../../../emData/LUTsReduced ./LUTs
+} else {
+  # synth_1
+  file copy -force ../../../../../../../emData/LUTsReduced ./LUTs
+}

--- a/IntegrationTests/ReducedConfig/IRtoTB/script/runSim.tcl
+++ b/IntegrationTests/ReducedConfig/IRtoTB/script/runSim.tcl
@@ -8,6 +8,9 @@ reset_simulation sim_1
 file delete -force dataOut/
 file mkdir dataOut/
 
+# Run pre.tcl if it exists
+set_property -name {xsim.compile.tcl.pre} -value [get_files pre.tcl -of [get_fileset utils_1]] -objects [get_filesets sim_1]
+
 # Launch Simulation
 launch_simulation
 

--- a/IntegrationTests/TETC/script/makeProject.tcl
+++ b/IntegrationTests/TETC/script/makeProject.tcl
@@ -27,6 +27,9 @@ add_files -fileset sources_1 [glob common/hdl/*.vhd]
 # Add HDL for TB
 add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]
 
+# Add utility files
+add_files -fileset utils_1 [glob ./pre.tcl]
+
 # Add constraints (clock etc.)
 add_files -fileset constrs_1 [glob common/hdl/constraints.xdc]
 

--- a/IntegrationTests/TETC/script/pre.tcl
+++ b/IntegrationTests/TETC/script/pre.tcl
@@ -1,0 +1,10 @@
+# Copy LUTs to xsim or synth_1 directory
+set cwd [file tail [pwd]]
+file delete -force ./LUTs
+if {$cwd == "xsim"} {
+  # xsim
+  file copy -force ../../../../../../../../emData/LUTs ./LUTs
+} else {
+  # synth_1
+  file copy -force ../../../../../../emData/LUTs ./LUTs
+}

--- a/IntegrationTests/TETC/script/runSim.tcl
+++ b/IntegrationTests/TETC/script/runSim.tcl
@@ -8,6 +8,9 @@ reset_simulation sim_1
 file delete -force dataOut/
 file mkdir dataOut/
 
+# Run pre.tcl if it exists
+set_property -name {xsim.compile.tcl.pre} -value [get_files pre.tcl -of [get_fileset utils_1]] -objects [get_filesets sim_1]
+
 # Launch Simulation
 launch_simulation
 

--- a/IntegrationTests/common/hdl/tf_pkg.vhd
+++ b/IntegrationTests/common/hdl/tf_pkg.vhd
@@ -117,8 +117,6 @@ package tf_pkg is
   -- ########################### Functions ################################################################
   function clogb2     (bit_depth : integer) return integer;
 
-  function getDirSCRIPT return string;
-
   function to_bstring(sl : std_logic) return string;
 
   function to_bstring(slv : std_logic_vector) return string;
@@ -190,21 +188,6 @@ package body tf_pkg is
   function clogb2 (bit_depth : integer) return integer is
   begin
     return integer( ceil( log2( real( bit_depth ) ) ) );
-  end;
-
-
-  --! @brief Returns directory path to script/
-  function getDirSCRIPT return string is
-  begin
-    if IS_SIMULATION then
-      -- Sim path specified relative to Vivado project's xsim directory. 
-      -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/
-      return "../../../../../";
-    else
-      -- Synth path specified relative to dir where you run Vivado.
-      -- e.g. IntegrationTests/PRMEMC/script/Work/Work.runs/synth_1/
-      return "../../../";
-    end if;
   end;
 
   function to_bstring(sl : std_logic) return string is

--- a/IntegrationTests/common/script/synth.tcl
+++ b/IntegrationTests/common/script/synth.tcl
@@ -21,6 +21,9 @@ reset_run synth_1
 # Needed if design doesn't connect to I/O pins of FPGA.
 set_property -name {STEPS.SYNTH_DESIGN.ARGS.MORE OPTIONS} -value {-mode out_of_context} -objects [get_runs synth_1]
 
+# Run pre.tcl if it exists
+set_property -name {STEPS.SYNTH_DESIGN.TCL.PRE} -value [get_files pre.tcl -of [get_fileset utils_1]] -objects [get_runs synth_1]
+
 # Synthesis
 update_compile_order -fileset sources_1
 launch_runs synth_1 -jobs 4


### PR DESCRIPTION
This PR introduces pre-simulation and pre-synthesis scripts to copy the appropriate LUTs/ directory into the Vivado project directory. This makes it easier to reference the LUTs/ directory, especially when working in a framework such as EMP, since there are no relative paths to deal with.

This PR is dependent on cms-L1TK/project_generation_scripts#47 , which is already merged.