### PR TITLE
Add getBitStr Method

### DIFF
--- a/TrackletAlgorithm/AllStubMemory.h
+++ b/TrackletAlgorithm/AllStubMemory.h
@@ -194,6 +194,15 @@ public:
     str += "|"+decodeToBits(getBend());
     return str;
   }
+
+  std::string getBitStrDisk2S() const {
+      std::string str = decodeToBits(getR());
+      str += "|"+decodeToBits(getZ());
+      str += "|"+decodeToBits(getPhi());
+      str += "|"+decodeToBits(getAlpha());
+      str += "|"+decodeToBits(getBend());
+      return str;
+  }
 #endif
 
 private:

--- a/TrackletAlgorithm/AllStubMemory.h
+++ b/TrackletAlgorithm/AllStubMemory.h
@@ -194,8 +194,17 @@ public:
     str += "|"+decodeToBits(getBend());
     return str;
   }
+#endif
 
-  std::string getBitStrDisk2S() const {
+private:
+
+  AllStubData data_;
+
+};
+
+#ifdef CMSSW_GIT_HASH
+  template<>
+  inline std::string AllStub<DISK2S>::getBitStr() const {
       std::string str = decodeToBits(getR());
       str += "|"+decodeToBits(getZ());
       str += "|"+decodeToBits(getPhi());
@@ -204,12 +213,6 @@ public:
       return str;
   }
 #endif
-
-private:
-
-  AllStubData data_;
-
-};
 
 // Special data object definition
 template<>


### PR DESCRIPTION
This PR adds a getBitStr method to the AllStubMemory.h file for disk 2S memories. These methods are only used in the future SW CMSSW emulation