### PR TITLE
TrackBuilder disk-only and overlap seeds

### DIFF
--- a/TestBenches/TrackBuilder_test.cpp
+++ b/TestBenches/TrackBuilder_test.cpp
@@ -32,6 +32,18 @@ using namespace std;
 #elif SEED_ == L5L6_
   constexpr unsigned kNBarrelStubs = 4;
   constexpr unsigned kNDiskStubs = 0;
+#elif SEED_ == D1D2_
+  constexpr unsigned kNBarrelStubs = 2;
+  constexpr unsigned kNDiskStubs = 3;
+#elif SEED_ == D3D4_
+  constexpr unsigned kNBarrelStubs = 1;
+  constexpr unsigned kNDiskStubs = 3;
+#elif SEED_ == L1D1_
+  constexpr unsigned kNBarrelStubs = 0;
+  constexpr unsigned kNDiskStubs = 4;
+#elif SEED_ == L2D1_
+  constexpr unsigned kNBarrelStubs = 1;
+  constexpr unsigned kNDiskStubs = 3;
 #else
 #  error "Undefined seed"
 #endif

--- a/project/script_TB.tcl
+++ b/project/script_TB.tcl
@@ -6,11 +6,16 @@
 # get some information about the executable and environment
 source env_hls.tcl
 
+# FIXME: FT_D1D2 is excluded for now because it currently produces extra
+# entries compared to the emulation
 set modules_to_test {
   {FT_L1L2}
   {FT_L2L3}
   {FT_L3L4}
   {FT_L5L6}
+  {FT_D3D4}
+  {FT_L1D1}
+  {FT_L2D1}
 }
 # module_to_export must correspond to the default macros set at the top of the
 # test bench; otherwise, the C/RTL cosimulation will fail


### PR DESCRIPTION
This PR just adds what we need to test the TrackBuilder for the disk-only and overlap seeds.

The additional seeds have almost perfect agreement with the emulation. The only exception is a few events that have extra entries for D1D2. For now, I just exclude this TrackBuilder from the list of modules to test in project/script_TB.tcl.