### PR TITLE
TM download bug fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -283,7 +283,7 @@ TB-vivado-hls-build:
 TM-vivado-hls-build:
   <<: *template_hls-build
   needs: ["download", "TM-quality-check"]
-  allow_failure: true # remove after regenerating test vectors
+  allow_failure: true # FIXME: testbench currently always passes
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -283,7 +283,7 @@ TB-vivado-hls-build:
 TM-vivado-hls-build:
   <<: *template_hls-build
   needs: ["download", "TM-quality-check"]
-  allow_failure: true # FIXME: testbench currently always passes
+  allow_failure: false # FIXME: testbench currently always passes
   variables:
     EXECUTABLE: 'vivado_hls'
     VIVADO_VERSION: "2019.2"

--- a/emData/download.sh
+++ b/emData/download.sh
@@ -307,7 +307,7 @@ do
 
 # Create a list of all processing modules. The VMRs in the combined config get
 # a special name.
-processing_modules=`sed "s/VMRouterCM: VMR/&CM/g" LUTs/processingmodules.dat LUTsCM/processingmodules.dat LUTsReduced/processingmodules.dat LUTsBarrel/processingmodules.dat | awk '{print $2}' | sort -u | grep ${module_type}_`
+processing_modules=`sed "s/VMRouterCM: VMR/&CM/g" LUTs/processingmodules.dat LUTsCM/processingmodules.dat LUTsReduced/processingmodules.dat LUTsBarrel/processingmodules.dat | awk '{print $2}' | sort -u | grep ${module_type}`
 
 # For each of the desired modules, create a dedicated directory with symbolic
 # links to the associated test-bench files.


### PR DESCRIPTION
TM was crashing because the emData/PD folders were not created by the download.sh anymore. Fixed the bug, and also removed the allow failure in the CI to avoid similar things happening again (the TM tb is always passing anyway). 