### PR TITLE
Fixed disk bits

### DIFF
--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -218,7 +218,9 @@ inline void step(const VMStubMECM<VMSMEType> stubmem[4][1<<(kNbitsrzbinMP+kNbits
 
     constexpr bool isDisk = LAYER > TF::L6;
 
-    constexpr unsigned int kNBitBin = !isDisk ? 3 : 4;
+    constexpr auto kNBitBinPS = 3;
+    constexpr auto kNBitBin2S = 4;
+    const unsigned int kNBitBin = isPSStub ? kNBitBinPS : kNBitBin2S;
     constexpr unsigned int kRInvSteps = 32;
     constexpr unsigned int kRInvBits = BITS_TO_REPRESENT(kRInvSteps - 1);
     
@@ -242,10 +244,9 @@ inline void step(const VMStubMECM<VMSMEType> stubmem[4][1<<(kNbitsrzbinMP+kNbits
 
     //here we always use the larger number of bits for the bend
     // Check if stub bend and proj rinv consistent
-    auto const index_part1 = (VMProjType == DISK && isPSseed____) ? projrinv____.concat(stubbendReduced) : projrinv____.concat(stubbend);
-    auto const index_part2 = ((VMProjType == DISK && isPSseed____) ? (1 << (kRInvBits + kNBitBin)) : 0);
-    const ap_int<1> diskps = isDisk && isPSStub;
-    auto const index = diskps ? (diskps,projrinv____,stubbendReduced) : (diskps,projrinv____,stubbend);
+    ap_uint<kNBitBin2S+kRInvBits+1> diskps = isDisk && isPSStub;
+    ap_uint<kRInvBits+kNBitBin2S> projrinv_long = projrinv____;
+    const ap_uint<1+kNBitBin2S+kRInvBits> index = (diskps << (kNBitBin2S + kRInvBits)) + (projrinv_long << kNBitBin) + (diskps ? ap_uint<kNBitBin2S>(stubbendReduced) : ap_uint<kNBitBin2S>(stubbend));
 
     //Check if stub bend and proj rinv consistent
     projseqs_[writeindex_] = projseq____;

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -1197,7 +1197,7 @@ void MatchProcessor(BXType bx,
   constexpr regionType APTYPE = TF::layerDiskType[LAYER];
 
   //Initialize table for bend-rinv consistency
-  ap_uint<1> table[kNMatchEngines][(LAYER<TF::L4)?256:512]; //FIXME Need to figure out how to replace 256 with meaningful const.
+  ap_uint<1> table[kNMatchEngines][LAYER<TF::D1 ? (LAYER<TF::L4 ? 256 : 512) : 768]; //FIXME Need to figure out how to replace 256 with meaningful const.
   //Use of dim=0 seems to have small improvement on timing - not sure why
 #pragma HLS ARRAY_PARTITION variable=table dim=0 complete
   readtable: for(int iMEU = 0; iMEU < kNMatchEngines; ++iMEU) {

--- a/emData/download.sh
+++ b/emData/download.sh
@@ -10,8 +10,8 @@ memprints_url_reduced="https://cernbox.cern.ch/remote.php/dav/public-files/4jZdh
 luts_url_reduced="https://cernbox.cern.ch/remote.php/dav/public-files/mcGz25JNu19Oqzm/LUTs.tar.gz"
 # Combined modules
 # Updated files from Jason for TP disk with extra sign bit for disks in AllInnerStubs memories. This is in cmssw PR #230
-memprints_url_cm="https://cernbox.cern.ch/remote.php/dav/public-files/ubP8YbYfNA6kOBx/MemPrints_10242023.tar.gz"
-luts_url_cm="https://cernbox.cern.ch/remote.php/dav/public-files/iQusnc3zGrAU5fv/LUTs.tgz"
+memprints_url_cm="https://cernbox.cern.ch/remote.php/dav/public-files/Gfv0lbIVWBdFsoa/MemPrints_10242023.tar.gz"
+luts_url_cm="https://cernbox.cern.ch/remote.php/dav/public-files/CfDiIlwterSBOSZ/LUTs.tar.gz"
 # Reduced Combined modules
 memprints_url_reducedcm="https://cernbox.cern.ch/remote.php/dav/public-files/g0EIkgWgie5mBob/MemPrints.tar.gz"
 luts_url_reducedcm="https://cernbox.cern.ch/remote.php/dav/public-files/HT8q7fk4UvhpdPK/LUTs.tar.gz"

--- a/emData/download.sh
+++ b/emData/download.sh
@@ -10,8 +10,8 @@ memprints_url_reduced="https://cernbox.cern.ch/remote.php/dav/public-files/4jZdh
 luts_url_reduced="https://cernbox.cern.ch/remote.php/dav/public-files/mcGz25JNu19Oqzm/LUTs.tar.gz"
 # Combined modules
 # Updated files from Jason for TP disk with extra sign bit for disks in AllInnerStubs memories. This is in cmssw PR #230
-memprints_url_cm="https://aryd.web.cern.ch/aryd/MemPrintsCM_230822.tgz"
-luts_url_cm="https://cernbox.cern.ch/remote.php/dav/public-files/uoKcrxMXtjVHagL/LUTs.tar.gz"
+memprints_url_cm="https://cernbox.cern.ch/remote.php/dav/public-files/ubP8YbYfNA6kOBx/MemPrints_10242023.tar.gz"
+luts_url_cm="https://cernbox.cern.ch/remote.php/dav/public-files/iQusnc3zGrAU5fv/LUTs.tgz"
 # Reduced Combined modules
 memprints_url_reducedcm="https://cernbox.cern.ch/remote.php/dav/public-files/g0EIkgWgie5mBob/MemPrints.tar.gz"
 luts_url_reducedcm="https://cernbox.cern.ch/remote.php/dav/public-files/HT8q7fk4UvhpdPK/LUTs.tar.gz"


### PR DESCRIPTION
This PR fixes a bug in the MP tables for the disks (not enough bits) and updates the index value to match the recent emulation PR (https://github.com/cms-L1TK/cmssw/pull/242). I'm running a full set of tests now, but so far I see full agreement with my latest test vectors (https://cernbox.cern.ch/s/8ADWsUnqUAPmI2m/download).