### PR TITLE
revert accdiental change in MemoryTemplateteBinnedCM.h

### DIFF
--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -133,7 +133,7 @@ class MemoryTemplateBinnedCM{
     if (nentry_ibx < getNEntryPerBin()-1) { // Max 15 stubs in each memory due to 4 bit nentries
       // write address for slot: getNEntryPerBin() * slot + nentry_ibx
 
-      writememloop:for (unsigned int icopy=0;icopy<NCOPY;icopy++) {
+      writememloop:for (unsigned int icopy=0;icopy< (signed) NCOPY;icopy++) {
 #pragma HLS unroll
 	dataarray_[icopy][ibx][getNEntryPerBin()*slot+nentry_ibx] = data;
       }


### PR DESCRIPTION
PR reverts removal of '(signed)' in a integer comparison that is needed for future SW