### PR TITLE
CompareMemWithFile Fix for FutureSW

### DIFF
--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -142,8 +142,13 @@ unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
   constexpr int msb = (LSB >= 0 && MSB >= LSB) ? MSB : MemType::getWidth() - 1;
 
   for (unsigned int i = 0; i < memory_ref.getDepth(); ++i) {
+#ifdef CMSSW_GIT_HASH
+    auto data_ref = memory_ref.read_mem(ievt,i).raw();
+    auto data_com = memory.read_mem(ievt,i).raw();
+#else
     auto data_ref = memory_ref.read_mem(ievt,i).raw().range(msb,lsb);
     auto data_com = memory.read_mem(ievt,i).raw().range(msb,lsb);
+#endif
     if (i==0) {
       // If both reference and computed memories are completely empty, skip it
       if (data_com == 0 && data_ref == 0) break;


### PR DESCRIPTION
This change edits the FileReadUtility.h function compareMemWithFile to remove the range function from the reference and computed bitstrings. In CMSSW the range function has been seen to cause odd behavior and leads to memories appearing blank during memory checking. This is solved by using an ifdef CMSSW_GIT_HASH statement to remove the range when working in CMSSW. 