### PR TITLE
Memory fixes

### DIFF
--- a/IntegrationTests/BarrelConfig/IRtoTB/script/makeProject.tcl
+++ b/IntegrationTests/BarrelConfig/IRtoTB/script/makeProject.tcl
@@ -179,6 +179,7 @@ add_files -fileset sources_1 [glob ../hdl/SectorProcessor*.vhd]
 add_files -fileset sources_1 [glob ../hdl/memUtil_pkg.vhd]
 add_files -fileset sources_1 [glob common/hdl/*.vhd]
 remove_files -fileset sources_1 [glob common/hdl/latency_monitor.vhd]
+remove_files -fileset sources_1 [glob common/hdl/tf_mem_new.vhd]
 
 # Add HDL for TB
 add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]

--- a/IntegrationTests/IRVMR/script/makeProject.tcl
+++ b/IntegrationTests/IRVMR/script/makeProject.tcl
@@ -26,6 +26,7 @@ set topLevelHDL "SectorProcessorFull"
 add_files -fileset sources_1 [glob ../hdl/SectorProcessor*.vhd]
 add_files -fileset sources_1 [glob ../hdl/memUtil_pkg.vhd]
 add_files -fileset sources_1 [glob common/hdl/*.vhd]
+remove_files -fileset sources_1 [glob common/hdl/tf_mem_new.vhd]
 
 # Add HDL for TB
 add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]

--- a/IntegrationTests/PRMEMC/script/makeProject.tcl
+++ b/IntegrationTests/PRMEMC/script/makeProject.tcl
@@ -25,6 +25,7 @@ set topLevelHDL "SectorProcessorFull"
 add_files -fileset sources_1 [glob ../hdl/SectorProcessor*.vhd]
 add_files -fileset sources_1 [glob ../hdl/memUtil_pkg.vhd]
 add_files -fileset sources_1 [glob common/hdl/*.vhd]
+remove_files -fileset sources_1 [glob common/hdl/tf_mem_new.vhd]
 
 # Add HDL for TB
 add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]

--- a/IntegrationTests/ReducedCombinedConfig/script/makeProject.tcl
+++ b/IntegrationTests/ReducedCombinedConfig/script/makeProject.tcl
@@ -45,6 +45,7 @@ add_files -fileset sources_1 [glob ../hdl/SectorProcessorFull.vhd]
 add_files -fileset sources_1 [glob ../hdl/memUtil_pkg.vhd]
 add_files -fileset sources_1 [glob common/hdl/*.vhd]
 remove_files -fileset sources_1 [glob common/hdl/latency_monitor.vhd]
+remove_files -fileset sources_1 [glob common/hdl/tf_mem_new.vhd]
 
 # Add HDL for TB
 add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]

--- a/IntegrationTests/ReducedConfig/IRtoTB/script/makeProject.tcl
+++ b/IntegrationTests/ReducedConfig/IRtoTB/script/makeProject.tcl
@@ -58,6 +58,7 @@ add_files -fileset sources_1 [glob ../hdl/SectorProcessor*.vhd]
 add_files -fileset sources_1 [glob ../hdl/memUtil_pkg.vhd]
 add_files -fileset sources_1 [glob common/hdl/*.vhd]
 remove_files -fileset sources_1 [glob common/hdl/latency_monitor.vhd]
+remove_files -fileset sources_1 [glob common/hdl/tf_mem_new.vhd]
 
 # Add HDL for TB
 add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]

--- a/IntegrationTests/ReducedConfig/MCTB/script/makeProject.tcl
+++ b/IntegrationTests/ReducedConfig/MCTB/script/makeProject.tcl
@@ -27,6 +27,7 @@ add_files -fileset sources_1 [glob ../hdl/SectorProcessor*.vhd]
 add_files -fileset sources_1 [glob ../hdl/memUtil_pkg.vhd]
 add_files -fileset sources_1 [glob common/hdl/*.vhd]
 remove_files -fileset sources_1 [glob common/hdl/latency_monitor.vhd]
+remove_files -fileset sources_1 [glob common/hdl/tf_mem_new.vhd]
 
 # Add HDL for TB
 add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]

--- a/IntegrationTests/TETC/script/makeProject.tcl
+++ b/IntegrationTests/TETC/script/makeProject.tcl
@@ -23,6 +23,7 @@ set topLevelHDL "SectorProcessorFull"
 add_files -fileset sources_1 [glob ../hdl/SectorProcessor*.vhd]
 add_files -fileset sources_1 [glob ../hdl/memUtil_pkg.vhd]
 add_files -fileset sources_1 [glob common/hdl/*.vhd]
+remove_files -fileset sources_1 [glob common/hdl/tf_mem_new.vhd]
 
 # Add HDL for TB
 add_files -fileset sim_1 [glob ../tb/tb_tf_top.vhd]

--- a/IntegrationTests/common/hdl/tf_mem.vhd
+++ b/IntegrationTests/common/hdl/tf_mem.vhd
@@ -114,6 +114,7 @@ process(clka)
   variable vi_page_cnt  : integer := 0;  -- Page counter
   variable page         : integer := 0;
   variable addr_in_page : integer := 0;
+  variable written      : integer := 0;
 begin
   if rising_edge(clka) then -- ######################################### Start counter initially
     if DEBUG then
@@ -135,6 +136,7 @@ begin
       end if;
     end if;
     if (wea='1') then
+      written := 1;
       if DEBUG then
         report "tm_mem "&NAME&" writeaddr "&to_bstring(addra)&" "&to_bstring(dina);
       end if;
@@ -148,6 +150,8 @@ begin
       else
         nent_o(page) <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o(page))) + 1, nent_o(page)'length)); -- + 1 (slv)
       end if;	
+    elsif (written=0) then
+      nent_o <= (others => (others => '0'));
     end if;
   end if;
 end process;

--- a/IntegrationTests/common/hdl/tf_mem_bin.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_bin.vhd
@@ -116,6 +116,7 @@ process(clka)
   variable vi_nent_idx  : integer := 0;  -- Bin index of nent
   variable page         : integer := 0;
   variable addr_in_page : integer := 0;
+  variable written      : integer := 0;
   --variable v_line_out   : line;          -- Line for debug
 begin
   if rising_edge(clka) then
@@ -135,6 +136,7 @@ begin
       end if;
     end if;
     if (wea='1') then
+      written := 1;
       sa_RAM_data(to_integer(unsigned(addra))) <= dina; -- Write data
       -- Count entries
       vi_nent_idx := to_integer(shift_right(unsigned(addra), clogb2(NUM_ENTRIES_PER_MEM_BINS))) mod NUM_MEM_BINS; -- Calculate bin index
@@ -148,6 +150,8 @@ begin
       else
         nent_o(page)(vi_nent_idx) <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o(page)(vi_nent_idx))) + 1, nent_o(page)(vi_nent_idx)'length)); -- + 1 (slv)
       end if; 
+    elsif (written=0) then
+      nent_o <= (others => (others => (others => '0')));
     end if; -- (wea='1')
   end if;
 end process;

--- a/IntegrationTests/common/hdl/tf_mem_bin_cm4.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_bin_cm4.vhd
@@ -176,7 +176,7 @@ begin
       end if; 
     elsif (written=0) then
       mask_o <= (others => (others => '0'));
-      nent_o <= (others => ((others => (others => '0')));
+      nent_o <= (others => (others => (others => '0')));
     end if; -- (wea='1')
   end if;
 end process;

--- a/IntegrationTests/common/hdl/tf_mem_bin_cm4.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_bin_cm4.vhd
@@ -135,6 +135,7 @@ process(clka)
   variable vi_nent_idx  : integer := 0;  -- Bin index of nent
   variable page         : integer := 0;
   variable addr_in_page : integer := 0;
+  variable written      : integer := 0;
   --variable v_line_out   : line;          -- Line for debug
 begin
   if rising_edge(clka) then
@@ -155,6 +156,7 @@ begin
       end if;
     end if;
     if (wea='1') then
+      written := 1;
       sa_RAM_data0(to_integer(unsigned(addra))) <= dina; -- Write data
       sa_RAM_data1(to_integer(unsigned(addra))) <= dina; -- Write data
       sa_RAM_data2(to_integer(unsigned(addra))) <= dina; -- Write data
@@ -172,6 +174,9 @@ begin
       else
         nent_o(page)(vi_nent_idx) <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o(page)(vi_nent_idx))) + 1, nent_o(page)(vi_nent_idx)'length)); -- + 1 (slv)
       end if; 
+    elsif (written=0) then
+      mask_o <= (others => (others => '0'));
+      nent_o <= (others => ((others => (others => '0')));
     end if; -- (wea='1')
   end if;
 end process;

--- a/IntegrationTests/common/hdl/tf_mem_bin_cm5.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_bin_cm5.vhd
@@ -145,6 +145,7 @@ process(clka)
   variable vi_nent_idx  : integer := 0;  -- Bin index of nent
   variable page         : integer := 0;
   variable addr_in_page : integer := 0;
+  variable written      : integer := 0;
   --variable v_line_out   : line;          -- Line for debug
 begin
   if rising_edge(clka) then
@@ -168,6 +169,7 @@ begin
       end if;
     end if;
     if (wea='1') then
+      written := 1;
       sa_RAM_data0(to_integer(unsigned(addra))) <= dina; -- Write data
       sa_RAM_data1(to_integer(unsigned(addra))) <= dina; -- Write data
       sa_RAM_data2(to_integer(unsigned(addra))) <= dina; -- Write data
@@ -189,6 +191,9 @@ begin
       else
         nent_o(page)(vi_nent_idx) <= std_logic_vector(to_unsigned(to_integer(unsigned(nent_o(page)(vi_nent_idx))) + 1, nent_o(page)(vi_nent_idx)'length)); -- + 1 (slv)
       end if; 
+    elsif (written=0) then
+      mask_o <= (others => (others => '0'));
+      nent_o <= (others => (others => (others => '0')));
     end if; -- (wea='1')
   end if;
 end process;

--- a/IntegrationTests/common/hdl/tf_mem_new.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_new.vhd
@@ -1,0 +1,107 @@
+-- New version of unbinned memory module based on Thomas Schuh's work. The ports
+-- have been updated to be more consistent with those written by the project
+-- generation scripts.
+
+library ieee;
+use ieee.std_logic_1164.all;
+use work.tf_pkg.all;
+
+entity tf_mem is
+generic (
+  RAM_WIDTH: natural := 14;
+  NUM_PAGES: natural := 2;
+  RAM_DEPTH: natural := NUM_PAGES*PAGE_LENGTH;
+  RAM_TYPE: string := "block"
+);
+port (
+  clk: in std_logic;
+  --memory_din: in t_write;
+  rstb: in std_logic;
+  wea: in std_logic;
+  bxa: in std_logic_vector( 2 downto 0 );  -- set to bx_o
+  addra: in std_logic_vector( clogb2(RAM_DEPTH) - 1 downto 0 );
+  dina: in std_logic_vector( RAM_WIDTH - 1 downto 0 );
+  --memory_read: in t_read;
+  addrb: in std_logic_vector( clogb2(RAM_DEPTH) - 1 downto 0 );
+  --memory_dout: out t_data
+  nent_o: out t_arr_7b(0 to NUM_PAGES-1);
+  doutb: out std_logic_vector( RAM_WIDTH - 1 downto 0 )
+);
+end;
+
+
+architecture rtl of tf_mem is
+
+constant widthAddr: natural := clogb2(RAM_DEPTH);
+constant widthNent: natural := 7;
+
+constant widthNentIn: natural := widthNent;
+function init_widthIndexBX return natural is begin if widthAddr = 8 then return 1; end if; return 3; end function;
+constant widthIndexBX: natural := init_widthIndexBX;
+constant widthIndexNent: natural := widthAddr - widthNentIn;
+
+type t_ram is array ( 0 to  2 ** widthAddr - 1 ) of std_logic_vector( RAM_WIDTH - 1 downto 0 );
+
+signal bx, bxReg: std_logic_vector( widthIndexBX - 1 downto 0 ) := ( others => '0' );
+signal ram: t_ram := ( others => ( others => '0' ) );
+signal nent: std_logic_vector( widthNent - 1 downto 0 ) := ( others => '0' );
+signal indexNent: std_logic_vector( widthIndexNent - 1 downto 0 ) := ( others => '0' );
+signal optional: std_logic_vector( RAM_WIDTH - 1 downto 0 ) := ( others => '0' );
+signal reg: std_logic_vector( RAM_WIDTH - 1 downto 0 ) := ( others => '0' );
+signal dout_nents: t_arr_7b(0 to NUM_PAGES-1) := ( others => ( others => '0' ) );
+signal dout_data: std_logic_vector( RAM_WIDTH - 1 downto 0 ) := ( others => '0' );
+
+attribute ram_style: string;
+attribute ram_style of ram: signal is RAM_TYPE;
+
+begin
+
+
+doutb <= dout_data;
+nent_o <= dout_nents;
+
+
+-- step 1
+
+nent <= incr( resize( addra( widthNentIn - 1 downto 0 ), widthNent ) );
+indexNent <= addra( widthAddr - 1 downto widthAddr - widthIndexNent );
+bx <= bxa( widthIndexBX - 1 downto 0 );
+
+-- step 2
+
+dout_data( RAM_WIDTH - 1 downto 0 ) <= reg;
+
+
+process ( clk ) is
+begin
+if rising_edge( clk ) then
+
+  -- step 1
+
+  bxReg <= bx;
+  optional <= ram( uint( addrb( widthAddr - 1 downto 0 ) ) );
+
+  if bxReg /= bx then
+    dout_nents( uint( incr( bx ) ) )( widthNent - 1 downto 0 ) <= ( others => '0' );
+  end if;
+
+  if wea = '1' then
+    dout_nents( uint( indexNent ) )( widthNent - 1 downto 0 ) <= nent;
+    ram( uint( addra( widthAddr - 1 downto 0 ) ) ) <= dina( RAM_WIDTH - 1 downto 0 );
+  end if; 
+
+  if rstb = '1' then
+    for k in 0 to 2 ** widthIndexNent - 1 loop
+      dout_nents( k )( widthNent - 1 downto 0 ) <= ( others => '0' );
+    end loop;
+  end if;
+
+  -- step 2
+
+  reg <= optional;
+
+end if;
+end process;
+
+
+end;


### PR DESCRIPTION
While working on the simulation of the barrel-only project, I noticed seemingly random differences related to the `nent_o` ports on the memory modules. Looking at the logic, I see that the output is not always well-defined, in particular, before the first write-enable signal is received.

I fix this by adding an integer variable that is initialized to zero and is assigned one when the first write-enable is received. Zeroes are output on `nent_o` while this variable is zero. Something similar is done for the `mask_o` ports on the binned memories for the combined module chains.

This seems to have no effect on the results from the skinny chain, but greatly improves the agreement for the barrel-only project:
|   | `master` branch | `mem_fix` branch |
| ------------- | ------------- | ------------- |
| bad events in TF_L1L2 | 100 | 12 |
| bad events in TF_L2L3 | 58 | 0 |
| bad events in TF_L3L4 | 100 | 10 |
| bad events in TF_L5L6 | 100 | 17 |

I've also added the unbinned memory module based on Thomas Schuh's work, which is currently used on the barrel_config branch. This is just for reference, and it is not yet used here.