### PR TITLE
Future sw update

### DIFF
--- a/emData/generate_MP.py
+++ b/emData/generate_MP.py
@@ -131,7 +131,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "MatchProcessor_param
     maxFMMems += str(len(TPMems.keys())) + "] = {"
 
     # Calculate parameters and print out parameters and top function for each MP.
-    for mpName in sorted(TPMems.keys()):
+    for mpName in sorted(TPMems.keys(), key = lambda x: x.startswith('L')):
         seed = re.sub(r"MP_(..)....", r"\1", mpName)
         iMP = re.sub(r"MP_.....(.)", r"\1", mpName)
 
@@ -144,7 +144,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "MatchProcessor_param
         
         maxTPMems += seed + "PHI" + iMP + "maxTrackletProjections"
         maxFMMems += seed + "PHI" + iMP + "maxFullMatchCopies"
-        if mpName != sorted(TPMems.keys())[-1]:
+        if mpName != sorted(TPMems.keys(), key=lambda x: x.startswith('L'))[-1]:
             maxTPMems += ",\n				   "
             maxFMMems += ",\n				   " 
 


### PR DESCRIPTION
Update to the generateMP script to put max full match and max tracklet projection arrays into different order. Previously was done alphabetically and is now changed to start with L1PHIA and end with D5PHID. These arrays are only used by the future SW so the ordering should not affect firmware.