### PR TITLE
Trackmerger nostream

### DIFF
--- a/TestBenches/TrackMerger_test.cpp
+++ b/TestBenches/TrackMerger_test.cpp
@@ -39,7 +39,7 @@ int main(){
 
   auto &fout_outputTracks = tb.files("old_CleanTrack_CT_L1L2*"); // use CleanTrack_CT_L1L2_04.dat when tracks have been merged or if no merge make a copy e.g. output_TrackFit_TF_L1L2*
   // Loop over events
-  for (unsigned int ievt = 0; ievt < nevents; ++ievt) { //nevents
+  for (unsigned int ievt = 0; ievt < nevents; ++ievt) { 
     cout << "Event: " << dec << ievt << endl;
     
     for (unsigned short i = 0; i < kMaxTrack; ++i){

--- a/TestBenches/TrackMerger_test.cpp
+++ b/TestBenches/TrackMerger_test.cpp
@@ -30,14 +30,14 @@ int main(){
   TrackFitType::DiskStubWord diskStubWords_o[kMaxTrack][4];
   TrackFitMemory<NBarrelStub, NDiskStub> outputTracks;
   // int outputNumber;
-
+ 
   TBHelper tb("../../../../../emData/PD/PD/");
 
   // Open input files
-  auto &fin_inputTracks = tb.files("old_TrackFit_TF_L1L2*");
+  auto &fin_inputTracks = tb.files("TrackFit_TF_L1L2*");
 
 
-  auto &fout_outputTracks = tb.files("old_CleanTrack_CT_L1L2*"); // use CleanTrack_CT_L1L2_04.dat when tracks have been merged or if no merge make a copy e.g. output_TrackFit_TF_L1L2*
+  auto &fout_outputTracks = tb.files("CleanTrack_CT_L1L2*"); // use CleanTrack_CT_L1L2_04.dat when tracks have been merged or if no merge make a copy e.g. output_TrackFit_TF_L1L2*
   // Loop over events
   for (unsigned int ievt = 0; ievt < nevents; ++ievt) { 
     cout << "Event: " << dec << ievt << endl;
@@ -111,10 +111,12 @@ int main(){
       
       outputTracks.write_mem(bx, track, nTracks );
       ++nTracks;
+      
     } 
 
     // Comparing outputs
     err_count += compareMemWithFile<TrackFitMemory<NBarrelStub, NDiskStub>>(outputTracks, fout_outputTracks.at(0), ievt, "Tracks", truncation);
+    outputTracks.clear();
     
   }
 

--- a/TestBenches/TrackMerger_test.cpp
+++ b/TestBenches/TrackMerger_test.cpp
@@ -37,8 +37,7 @@ int main(){
   auto &fin_inputTracks = tb.files("TrackFit_TF_L1L2*");
 
 
-  auto &fout_outputTracks = tb.files("CleanTrack_CT_L1L2*"); // use CleanTrack_CT_L1L2_04.dat when tracks have been merged or if no merge make a copy e.g. output_TrackFit_TF_L1L2*
-  // Loop over events
+  auto &fout_outputTracks = tb.files("CleanTrack_CT_L1L2*"); 
   for (unsigned int ievt = 0; ievt < nevents; ++ievt) { 
     cout << "Event: " << dec << ievt << endl;
     
@@ -116,10 +115,9 @@ int main(){
 
     // Comparing outputs
     err_count += compareMemWithFile<TrackFitMemory<NBarrelStub, NDiskStub>>(outputTracks, fout_outputTracks.at(0), ievt, "Tracks", truncation);
-    outputTracks.clear();
     
   }
-
+  // Commented as f/w does not match the s/w - implementations are different so test vectors are different, TB fails.
   // Handling case of err%256 == 0 
   // if (err_count > 255) err_count = 255;
   // return err_count;

--- a/TestBenches/TrackMerger_test.cpp
+++ b/TestBenches/TrackMerger_test.cpp
@@ -67,13 +67,11 @@ int main(){
     for(unsigned short i = 0; i < kMaxTrack; i++){
       TrackFitType track;
       if (i < inputTracks.getEntries(bx)) {
-      track = inputTracks.read_mem(bx, i+1); //i+1 for merge
+      track = inputTracks.read_mem(bx, i);
       } else {
         track = TrackFitType();
       } 
-      // std::cout << "tbIn TrkWrd: " << std::hex << track.getTrackWord() << std::endl;
       trackWord[i] = track.getTrackWord();
-      // std::cout << "tbTrkSet: " << std::hex << trackWord[i] << std::endl;
       barrelStubWords[i][0] = track.getBarrelStubWord<0>();
       barrelStubWords[i][1] = track.getBarrelStubWord<1>();
       barrelStubWords[i][2] = track.getBarrelStubWord<2>();

--- a/TestBenches/TrackMerger_test.cpp
+++ b/TestBenches/TrackMerger_test.cpp
@@ -13,35 +13,22 @@
 const int nevents = 100;
 
 using namespace std;
-using namespace hls;
 
 int main(){
   //Error counter
   int err_count = 0;
     
   // Input memories
-  stream<TrackFitType::TrackWord> trackWord("input_stream_1");
-  static stream<TrackFitType::BarrelStubWord> barrelStubWords_0("input_stream_2");
-  static stream<TrackFitType::BarrelStubWord> barrelStubWords_1("input_stream_3");
-  static stream<TrackFitType::BarrelStubWord> barrelStubWords_2("input_stream_4");
-  static stream<TrackFitType::BarrelStubWord> barrelStubWords_3("input_stream_5");
-  static stream<TrackFitType::DiskStubWord> diskStubWords_0("input_stream_6");
-  static stream<TrackFitType::DiskStubWord> diskStubWords_1("input_stream_7");
-  static stream<TrackFitType::DiskStubWord> diskStubWords_2("input_stream_8");
-  static stream<TrackFitType::DiskStubWord> diskStubWords_3("input_stream_9");
-  static TrackFitMemory<NBarrelStub, NDiskStub> inputTracks;
+  TrackFitType::TrackWord trackWord[kMaxTrack];
+  TrackFitType::BarrelStubWord barrelStubWords[kMaxTrack][4];
+  TrackFitType::DiskStubWord diskStubWords[kMaxTrack][4];
+  TrackFitMemory<NBarrelStub, NDiskStub> inputTracks;
 
   // Output memories
-  stream<TrackFitType::TrackWord> trackWord_o("output_stream_1");
-  static stream<TrackFitType::BarrelStubWord> barrelStubWords_0_o("output_stream_2");
-  static stream<TrackFitType::BarrelStubWord> barrelStubWords_1_o("output_stream_3");
-  static stream<TrackFitType::BarrelStubWord> barrelStubWords_2_o("output_stream_4");
-  static stream<TrackFitType::BarrelStubWord> barrelStubWords_3_o("output_stream_5");
-  static stream<TrackFitType::DiskStubWord> diskStubWords_0_o("output_stream_6");
-  static stream<TrackFitType::DiskStubWord> diskStubWords_1_o("output_stream_7");
-  static stream<TrackFitType::DiskStubWord> diskStubWords_2_o("output_stream_8");
-  static stream<TrackFitType::DiskStubWord> diskStubWords_3_o("output_stream_9");
-  static TrackFitMemory<NBarrelStub, NDiskStub> outputTracks;
+  TrackFitType::TrackWord trackWord_o[kMaxTrack];
+  TrackFitType::BarrelStubWord barrelStubWords_o[kMaxTrack][4];
+  TrackFitType::DiskStubWord diskStubWords_o[kMaxTrack][4];
+  TrackFitMemory<NBarrelStub, NDiskStub> outputTracks;
   // int outputNumber;
 
   TBHelper tb("../../../../../emData/PD/PD/");
@@ -52,9 +39,23 @@ int main(){
 
   auto &fout_outputTracks = tb.files("old_CleanTrack_CT_L1L2*"); // use CleanTrack_CT_L1L2_04.dat when tracks have been merged or if no merge make a copy e.g. output_TrackFit_TF_L1L2*
   // Loop over events
-  for (unsigned int ievt = 0; ievt < nevents; ++ievt) {
+  for (unsigned int ievt = 0; ievt < nevents; ++ievt) { //nevents
     cout << "Event: " << dec << ievt << endl;
     
+    for (unsigned short i = 0; i < kMaxTrack; ++i){
+      trackWord[i] = TrackFitType::TrackWord(0);
+      trackWord_o[i] = TrackFitType::TrackWord(0);
+
+      for (unsigned short nStub = 0; nStub < 4; nStub++){
+        barrelStubWords[i][nStub] = TrackFitType::BarrelStubWord(0);
+        diskStubWords[i][nStub] = TrackFitType::DiskStubWord(0);
+        barrelStubWords_o[i][nStub] = TrackFitType::BarrelStubWord(0);
+        diskStubWords_o[i][nStub] = TrackFitType::DiskStubWord(0);
+      }
+    }
+
+    outputTracks.clear();
+
     // Read in next event from input
     writeMemFromFile<TrackFitMemory<NBarrelStub, NDiskStub>> (inputTracks, fin_inputTracks.at(0), ievt);
     
@@ -66,59 +67,49 @@ int main(){
     for(unsigned short i = 0; i < kMaxTrack; i++){
       TrackFitType track;
       if (i < inputTracks.getEntries(bx)) {
-        track = inputTracks.read_mem(bx, i+1); //i+1 for merge
+      track = inputTracks.read_mem(bx, i+1); //i+1 for merge
       } else {
         track = TrackFitType();
-      }
-      trackWord << track.getTrackWord();
-      barrelStubWords_0 << track.getBarrelStubWord<0>();
-      barrelStubWords_1 << track.getBarrelStubWord<1>();
-      barrelStubWords_2 << track.getBarrelStubWord<2>();
-      barrelStubWords_3 << track.getBarrelStubWord<3>();
-      diskStubWords_0 << track.getDiskStubWord<4>();
-      diskStubWords_1 << track.getDiskStubWord<5>();
-      diskStubWords_2 << track.getDiskStubWord<6>();
-      diskStubWords_3 << track.getDiskStubWord<7>();
+      } 
+      // std::cout << "tbIn TrkWrd: " << std::hex << track.getTrackWord() << std::endl;
+      trackWord[i] = track.getTrackWord();
+      // std::cout << "tbTrkSet: " << std::hex << trackWord[i] << std::endl;
+      barrelStubWords[i][0] = track.getBarrelStubWord<0>();
+      barrelStubWords[i][1] = track.getBarrelStubWord<1>();
+      barrelStubWords[i][2] = track.getBarrelStubWord<2>();
+      barrelStubWords[i][3] = track.getBarrelStubWord<3>();
+      diskStubWords[i][0] = track.getDiskStubWord<4>();
+      diskStubWords[i][1] = track.getDiskStubWord<5>();
+      diskStubWords[i][2] = track.getDiskStubWord<6>();
+      diskStubWords[i][3] = track.getDiskStubWord<7>();
     }
 
     // Unit under test
     TrackMergerTop(bx,
     trackWord,
-    barrelStubWords_0, 
-    barrelStubWords_1,
-    barrelStubWords_2,
-    barrelStubWords_3,
-    diskStubWords_0,
-    diskStubWords_1,
-    diskStubWords_2,
-    diskStubWords_3,
+    barrelStubWords,
+    diskStubWords,
     bx_o,
     trackWord_o,
-    barrelStubWords_0_o,
-    barrelStubWords_1_o,
-    barrelStubWords_2_o,
-    barrelStubWords_3_o,
-    diskStubWords_0_o,
-    diskStubWords_1_o,
-    diskStubWords_2_o, 
-    diskStubWords_3_o
+    barrelStubWords_o,
+    diskStubWords_o
     );
 
     bool truncation = false;
 
     // Filling outputs
     unsigned nTracks = 0;
-    for (unsigned short i = 0; i < kMaxTrack+kNComparisonModules; i++){ //first 16 CMs don't appear in output first if outputting unmerged tracks first
+    for (unsigned short i = 0; i < kMaxTrack; i++){ 
       TrackFitType track;
-      track.setTrackWord(trackWord_o.read());
-      track.setBarrelStubWord<0>(barrelStubWords_0_o.read());
-      track.setBarrelStubWord<1>(barrelStubWords_1_o.read());
-      track.setBarrelStubWord<2>(barrelStubWords_2_o.read());
-      track.setBarrelStubWord<3>(barrelStubWords_3_o.read());
-      track.setDiskStubWord<4>(diskStubWords_0_o.read());
-      track.setDiskStubWord<5>(diskStubWords_1_o.read());
-      track.setDiskStubWord<6>(diskStubWords_2_o.read());
-      track.setDiskStubWord<7>(diskStubWords_3_o.read());
+      track.setTrackWord(trackWord_o[i]);
+      track.setBarrelStubWord<0>(barrelStubWords_o[i][0]);
+      track.setBarrelStubWord<1>(barrelStubWords_o[i][1]);
+      track.setBarrelStubWord<2>(barrelStubWords_o[i][2]);
+      track.setBarrelStubWord<3>(barrelStubWords_o[i][3]);
+      track.setDiskStubWord<4>(diskStubWords_o[i][0]);
+      track.setDiskStubWord<5>(diskStubWords_o[i][1]);
+      track.setDiskStubWord<6>(diskStubWords_o[i][2]);
+      track.setDiskStubWord<7>(diskStubWords_o[i][3]);
       
       outputTracks.write_mem(bx, track, nTracks );
       ++nTracks;
@@ -126,7 +117,6 @@ int main(){
 
     // Comparing outputs
     err_count += compareMemWithFile<TrackFitMemory<NBarrelStub, NDiskStub>>(outputTracks, fout_outputTracks.at(0), ievt, "Tracks", truncation);
-    
     
   }
 

--- a/TopFunctions/TrackMergerTop.cc
+++ b/TopFunctions/TrackMergerTop.cc
@@ -1,34 +1,28 @@
 #include "TrackMergerTop.h"
 
 void TrackMergerTop(const BXType bx,
-  stream<TrackFitType::TrackWord> &trackWord,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_0,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_1,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_2,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_3,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_0,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_1,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_2,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_3,
+  const TrackFitType::TrackWord trackWord[kMaxTrack],
+  const TrackFitType::BarrelStubWord barrelStubWords[kMaxTrack][NBarrelStub],
+  const TrackFitType::DiskStubWord diskStubWords[kMaxTrack][NDiskStub],
   BXType bx_o,
-  stream<TrackFitType::TrackWord> &trackWord_o,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_0_o, 
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_1_o, 
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_2_o, 
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_3_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_0_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_1_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_2_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_3_o
+  TrackFitType::TrackWord (&trackWord_o)[kMaxTrack],
+  TrackFitType::BarrelStubWord (&barrelStubWords_o)[kMaxTrack][NBarrelStub],
+  TrackFitType::DiskStubWord (&diskStubWords_o)[kMaxTrack][NDiskStub]
   ){
     #pragma HLS inline recursive
-    TrackMerger(bx, trackWord, 
-      barrelStubWords_0, 
-      barrelStubWords_1, barrelStubWords_2, barrelStubWords_3,
-      diskStubWords_0, diskStubWords_1, diskStubWords_2, diskStubWords_3, 
-      bx_o, 
-      trackWord_o, 
-      barrelStubWords_0_o, barrelStubWords_1_o, barrelStubWords_2_o, barrelStubWords_3_o, 
-      diskStubWords_0_o, diskStubWords_1_o, diskStubWords_2_o, diskStubWords_3_o 
-    );
+    #pragma HLS stream variable=trackWord
+    #pragma HLS stream variable=barrelStubWords
+    #pragma HLS stream variable=diskStubWords
+    #pragma HLS stream variable=trackWord_o
+    #pragma HLS stream variable=barrelStubWords_o
+    #pragma HLS stream variable=diskStubWords_o
+
+    TrackMerger(bx,
+                trackWord,
+                barrelStubWords,
+                diskStubWords,
+                bx_o,
+                trackWord_o,
+                barrelStubWords_o,
+                diskStubWords_o);
 }

--- a/TopFunctions/TrackMergerTop.h
+++ b/TopFunctions/TrackMergerTop.h
@@ -1,30 +1,17 @@
 #ifndef TrackletAlgorithm_TrackMergerTop_h
 #define TrackletAlgorithm_TrackMergerTop_h
 
-#include "hls_stream.h"
 #include "../TrackletAlgorithm/TrackMerger.h"
 #include "../TrackletAlgorithm/TrackHandler.h"
 
 void TrackMergerTop(const BXType bx,
-  stream<TrackFitType::TrackWord> &trackWord,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_0,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_1,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_2,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_3,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_0,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_1,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_2,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_3,
+  const TrackFitType::TrackWord trackWord[kMaxTrack],
+  const TrackFitType::BarrelStubWord barrelStubWords[kMaxTrack][NBarrelStub],
+  const TrackFitType::DiskStubWord diskStubWords[kMaxTrack][NDiskStub],
   BXType bx_o,
-  stream<TrackFitType::TrackWord> &trackWord_o,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_0_o, 
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_1_o, 
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_2_o, 
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_3_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_0_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_1_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_2_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_3_o
-);
+  TrackFitType::TrackWord (&trackWord_o)[kMaxTrack],
+  TrackFitType::BarrelStubWord (&barrelStubWords_o)[kMaxTrack][NBarrelStub],
+  TrackFitType::DiskStubWord (&diskStubWords_o)[kMaxTrack][NDiskStub]
+  );
 
 #endif

--- a/TrackletAlgorithm/TrackHandler.cc
+++ b/TrackletAlgorithm/TrackHandler.cc
@@ -2,22 +2,24 @@
 
 bool TrackHandler::compareTrack(const TrackStruct &trk, TrackStruct &masterTrk, unsigned int& matchFound, unsigned int mergeCondition){
   // Compare the two tracks, masterTrack and trk
-  unsigned int matchesFoundBarrel = 0;
-  unsigned int matchesFoundDisk = 0;
-
-  for (unsigned int barrelStubNum = 0; barrelStubNum < NBarrelStub; barrelStubNum++){
+  #pragma HLS array_partition variable=matchesFoundBarrel complete dim=0
+  #pragma HLS array_partition variable=matchesFoundDisk complete dim=0
+  #pragma HLS array_partition variable=masterTrk._barrelStubArray complete dim=0
+  #pragma HLS array_partition variable=trk._barrelStubArray complete dim=0
+  #pragma HLS array_partition variable=masterTrk._diskStubArray complete dim=0
+  #pragma HLS array_partition variable=trk._diskStubArray complete dim=0
+  LOOP_CompareStubs:
+  for (unsigned int layerIndex = 0; layerIndex < 4; layerIndex++){
     #pragma HLS unroll
-    auto masterBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._barrelStubArray[barrelStubNum][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
-    auto inputBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._barrelStubArray[barrelStubNum][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
+    ap_uint<TrackFitType::kTFStubIndexSize> masterBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._barrelStubArray[layerIndex][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
+    ap_uint<TrackFitType::kTFStubIndexSize> inputBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._barrelStubArray[layerIndex][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
+    ap_uint<TrackFitType::kTFStubIndexSize> masterDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._diskStubArray[layerIndex][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
+    ap_uint<TrackFitType::kTFStubIndexSize> inputDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._diskStubArray[layerIndex][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
 
-    if ((masterBarrelStubIndex == inputBarrelStubIndex) && (masterBarrelStubIndex > 0)) matchesFoundBarrel++;
-  }
-  LOOP_CompareTrackDisk:
-  for (unsigned int diskStubNum = 0; diskStubNum < NDiskStub; diskStubNum++){ 
-    #pragma HLS unroll
-    auto masterDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._diskStubArray[diskStubNum][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
-    auto inputDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._diskStubArray[diskStubNum][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
-    if((masterDiskStubIndex == inputDiskStubIndex) && (masterDiskStubIndex > 0)) matchesFoundDisk++;
+    ((masterBarrelStubIndex == inputBarrelStubIndex) && (masterBarrelStubIndex > 0)) ? matchesFoundBarrel[layerIndex][0] = 1 : matchesFoundBarrel[layerIndex][0] = 0;
+
+    ((masterDiskStubIndex == inputDiskStubIndex) && (masterDiskStubIndex > 0)) ? matchesFoundDisk[layerIndex][0] = 1 : matchesFoundDisk[layerIndex][0] = 0;
+    
   }
 
   // Update #matches found 
@@ -25,7 +27,7 @@ bool TrackHandler::compareTrack(const TrackStruct &trk, TrackStruct &masterTrk, 
   LOOP_MatchesFound:
   for (unsigned int layerIndex = 0; layerIndex < 4; layerIndex++){
     #pragma HLS unroll
-    matchesFound += matchesFoundBarrel + matchesFoundDisk;
+    matchesFound += matchesFoundBarrel[layerIndex][0] + matchesFoundDisk[layerIndex][0];
   }
   (matchesFound >= mergeCondition) ? matchFound = 1 : matchFound = 0; 
 
@@ -33,6 +35,10 @@ bool TrackHandler::compareTrack(const TrackStruct &trk, TrackStruct &masterTrk, 
 }
 
 void TrackHandler::mergeTrack(const TrackStruct &trk, TrackStruct &masterTrk){
+  #pragma HLS array_partition variable=masterTrk._barrelStubArray complete dim=0
+  #pragma HLS array_partition variable=trk._barrelStubArray complete dim=0
+  #pragma HLS array_partition variable=masterTrk._diskStubArray complete dim=0
+  #pragma HLS array_partition variable=trk._diskStubArray complete dim=0
   // Update master track
   // Check whether the stub word is non-zero in the compared track
   // Then add stub into master track if share > 3 stubs in common
@@ -56,18 +62,16 @@ void TrackHandler::mergeTrack(const TrackStruct &trk, TrackStruct &masterTrk){
   totalHitMap = mergedBarrelStubsMap + mergedDiskStubsMap;
   masterTrk._trackWord | totalHitMap;
   LOOP_BarrelStubs:
-  for (unsigned int barrelStubNum = 0; barrelStubNum < NBarrelStub; barrelStubNum++){  
-    #pragma HLS unroll 
+  for (unsigned int barrelStubNum = 0; barrelStubNum < NBarrelStub; barrelStubNum++){ 
+    #pragma HLS unroll
     LOOP_MergeBarrelStubs:
     for (unsigned int barrelStubIndex = 1; barrelStubIndex < layerStubIndexSize; barrelStubIndex++){
-      #pragma HLS unroll
-      #pragma HLS loop_flatten
+       #pragma HLS loop_flatten
       if((masterTrk._barrelStubArray[barrelStubNum][barrelStubIndex] == 0) && (trk._barrelStubArray[barrelStubNum][barrelStubIndex] != 0)){
         masterTrk._barrelStubArray[barrelStubNum][barrelStubIndex] = trk._barrelStubArray[barrelStubNum][barrelStubIndex];
       } else {
         LOOP_BitIndexBarrel:
         for (int bitIndex = 0; bitIndex < TrackFitType::kBarrelStubSize; bitIndex++){
-          #pragma HLS unroll
           masterTrk._barrelStubArray[barrelStubNum][barrelStubIndex] = trk._barrelStubArray[barrelStubNum][barrelStubIndex] | (stubPadding << bitIndex);
         }
       }
@@ -75,17 +79,15 @@ void TrackHandler::mergeTrack(const TrackStruct &trk, TrackStruct &masterTrk){
   }
   LOOP_DiskStubs:
   for (unsigned int diskStubNum = 0; diskStubNum < NDiskStub; diskStubNum++){
-    #pragma HLS unroll 
+    #pragma HLS unroll
     LOOP_MergeDiskStubs:
     for (unsigned int diskStubIndex = 1; diskStubIndex < layerStubIndexSize; diskStubIndex++){
-      #pragma HLS unroll
       #pragma HLS loop_flatten
       if((masterTrk._diskStubArray[diskStubNum][diskStubIndex] == 0) && (trk._diskStubArray[diskStubNum][diskStubIndex] != 0)){
         masterTrk._diskStubArray[diskStubNum][diskStubIndex] = trk._diskStubArray[diskStubNum][diskStubIndex];
       } else {
         LOOP_BitIndexDisk:
         for (int bitIndex = 0; bitIndex < TrackFitType::kDiskStubSize; bitIndex++){
-          #pragma HLS unroll
           masterTrk._diskStubArray[diskStubNum][diskStubIndex] = masterTrk._diskStubArray[diskStubNum][diskStubIndex] | (stubPadding << bitIndex);
 
         }

--- a/TrackletAlgorithm/TrackHandler.cc
+++ b/TrackletAlgorithm/TrackHandler.cc
@@ -14,16 +14,14 @@ bool TrackHandler::compareTrack(const TrackStruct &trk, TrackStruct &masterTrk, 
     ap_uint<TrackFitType::kTFStubIndexSize> masterBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._barrelStubArray[barrelStubNum][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
     ap_uint<TrackFitType::kTFStubIndexSize> inputBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._barrelStubArray[barrelStubNum][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
     
-    ((masterBarrelStubIndex == inputBarrelStubIndex) && (masterBarrelStubIndex > 0)) ? matchesFoundBarrel[barrelStubNum][0] = 1 : matchesFoundBarrel[barrelStubNum][0] = 0;
-  }
+    matchesFoundBarrel[barrelStubNum][0] = ((masterBarrelStubIndex == inputBarrelStubIndex) && (masterBarrelStubIndex > 0)) ?  1 : 0;  }
   LOOP_CompareDiskStubs:
   for (unsigned int diskStubNum = 0; diskStubNum < NDiskStub; diskStubNum++){
     #pragma HLS unroll
     ap_uint<TrackFitType::kTFStubIndexSize> masterDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._diskStubArray[diskStubNum][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
     ap_uint<TrackFitType::kTFStubIndexSize> inputDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._diskStubArray[diskStubNum][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
 
-    ((masterDiskStubIndex == inputDiskStubIndex) && (masterDiskStubIndex > 0)) ? matchesFoundDisk[diskStubNum][0] = 1 : matchesFoundDisk[diskStubNum][0] = 0;
-    
+    matchesFoundDisk[diskStubNum][0] = ((masterDiskStubIndex == inputDiskStubIndex) && (masterDiskStubIndex > 0)) ?  1 : 0;    
   }
 
   // Update #matches found 
@@ -33,7 +31,7 @@ bool TrackHandler::compareTrack(const TrackStruct &trk, TrackStruct &masterTrk, 
     #pragma HLS unroll
     matchesFound += matchesFoundBarrel[layerIndex][0] + matchesFoundDisk[layerIndex][0];
   }
-  (matchesFound >= mergeCondition) ? matchFound = 1 : matchFound = 0; 
+  matchFound = (matchesFound >= mergeCondition) ? 1 : 0;
 
   return matchFound;
 }
@@ -51,7 +49,7 @@ void TrackHandler::mergeTrack(const TrackStruct &trk, TrackStruct &masterTrk){
     #pragma HLS unroll
     if((masterTrk._barrelStubArray[barrelStubNum][0] == 0) && (trk._barrelStubArray[barrelStubNum][0] != 0)){
       masterTrk._barrelStubArray[barrelStubNum][0] = trk._barrelStubArray[barrelStubNum][0];
-      mergedBarrelStubsMap | (1 << TrackFitType::kTFHitCountSize*barrelStubNum);
+      mergedBarrelStubsMap = mergedBarrelStubsMap | (1 << TrackFitType::kTFHitCountSize*barrelStubNum);
     }
   }
   LOOP_SetInputDiskStubToMaster:
@@ -59,7 +57,7 @@ void TrackHandler::mergeTrack(const TrackStruct &trk, TrackStruct &masterTrk){
     #pragma HLS unroll
     if((masterTrk._diskStubArray[diskStubNum][0] == 0) && (trk._diskStubArray[diskStubNum][0] !=0 )){
       masterTrk._diskStubArray[diskStubNum][0] = trk._diskStubArray[diskStubNum][0];
-      mergedDiskStubsMap | (1 << TrackFitType::kTFHitCountSize*diskStubNum);
+      mergedDiskStubsMap = mergedDiskStubsMap | (1 << TrackFitType::kTFHitCountSize*diskStubNum);
     }
   }
 

--- a/TrackletAlgorithm/TrackHandler.cc
+++ b/TrackletAlgorithm/TrackHandler.cc
@@ -1,57 +1,47 @@
 #include "TrackHandler.h"
 
-bool TrackHandler::compareTrack(TrackStruct& trk, TrackStruct& masterTrk, unsigned int& matchFound, unsigned int mergeCondition){
-  // compare the two tracks, masterTrack and trk
-  LOOP_CompareTrackBarrel:
+bool TrackHandler::compareTrack(const TrackStruct &trk, TrackStruct &masterTrk, unsigned int& matchFound, unsigned int mergeCondition){
+  // Compare the two tracks, masterTrack and trk
+  unsigned int matchesFoundBarrel = 0;
+  unsigned int matchesFoundDisk = 0;
+
   for (unsigned int barrelStubNum = 0; barrelStubNum < NBarrelStub; barrelStubNum++){
     #pragma HLS unroll
     auto masterBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._barrelStubArray[barrelStubNum][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
     auto inputBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._barrelStubArray[barrelStubNum][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
 
-    if((masterBarrelStubIndex == inputBarrelStubIndex) && (masterBarrelStubIndex > 0)){
-      matchesFoundBarrel[barrelStubNum][0] = 1;
-    } else {
-      matchesFoundBarrel[barrelStubNum][0] = 0;
-    }
+    if ((masterBarrelStubIndex == inputBarrelStubIndex) && (masterBarrelStubIndex > 0)) matchesFoundBarrel++;
   }
   LOOP_CompareTrackDisk:
-  for (unsigned int diskStubNum = 0; diskStubNum < NDiskStub; diskStubNum++){
-    #pragma HLS unroll  
+  for (unsigned int diskStubNum = 0; diskStubNum < NDiskStub; diskStubNum++){ 
+    #pragma HLS unroll
     auto masterDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._diskStubArray[diskStubNum][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
     auto inputDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._diskStubArray[diskStubNum][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
-    if ((masterDiskStubIndex == inputDiskStubIndex) && (masterDiskStubIndex > 0)){
-      matchesFoundDisk[diskStubNum][0] = 1;
-    } else {
-      matchesFoundDisk[diskStubNum][0] = 0;
-    }
+    if((masterDiskStubIndex == inputDiskStubIndex) && (masterDiskStubIndex > 0)) matchesFoundDisk++;
   }
 
-  // update #matches found 
+  // Update #matches found 
   unsigned int matchesFound = 0;
   LOOP_MatchesFound:
   for (unsigned int layerIndex = 0; layerIndex < 4; layerIndex++){
     #pragma HLS unroll
-    matchesFound += matchesFoundBarrel[layerIndex][0] + matchesFoundDisk[layerIndex][0];
+    matchesFound += matchesFoundBarrel + matchesFoundDisk;
   }
-  if (matchesFound >= mergeCondition){
-    matchFound = 1;
-    return matchFound; 
-    } else {
-      matchFound = 0;
-      return matchFound;
-    }
+  (matchesFound >= mergeCondition) ? matchFound = 1 : matchFound = 0; 
+
+  return matchFound;
 }
 
-void TrackHandler::mergeTrack(TrackStruct& trk, TrackStruct& masterTrk){
-  // update master track
-  // check whether the stub word is non-zero in the compared track
-  // then add stub into master track if share > 3 stubs in common
+void TrackHandler::mergeTrack(const TrackStruct &trk, TrackStruct &masterTrk){
+  // Update master track
+  // Check whether the stub word is non-zero in the compared track
+  // Then add stub into master track if share > 3 stubs in common
   LOOP_SetInputBarrelStubToMaster:
   for(unsigned int barrelStubNum = 0; barrelStubNum < NBarrelStub; barrelStubNum++){
     #pragma HLS unroll
     if((masterTrk._barrelStubArray[barrelStubNum][0] == 0) && (trk._barrelStubArray[barrelStubNum][0] != 0)){
       masterTrk._barrelStubArray[barrelStubNum][0] = trk._barrelStubArray[barrelStubNum][0];
-      mergedBarrelStubsMap += (1 << TrackFitType::kTFHitCountSize*barrelStubNum);
+      mergedBarrelStubsMap | (1 << TrackFitType::kTFHitCountSize*barrelStubNum);
     }
   }
   LOOP_SetInputDiskStubToMaster:
@@ -59,18 +49,19 @@ void TrackHandler::mergeTrack(TrackStruct& trk, TrackStruct& masterTrk){
     #pragma HLS unroll
     if((masterTrk._diskStubArray[diskStubNum][0] == 0) && (trk._diskStubArray[diskStubNum][0] !=0 )){
       masterTrk._diskStubArray[diskStubNum][0] = trk._diskStubArray[diskStubNum][0];
-      mergedDiskStubsMap += (1 << TrackFitType::kTFHitCountSize*diskStubNum);
+      mergedDiskStubsMap | (1 << TrackFitType::kTFHitCountSize*diskStubNum);
     }
   }
 
   totalHitMap = mergedBarrelStubsMap + mergedDiskStubsMap;
   masterTrk._trackWord | totalHitMap;
   LOOP_BarrelStubs:
-  for (unsigned int barrelStubNum = 0; barrelStubNum < NBarrelStub; barrelStubNum++){ 
-    #pragma HLS unroll   
+  for (unsigned int barrelStubNum = 0; barrelStubNum < NBarrelStub; barrelStubNum++){  
+    #pragma HLS unroll 
     LOOP_MergeBarrelStubs:
     for (unsigned int barrelStubIndex = 1; barrelStubIndex < layerStubIndexSize; barrelStubIndex++){
       #pragma HLS unroll
+      #pragma HLS loop_flatten
       if((masterTrk._barrelStubArray[barrelStubNum][barrelStubIndex] == 0) && (trk._barrelStubArray[barrelStubNum][barrelStubIndex] != 0)){
         masterTrk._barrelStubArray[barrelStubNum][barrelStubIndex] = trk._barrelStubArray[barrelStubNum][barrelStubIndex];
       } else {
@@ -84,10 +75,11 @@ void TrackHandler::mergeTrack(TrackStruct& trk, TrackStruct& masterTrk){
   }
   LOOP_DiskStubs:
   for (unsigned int diskStubNum = 0; diskStubNum < NDiskStub; diskStubNum++){
-    #pragma HLS unroll
+    #pragma HLS unroll 
     LOOP_MergeDiskStubs:
     for (unsigned int diskStubIndex = 1; diskStubIndex < layerStubIndexSize; diskStubIndex++){
       #pragma HLS unroll
+      #pragma HLS loop_flatten
       if((masterTrk._diskStubArray[diskStubNum][diskStubIndex] == 0) && (trk._diskStubArray[diskStubNum][diskStubIndex] != 0)){
         masterTrk._diskStubArray[diskStubNum][diskStubIndex] = trk._diskStubArray[diskStubNum][diskStubIndex];
       } else {

--- a/TrackletAlgorithm/TrackHandler.cc
+++ b/TrackletAlgorithm/TrackHandler.cc
@@ -8,17 +8,21 @@ bool TrackHandler::compareTrack(const TrackStruct &trk, TrackStruct &masterTrk, 
   #pragma HLS array_partition variable=trk._barrelStubArray complete dim=0
   #pragma HLS array_partition variable=masterTrk._diskStubArray complete dim=0
   #pragma HLS array_partition variable=trk._diskStubArray complete dim=0
-  LOOP_CompareStubs:
-  for (unsigned int layerIndex = 0; layerIndex < 4; layerIndex++){
+  LOOP_CompareBarrelStubs:
+  for (unsigned int barrelStubNum = 0; barrelStubNum < NBarrelStub; barrelStubNum++){
     #pragma HLS unroll
-    ap_uint<TrackFitType::kTFStubIndexSize> masterBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._barrelStubArray[layerIndex][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
-    ap_uint<TrackFitType::kTFStubIndexSize> inputBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._barrelStubArray[layerIndex][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
-    ap_uint<TrackFitType::kTFStubIndexSize> masterDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._diskStubArray[layerIndex][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
-    ap_uint<TrackFitType::kTFStubIndexSize> inputDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._diskStubArray[layerIndex][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
+    ap_uint<TrackFitType::kTFStubIndexSize> masterBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._barrelStubArray[barrelStubNum][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
+    ap_uint<TrackFitType::kTFStubIndexSize> inputBarrelStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._barrelStubArray[barrelStubNum][0].range(kBarrelStubIndexSizeMSB, kBarrelStubIndexSizeLSB));
+    
+    ((masterBarrelStubIndex == inputBarrelStubIndex) && (masterBarrelStubIndex > 0)) ? matchesFoundBarrel[barrelStubNum][0] = 1 : matchesFoundBarrel[barrelStubNum][0] = 0;
+  }
+  LOOP_CompareDiskStubs:
+  for (unsigned int diskStubNum = 0; diskStubNum < NDiskStub; diskStubNum++){
+    #pragma HLS unroll
+    ap_uint<TrackFitType::kTFStubIndexSize> masterDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(masterTrk._diskStubArray[diskStubNum][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
+    ap_uint<TrackFitType::kTFStubIndexSize> inputDiskStubIndex = ap_uint<TrackFitType::kTFStubIndexSize>(trk._diskStubArray[diskStubNum][0].range(kDiskStubIndexSizeMSB, kDiskStubIndexSizeLSB));
 
-    ((masterBarrelStubIndex == inputBarrelStubIndex) && (masterBarrelStubIndex > 0)) ? matchesFoundBarrel[layerIndex][0] = 1 : matchesFoundBarrel[layerIndex][0] = 0;
-
-    ((masterDiskStubIndex == inputDiskStubIndex) && (masterDiskStubIndex > 0)) ? matchesFoundDisk[layerIndex][0] = 1 : matchesFoundDisk[layerIndex][0] = 0;
+    ((masterDiskStubIndex == inputDiskStubIndex) && (masterDiskStubIndex > 0)) ? matchesFoundDisk[diskStubNum][0] = 1 : matchesFoundDisk[diskStubNum][0] = 0;
     
   }
 

--- a/TrackletAlgorithm/TrackHandler.h
+++ b/TrackletAlgorithm/TrackHandler.h
@@ -12,7 +12,7 @@ const unsigned int kBarrelStubIndexSizeMSB = TrackFitType::kTFBarrelStubRSize + 
 const unsigned int kBarrelStubIndexSizeLSB = TrackFitType::kTFBarrelStubRSize + TrackFitType::kTFPhiResidSize + TrackFitType::kTFZResidSize;
 const unsigned int kDiskStubIndexSizeMSB = TrackFitType::kTFDiskStubRSize + TrackFitType::kTFPhiResidSize + TrackFitType::kTFRResidSize + TrackFitType::kTFStubIndexSize;
 const unsigned int kDiskStubIndexSizeLSB = TrackFitType::kTFDiskStubRSize + TrackFitType::kTFPhiResidSize + TrackFitType::kTFRResidSize;
-const unsigned int layerStubIndexSize = 1; // 7 stubs per layer
+const unsigned int layerStubIndexSize = 1; // 4 stubs per layer
 const unsigned int kBarrelStubMap = TrackFitType::kTFHitCountSize * NBarrelStub;
 const unsigned int kDiskStubMap = TrackFitType::kTFHitCountSize * NBarrelStub;
 const unsigned int kTotHitMap = kBarrelStubMap + kDiskStubMap;
@@ -22,6 +22,17 @@ struct TrackStruct {
   TrackFitType::TrackWord _trackWord = 0; 
   TrackFitType::BarrelStubWord _barrelStubArray[NBarrelStub][layerStubIndexSize] = {0}; 
   TrackFitType::DiskStubWord _diskStubArray[NDiskStub][layerStubIndexSize] = {0};
+
+  TrackFitType::TrackWord getTrkWord() const {return _trackWord;};
+  
+  TrackFitType::BarrelStubWord getBarrelStub (unsigned int layerIndex, unsigned int stubIndex) const {
+    return _barrelStubArray[layerIndex][stubIndex];
+  }
+
+  TrackFitType::DiskStubWord getDiskStub (unsigned int layerIndex, unsigned int stubIndex) const {
+    return _diskStubArray[layerIndex][stubIndex];
+  }
+
 };
 
 class TrackHandler {
@@ -30,9 +41,9 @@ class TrackHandler {
     
     ~TrackHandler(){};
 
-    bool compareTrack(TrackStruct& trk, TrackStruct& masterTrk, unsigned int& matchFound, unsigned int mergeCondition);
+    bool compareTrack(const TrackStruct &trk, TrackStruct &masterTrk, unsigned int& matchFound, unsigned int mergeCondition);
 
-    void mergeTrack(TrackStruct& trk, TrackStruct& masterTrk);
+    void mergeTrack(const TrackStruct &trk, TrackStruct &masterTrk);
 
     void setDebugFlag(unsigned int debugFlag){
       debug = debugFlag;
@@ -44,8 +55,8 @@ class TrackHandler {
     ap_uint<1> matchesFoundDisk[NDiskStub][layerStubIndexSize];
     ap_uint<1> stubPadding = 0;
     unsigned int debug = 0;
-    ap_uint<kDiskStubMap> mergedBarrelStubsMap;
-    ap_uint<kBarrelStubMap> mergedDiskStubsMap;
+    ap_uint<kBarrelStubMap> mergedBarrelStubsMap;
+    ap_uint<kDiskStubMap> mergedDiskStubsMap;
     ap_uint<kTotHitMap> totalHitMap;
 };
 

--- a/TrackletAlgorithm/TrackHandler.h
+++ b/TrackletAlgorithm/TrackHandler.h
@@ -12,16 +12,16 @@ const unsigned int kBarrelStubIndexSizeMSB = TrackFitType::kTFBarrelStubRSize + 
 const unsigned int kBarrelStubIndexSizeLSB = TrackFitType::kTFBarrelStubRSize + TrackFitType::kTFPhiResidSize + TrackFitType::kTFZResidSize;
 const unsigned int kDiskStubIndexSizeMSB = TrackFitType::kTFDiskStubRSize + TrackFitType::kTFPhiResidSize + TrackFitType::kTFRResidSize + TrackFitType::kTFStubIndexSize;
 const unsigned int kDiskStubIndexSizeLSB = TrackFitType::kTFDiskStubRSize + TrackFitType::kTFPhiResidSize + TrackFitType::kTFRResidSize;
-const unsigned int layerStubIndexSize = 1; // 4 stubs per layer
+const unsigned int maxNumStubs = 1; // 4 stubs per layer
 const unsigned int kBarrelStubMap = TrackFitType::kTFHitCountSize * NBarrelStub;
 const unsigned int kDiskStubMap = TrackFitType::kTFHitCountSize * NBarrelStub;
 const unsigned int kTotHitMap = kBarrelStubMap + kDiskStubMap;
 
 struct TrackStruct {
   
-  TrackFitType::TrackWord _trackWord = 0; 
-  TrackFitType::BarrelStubWord _barrelStubArray[NBarrelStub][layerStubIndexSize] = {0}; 
-  TrackFitType::DiskStubWord _diskStubArray[NDiskStub][layerStubIndexSize] = {0};
+  TrackFitType::TrackWord _trackWord; 
+  TrackFitType::BarrelStubWord _barrelStubArray[NBarrelStub][maxNumStubs]; 
+  TrackFitType::DiskStubWord _diskStubArray[NDiskStub][maxNumStubs];
 
   TrackFitType::TrackWord getTrkWord() const {return _trackWord;};
   
@@ -32,6 +32,9 @@ struct TrackStruct {
   TrackFitType::DiskStubWord getDiskStub (unsigned int layerIndex, unsigned int stubIndex) const {
     return _diskStubArray[layerIndex][stubIndex];
   }
+
+  void resetTracks();
+
 
 };
 
@@ -51,8 +54,8 @@ class TrackHandler {
 
     
   private:
-    ap_uint<1> matchesFoundBarrel[NBarrelStub][layerStubIndexSize];
-    ap_uint<1> matchesFoundDisk[NDiskStub][layerStubIndexSize];
+    ap_uint<1> matchesFoundBarrel[NBarrelStub][maxNumStubs];
+    ap_uint<1> matchesFoundDisk[NDiskStub][maxNumStubs];
     ap_uint<1> stubPadding = 0;
     unsigned int debug = 0;
     ap_uint<kBarrelStubMap> mergedBarrelStubsMap;

--- a/TrackletAlgorithm/TrackMerger.h
+++ b/TrackletAlgorithm/TrackMerger.h
@@ -10,14 +10,13 @@ const unsigned int kNComparisonModules = 16;
 const unsigned int kNBuffers = kNComparisonModules + 1;
 const unsigned int kMaxTrack = 50;
 const unsigned int kNLastTracks = kMaxTrack - kNComparisonModules;
-using namespace hls;
-
 
 class ComparisonModule{
     public:
     ComparisonModule()
      {  tracksProcessed = 0;
         masterTrack._trackWord = 0;
+
       }
     ~ComparisonModule(){};
 
@@ -29,7 +28,7 @@ class ComparisonModule{
 
     TrackFitType::TrackWord getMasterTrackWord(){return masterTrack._trackWord;}
 
-    void process(TrackStruct &inTrack, TrackStruct &outTrack);
+    void process(const TrackStruct &inTrack, TrackStruct &outTrack);
     
     TrackStruct& getMasterTrackStruct();
 
@@ -44,57 +43,35 @@ class ComparisonModule{
     TrackStruct masterTrack;
     TrackHandler trackHandler;
 
-    void fillUnmerged(TrackStruct& inTrack, TrackStruct* outTrack, unsigned int i);
+    void fillTrackArray(const TrackStruct& inTrack, TrackStruct* outTrack, unsigned int i);
 
     void loadTrack(
-      stream<TrackFitType::TrackWord> &trackWord,
-      stream<TrackFitType::BarrelStubWord> &barrelStubWords_0,
-      stream<TrackFitType::BarrelStubWord> &barrelStubWords_1,
-      stream<TrackFitType::BarrelStubWord> &barrelStubWords_2,
-      stream<TrackFitType::BarrelStubWord> &barrelStubWords_3,
-      stream<TrackFitType::DiskStubWord> &diskStubWords_0,
-      stream<TrackFitType::DiskStubWord> &diskStubWords_1,
-      stream<TrackFitType::DiskStubWord> &diskStubWords_2,
-      stream<TrackFitType::DiskStubWord> &diskStubWords_3,
+      const TrackFitType::TrackWord& trackWordIn,
+      const TrackFitType::BarrelStubWord (&barrelStubWordsIn)[NBarrelStub],
+      const TrackFitType::DiskStubWord (&diskStubWordsIn)[NDiskStub],
       TrackStruct& aTrack
     );
 
     void unloadTrack(
-       TrackStruct& aTrack,
-      stream<TrackFitType::TrackWord> &trackWord_o,
-      stream<TrackFitType::BarrelStubWord> &barrelStubWords_0_o, 
-      stream<TrackFitType::BarrelStubWord> &barrelStubWords_1_o, 
-      stream<TrackFitType::BarrelStubWord> &barrelStubWords_2_o, 
-      stream<TrackFitType::BarrelStubWord> &barrelStubWords_3_o, 
-      stream<TrackFitType::DiskStubWord> &diskStubWords_0_o, 
-      stream<TrackFitType::DiskStubWord> &diskStubWords_1_o, 
-      stream<TrackFitType::DiskStubWord> &diskStubWords_2_o, 
-      stream<TrackFitType::DiskStubWord> &diskStubWords_3_o 
+      TrackStruct& aTrack,
+      TrackFitType::TrackWord& trackWordOut,
+      TrackFitType::BarrelStubWord (&barrelStubWordsOut)[NBarrelStub],  
+      TrackFitType::DiskStubWord (&diskStubWordsOut)[NDiskStub]
     );
+
 
 };
 
 void TrackMerger(const BXType bx,
-  stream<TrackFitType::TrackWord> &trackWord,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_0,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_1,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_2,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_3,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_0,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_1,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_2,
-  stream<TrackFitType::DiskStubWord> &diskStubWords_3,
+  const TrackFitType::TrackWord trackWord[kMaxTrack],
+  const TrackFitType::BarrelStubWord barrelStubWords[kMaxTrack][NBarrelStub],
+  const TrackFitType::DiskStubWord diskStubWords[kMaxTrack][NDiskStub],
   BXType bx_o,
-  stream<TrackFitType::TrackWord> &trackWord_o,
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_0_o, 
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_1_o, 
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_2_o, 
-  stream<TrackFitType::BarrelStubWord> &barrelStubWords_3_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_0_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_1_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_2_o, 
-  stream<TrackFitType::DiskStubWord> &diskStubWords_3_o 
+  TrackFitType::TrackWord (&trackWord_o)[kMaxTrack],
+  TrackFitType::BarrelStubWord (&barrelStubWords_o)[kMaxTrack][NBarrelStub], 
+  TrackFitType::DiskStubWord (&diskStubWords_o)[kMaxTrack][NDiskStub] 
   );
+
 
 
 

--- a/TrackletAlgorithm/TrackMerger.h
+++ b/TrackletAlgorithm/TrackMerger.h
@@ -13,11 +13,7 @@ const unsigned int kNLastTracks = kMaxTrack - kNComparisonModules;
 
 class ComparisonModule{
     public:
-    ComparisonModule()
-     {  tracksProcessed = 0;
-        masterTrack._trackWord = 0;
-
-      }
+    ComparisonModule(){};
     ~ComparisonModule(){};
 
     unsigned int getMatchFound(){return matchFound;}
@@ -32,13 +28,16 @@ class ComparisonModule{
     
     TrackStruct& getMasterTrackStruct();
 
+    void resetCM();
+
+
   private:
 
     unsigned int matchFound{0};
     unsigned int mergeCondition = 3;
-    unsigned int tracksProcessed{0};
     unsigned int endOfStream{0};
     unsigned int endOfModule{0};
+    unsigned int tracksProcessed{0};
 
     TrackStruct masterTrack;
     TrackHandler trackHandler;
@@ -71,8 +70,6 @@ void TrackMerger(const BXType bx,
   TrackFitType::BarrelStubWord (&barrelStubWords_o)[kMaxTrack][NBarrelStub], 
   TrackFitType::DiskStubWord (&diskStubWords_o)[kMaxTrack][NDiskStub] 
   );
-
-
 
 
 #endif

--- a/project/script_TM.tcl
+++ b/project/script_TM.tcl
@@ -18,7 +18,6 @@ source settings_hls.tcl
 
 # data files
 add_files -tb ../emData/PD/
-config_dataflow -scalar_fifo_depth 50
 csim_design -compiler gcc -mflags "-j8"
 csynth_design
 cosim_design 

--- a/project/settings_hls.tcl
+++ b/project/settings_hls.tcl
@@ -12,17 +12,17 @@ config_compile -name_max_length 100
 # Set clock frequency
 create_clock -period 250MHz -name default
 
+# Set FPGA variable with part number
+source fpga.tcl
+
 switch -glob -- $exe {
     *vitis* {
         # Set the FPGA part number
-        set_part {xcvu7p-flvb2104-1-e}
+        set_part $FPGA
     }
     default {
         # Set the FPGA part number
-        set_part {xcvu13p-fsga2577-1-e}
-        #set_part {xcvu7p-flvb2104-1-e} -tool vivado
-        #set_part {xcku115-flvb2104-1-e} -tool vivado
-        #set_part {xcvu9p-flgc2104-1-e} -tool vivado
+        set_part $FPGA -tool vivado
 
         # Remove variables from IP interface if they are never used by HLS algo.
         config_interface -trim_dangling_port

--- a/project/settings_hls.tcl
+++ b/project/settings_hls.tcl
@@ -12,17 +12,16 @@ config_compile -name_max_length 100
 # Set clock frequency
 create_clock -period 250MHz -name default
 
-# Set FPGA variable with part number
-source fpga.tcl
-
 switch -glob -- $exe {
     *vitis* {
         # Set the FPGA part number
-        set_part $FPGA
+        set_part {xcvu7p-flvb2104-1-e}
     }
     default {
         # Set the FPGA part number
-        set_part $FPGA -tool vivado
+        set_part {xcvu7p-flvb2104-1-e} -tool vivado
+        #set_part {xcku115-flvb2104-1-e} -tool vivado
+        #set_part {xcvu9p-flgc2104-1-e} -tool vivado
 
         # Remove variables from IP interface if they are never used by HLS algo.
         config_interface -trim_dangling_port

--- a/project/settings_hls.tcl
+++ b/project/settings_hls.tcl
@@ -19,7 +19,8 @@ switch -glob -- $exe {
     }
     default {
         # Set the FPGA part number
-        set_part {xcvu7p-flvb2104-1-e} -tool vivado
+        set_part {xcvu13p-fsga2577-1-e}
+        #set_part {xcvu7p-flvb2104-1-e} -tool vivado
         #set_part {xcku115-flvb2104-1-e} -tool vivado
         #set_part {xcvu9p-flgc2104-1-e} -tool vivado
 


### PR DESCRIPTION
Updated version of track merger to use arrays for trackWord, barrelStubWords, and diskStubWords. This branch no longer uses the hls::stream class.