### PR TITLE
Adding compareMemWithTwoFiles to FileReadUtility for Future SW

### DIFF
--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -125,17 +125,11 @@ void writeMemFromFile(MemType& memory, std::ifstream& fin, int ievt, int base=16
   
 }
 
-template<class MemType, int InputBase=16, int OutputBase=16, int LSB=-1, int MSB=-1>
-unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
-                                int ievt, const std::string& label,
-                                const bool truncated = false, int maxProc = kMaxProc)
+template<class MemType, int OutputBase=16, int LSB=-1, int MSB=-1>
+unsigned int compareMemWithMem(const MemType& memory_ref, const MemType& memory, int ievt,
+                               const std::string& label, const bool truncated = false)
 {
   unsigned int err_count = 0;
-
-  ////////////////////////////////////////
-  // Read from file
-  MemType memory_ref;
-  writeMemFromFile<MemType>(memory_ref, fout, ievt, InputBase);
 
   constexpr int width = (LSB >= 0 && MSB >= LSB) ? (MSB + 1) : MemType::getWidth();
   constexpr int lsb = (LSB >= 0 && MSB >= LSB) ? LSB : 0;
@@ -180,6 +174,19 @@ unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
   }
   
   return err_count;
+}                                
+
+template<class MemType, int InputBase=16, int OutputBase=16, int LSB=-1, int MSB=-1>
+unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
+                                int ievt, const std::string& label,
+                                const bool truncated = false, int maxProc = kMaxProc)
+{
+  ////////////////////////////////////////
+  // Read from file
+  MemType memory_ref;
+  writeMemFromFile<MemType>(memory_ref, fout, ievt, InputBase);
+
+  return compareMemWithMem<MemType>(memory_ref, memory, ievt, label, truncated);
   
 }
 
@@ -419,70 +426,28 @@ unsigned int compareMemWithTwoFiles(const MemType& memory, std::vector<std::ifst
                                 int ievt, const std::string& label,
                                 const bool truncated = false, int maxProc = kMaxProc)
 {
-  unsigned int err_count = 0;
-
   ////////////////////////////////////////
   // Read from file
   MemType memory_ref;
   MemType memory_ref1;
   MemType memory_ref2;
   writeMemFromFile<MemType>(memory_ref1, *foutVec[0], ievt, InputBase);
+
   if (foutVec.size() > 1){
-  writeMemFromFile<MemType>(memory_ref2, *foutVec[1], ievt, InputBase);
+    writeMemFromFile<MemType>(memory_ref2, *foutVec[1], ievt, InputBase);
   }
   for (int i = 0; i<memory_ref1.getEntries(0); ++i){
     auto data_ref1 = memory_ref1.read_mem(0, i);
     memory_ref.write_mem(0, data_ref1, i);
   }
   if (foutVec.size() > 1){
-  for (int j = 0; j < memory_ref2.getEntries(0); ++j){
-    auto data_ref2 = memory_ref2.read_mem(0, j);
-    memory_ref.write_mem(0, data_ref2, j + memory_ref1.getEntries(0));
-  }
-  }
-  constexpr int width = (LSB >= 0 && MSB >= LSB) ? (MSB + 1) : MemType::getWidth();
-  constexpr int lsb = (LSB >= 0 && MSB >= LSB) ? LSB : 0;
-  constexpr int msb = (LSB >= 0 && MSB >= LSB) ? MSB : MemType::getWidth() - 1;
-
-  for (unsigned int i = 0; i < memory_ref.getDepth(); ++i) {
-    auto data_ref_raw = memory_ref.read_mem(ievt,i).raw();
-    auto data_com_raw = memory.read_mem(ievt,i).raw();
-    auto data_ref = data_ref_raw.range(msb,lsb);
-    auto data_com = data_com_raw.range(msb,lsb);
-    if (i==0) {
-      // If both reference and computed memories are completely empty, skip it
-      if (data_com == 0 && data_ref == 0) break;
-      std::cout << label << ":" << std::endl;
-      std::cout << "index" << "\t" << "reference" << "\t" << "computed" << std::endl;
+    for (int j = 0; j < memory_ref2.getEntries(0); ++j){
+      auto data_ref2 = memory_ref2.read_mem(0, j);
+      memory_ref.write_mem(0, data_ref2, j + memory_ref1.getEntries(0));
     }
-    // If have reached the end of valid entries in both computed and reference, don't bother printing further
-    if (data_com == 0 && data_ref == 0) continue;
-
-    std::cout << i << "\t";
-    if (OutputBase == 2) std::cout << std::bitset<width>(data_ref) << "\t";
-    else                 std::cout << std::hex << data_ref << "\t";
-    
-    if (OutputBase == 2) std::cout << std::bitset<width>(data_com);
-    else                 std::cout << std::hex << data_com; // << std::endl;
-
-    // If there is extra entries in reference
-    if (data_com == 0) {
-      std::cout << "\t" << "<=== missing";
-      if (!truncated) err_count++;
-    // If there is extra entries in computed
-    } else if (data_ref == 0) {
-      std::cout << "\t" << "<=== EXTRA";
-      err_count++;
-    // If reference and computed entry are inconsistent
-    } else if (data_com != data_ref) {
-      std::cout << "\t" << "<=== INCONSISTENT";
-      err_count++;
-    }
-
-    std::cout << std::endl;
   }
-  
-  return err_count;
+
+  return compareMemWithMem<MemType>(memory_ref, memory, ievt, label, truncated);
   
 }
 


### PR DESCRIPTION
Added a function to FileReadUtility.h, compareMemWithTwoFiles, which will be needed as a dependency for an upcoming PR in order to properly check the IRProducer / IRFakeProducer memories in the IRAnalyer. The existing function, compareMemWithFile, cannot be used in checkIRMemories, as two reference files are needed for each instance of computed memories. This function could presumably be used in any other cases in which two memory reference files are needed to be compared with an instance of computed memories. 