### PR TITLE
Update to VU13P

### DIFF
--- a/IntegrationTests/BarrelConfig/IRtoTB/script/makeProject.tcl
+++ b/IntegrationTests/BarrelConfig/IRtoTB/script/makeProject.tcl
@@ -3,7 +3,7 @@
 
 # Create project
 set projName "Work"
-set FPGA "xcvu7p-flvb2104-1-e"
+source common/script/fpga.tcl
 create_project -force ${projName} ./${projName} -part $FPGA
 set_property target_language VHDL [current_project]
 

--- a/IntegrationTests/IRVMR/script/makeProject.tcl
+++ b/IntegrationTests/IRVMR/script/makeProject.tcl
@@ -3,7 +3,7 @@
 
 # Create project
 set projName "Work"
-set FPGA "xcvu7p-flvb2104-1-e"
+source common/script/fpga.tcl
 create_project -force ${projName} ./${projName} -part $FPGA
 set_property target_language VHDL [current_project]
 

--- a/IntegrationTests/PRMEMC/script/makeProject.tcl
+++ b/IntegrationTests/PRMEMC/script/makeProject.tcl
@@ -3,7 +3,7 @@
 
 # Create project
 set projName "Work"
-set FPGA "xcvu7p-flvb2104-1-e"
+source common/script/fpga.tcl
 create_project -force ${projName} ./${projName} -part $FPGA
 set_property target_language VHDL [current_project]
 

--- a/IntegrationTests/ReducedCombinedConfig/script/makeProject.tcl
+++ b/IntegrationTests/ReducedCombinedConfig/script/makeProject.tcl
@@ -3,7 +3,7 @@
 
 # Create project
 set projName "Work"
-set FPGA "xcvu7p-flvb2104-1-e"
+source common/script/fpga.tcl
 create_project -force ${projName} ./${projName} -part $FPGA
 set_property target_language VHDL [current_project]
 

--- a/IntegrationTests/ReducedConfig/IRtoTB/script/makeProject.tcl
+++ b/IntegrationTests/ReducedConfig/IRtoTB/script/makeProject.tcl
@@ -3,7 +3,7 @@
 
 # Create project
 set projName "Work"
-set FPGA "xcvu7p-flvb2104-1-e"
+source common/script/fpga.tcl
 create_project -force ${projName} ./${projName} -part $FPGA
 set_property target_language VHDL [current_project]
 

--- a/IntegrationTests/ReducedConfig/MCTB/script/makeProject.tcl
+++ b/IntegrationTests/ReducedConfig/MCTB/script/makeProject.tcl
@@ -3,7 +3,7 @@
 
 # Create project
 set projName "Work"
-set FPGA "xcvu7p-flvb2104-1-e"
+source common/script/fpga.tcl
 create_project -force ${projName} ./${projName} -part $FPGA
 set_property target_language VHDL [current_project]
 

--- a/IntegrationTests/TETC/script/makeProject.tcl
+++ b/IntegrationTests/TETC/script/makeProject.tcl
@@ -3,7 +3,7 @@
 
 # Create project
 set projName "Work"
-set FPGA "xcvu7p-flvb2104-1-e"
+source common/script/fpga.tcl
 create_project -force ${projName} ./${projName} -part $FPGA
 set_property target_language VHDL [current_project]
 

--- a/project/settings_hls.tcl
+++ b/project/settings_hls.tcl
@@ -12,16 +12,17 @@ config_compile -name_max_length 100
 # Set clock frequency
 create_clock -period 250MHz -name default
 
+# Set FPGA variable with part number
+source ../IntegrationTests/common/script/fpga.tcl
+
 switch -glob -- $exe {
     *vitis* {
         # Set the FPGA part number
-        set_part {xcvu7p-flvb2104-1-e}
+        set_part $FPGA
     }
     default {
         # Set the FPGA part number
-        set_part {xcvu7p-flvb2104-1-e} -tool vivado
-        #set_part {xcku115-flvb2104-1-e} -tool vivado
-        #set_part {xcvu9p-flgc2104-1-e} -tool vivado
+        set_part $FPGA -tool vivado
 
         # Remove variables from IP interface if they are never used by HLS algo.
         config_interface -trim_dangling_port


### PR DESCRIPTION
This PR updates the default part number to a VU13P.

It also moves the part number to a single file, to be used by both HLS and Vivado, for consistency.