### PR TITLE
Removing some LUTs

### DIFF
--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -221,22 +221,22 @@ inline void step(const VMStubMECM<VMSMEType> stubmem[4][1<<(kNbitsrzbinMP+kNbits
     constexpr unsigned int kRInvSteps = 32;
     constexpr unsigned int kRInvBits = BITS_TO_REPRESENT(kRInvSteps - 1);
     
-    static const ap_uint<1 << 2*projfinephibits> phiLUT = isLessThanSize<projfinephibits,StubPhiPositionConsistency::kMax,false,projfinephibits,stubfinephibits>();
-    static const ap_uint<1 << 2*projfinephibits> stubZBarrelPS = isLessThanSize<projfinephibits,StubZPositionBarrelConsistency::kBarrelPSMax,true,stubfinephibits,projfinephibits>();
-    static const ap_uint<1 << 2*projfinephibits> stubZBarrel2S = isLessThanSize<projfinephibits,StubZPositionBarrelConsistency::kBarrel2SMax,true,stubfinephibits,projfinephibits>();
-    static const ap_uint<1 << 2*projfinephibits> stubZDiskPS = isLessThanSize<projfinephibits,StubZPositionDiskConsistency::kDiskPSMax,true,stubfinephibits,projfinephibits>();
-    static const ap_uint<1 << 2*projfinephibits> stubZDisk2S = isLessThanSize<projfinephibits,StubZPositionDiskConsistency::kDisk2SMax,true,stubfinephibits,projfinephibits>();
-    bool passphi = phiLUT[(projfinephi____,stubfinephi)];//isLessThanSize<projfinephibits,StubPhiPositionConsistency::kMax,false,projfinephibits,stubfinephibits>()[(projfinephi____,stubfinephi)];
+    bool phiLUT = isLessThanSizeBool<projfinephibits,StubPhiPositionConsistency::kMax,false,projfinephibits,stubfinephibits>(projfinephi____,stubfinephi);
+    bool stubZBarrelPS = isLessThanSizeBool<projfinephibits,StubZPositionBarrelConsistency::kBarrelPSMax,true,stubfinephibits,projfinephibits>(stubfinez,projfinezadj____);
+    bool stubZBarrel2S = isLessThanSizeBool<projfinephibits,StubZPositionBarrelConsistency::kBarrel2SMax,true,stubfinephibits,projfinephibits>(stubfinez,projfinezadj____);
+    bool stubZDiskPS = isLessThanSizeBool<projfinephibits,StubZPositionDiskConsistency::kDiskPSMax,true,stubfinephibits,projfinephibits>(stubfinez,projfinezadj____);
+    bool stubZDisk2S = isLessThanSizeBool<projfinephibits,StubZPositionDiskConsistency::kDisk2SMax,true,stubfinephibits,projfinephibits>(stubfinez,projfinezadj____);
+    bool passphi = phiLUT;//isLessThanSizeBool<projfinephibits,StubPhiPositionConsistency::kMax,false,projfinephibits,stubfinephibits>()(projfinephi____,stubfinephi);
     
     //Check if stub z position consistent
     bool pass = false;
     if(!isDisk) {
       // check if abs(projfinezadj____ - stubfinez) < StubZPositionBarrelConsistency::kBarrel(PS|2S)Max
-      pass = isPSseed____ ? stubZBarrelPS[(stubfinez,projfinezadj____)] : stubZBarrel2S[(stubfinez,projfinezadj____)];
+      pass = isPSseed____ ? stubZBarrelPS : stubZBarrel2S;
     }
     else {
       // check if abs(projfinezadj____ - stubfinez) < StubZPositionBarrelConsistency::kDisk(PS|2S)Max
-      pass = isPSStub ? stubZDiskPS[(stubfinez,projfinezadj____)] : stubZDisk2S[(stubfinez,projfinezadj____)];
+      pass = isPSStub ? stubZDiskPS : stubZDisk2S;
     }
 
     //here we always use the larger number of bits for the bend

--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -284,7 +284,7 @@ inline void step(const VMStubMECM<VMSMEType> stubmem[4][1<<(kNbitsrzbinMP+kNbits
 #endif
 
  inline void set_empty() {
-   empty_ = emptyUnit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
+   empty_ = emptyUnitBool<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>(readindex_,writeindex_);
  }
 
  inline bool empty() const {
@@ -293,7 +293,7 @@ inline void step(const VMStubMECM<VMSMEType> stubmem[4][1<<(kNbitsrzbinMP+kNbits
  }
  
  inline bool nearFull() {
-   return nearFull3Unit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
+   return nearFull3UnitBool<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>(readindex_,writeindex_);
  }
 
  inline bool idle() {

--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -284,7 +284,7 @@ inline void step(const VMStubMECM<VMSMEType> stubmem[4][1<<(kNbitsrzbinMP+kNbits
 #endif
 
  inline void set_empty() {
-   empty_ = emptyUnitBool<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>(readindex_,writeindex_);
+   empty_ = emptyUnit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
  }
 
  inline bool empty() const {
@@ -293,7 +293,7 @@ inline void step(const VMStubMECM<VMSMEType> stubmem[4][1<<(kNbitsrzbinMP+kNbits
  }
  
  inline bool nearFull() {
-   return nearFull3UnitBool<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>(readindex_,writeindex_);
+   return nearFull3Unit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
  }
 
  inline bool idle() {

--- a/TrackletAlgorithm/MatchEngineUnit_parameters.h
+++ b/TrackletAlgorithm/MatchEngineUnit_parameters.h
@@ -5,7 +5,6 @@
 // each MEU and that come directly from the wiring.
 //
 
-/* REPLACED BY bool version
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFullUnit() {
   ap_uint<(1 << (2 * kNBitsBuffer))> lut;
@@ -21,7 +20,6 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFullUnit() {
   }
   return lut;
 }
-*/
 
 template<int kNBitsBuffer>
 static bool nearFullUnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> wptr) {
@@ -30,7 +28,6 @@ static bool nearFullUnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> w
   return wptr1==rptr || wptr2==rptr;
 }
 
-/* REPLACED BY bool version
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull3Unit() {
   ap_uint<(1 << (2 * kNBitsBuffer))> lut;
@@ -47,7 +44,6 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull3Unit() {
   }
   return lut;
 }
-*/
 
 template<int kNBitsBuffer>
 static bool nearFull3UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> wptr) {
@@ -57,7 +53,6 @@ static bool nearFull3UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> 
   return wptr1==rptr || wptr2==rptr || wptr3==rptr;
 }
 
-/* REPLACED BY bool version
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull4Unit() {
   ap_uint<(1 << (2 * kNBitsBuffer))> lut;
@@ -75,7 +70,6 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull4Unit() {
   }
   return lut;
 }
-*/
 
 template<int kNBitsBuffer>
 static bool nearFull4UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> wptr) {
@@ -86,7 +80,6 @@ static bool nearFull4UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> 
   return wptr1==rptr || wptr2==rptr || wptr3==rptr || wptr4==rptr;
 }
 
-/* REPLACED BY bool version
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> emptyUnit() {
   ap_uint<(1 << (2 * kNBitsBuffer))> lut;
@@ -100,7 +93,6 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> emptyUnit() {
   }
   return lut;
 }
-*/
 
 template<int kNBitsBuffer>
 static bool emptyUnitBool(ap_uint<kNBitsBuffer> wptr, ap_uint<kNBitsBuffer> rptr) {
@@ -152,7 +144,6 @@ static const ap_uint<1 << nbits> isLessThanSize() {
   return tab;
 }
 
-/* REPLACED BY bool version
 template<int nbits, int max, bool lessThan, int proj, int stub>
 static const ap_uint<1 << 2*nbits> isLessThanSize() {
   ap_uint<1 << 2*nbits> tab(0);
@@ -174,7 +165,6 @@ static const ap_uint<1 << 2*nbits> isLessThanSize() {
   }
   return tab;
 }
-*/
 
 template<int nbits, int max, bool lessThan, int proj, int stub>
 static bool isLessThanSizeBool(ap_uint<nbits> projphi, ap_uint<nbits> stubphi) {

--- a/TrackletAlgorithm/MatchEngineUnit_parameters.h
+++ b/TrackletAlgorithm/MatchEngineUnit_parameters.h
@@ -22,6 +22,13 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFullUnit() {
 }
 
 template<int kNBitsBuffer>
+static bool nearFullUnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> wptr) {
+  auto wptr1 = wptr+1;
+  auto wptr2 = wptr+2;
+  return wptr1==rptr || wptr2==rptr;
+}
+
+template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull3Unit() {
   ap_uint<(1 << (2 * kNBitsBuffer))> lut;
   for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
@@ -36,6 +43,14 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull3Unit() {
     lut[i] = result;
   }
   return lut;
+}
+
+template<int kNBitsBuffer>
+static bool nearFull3UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> wptr) {
+  ap_uint<kNBitsBuffer> wptr1 = wptr+1;
+  ap_uint<kNBitsBuffer> wptr2 = wptr+2;
+  ap_uint<kNBitsBuffer> wptr3 = wptr+3;
+  return wptr1==rptr || wptr2==rptr || wptr3==rptr;
 }
 
 template<int kNBitsBuffer>
@@ -57,6 +72,15 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull4Unit() {
 }
 
 template<int kNBitsBuffer>
+static bool nearFull4UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> wptr) {
+  ap_uint<kNBitsBuffer> wptr1 = wptr+1;
+  ap_uint<kNBitsBuffer> wptr2 = wptr+2;
+  ap_uint<kNBitsBuffer> wptr3 = wptr+3;
+  ap_uint<kNBitsBuffer> wptr4 = wptr+4;
+  return wptr1==rptr || wptr2==rptr || wptr3==rptr || wptr4==rptr;
+}
+
+template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> emptyUnit() {
   ap_uint<(1 << (2 * kNBitsBuffer))> lut;
   for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
@@ -68,6 +92,14 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> emptyUnit() {
     lut[i] = result;
   }
   return lut;
+}
+
+template<int kNBitsBuffer>
+static bool emptyUnitBool(ap_uint<kNBitsBuffer> wptr, ap_uint<kNBitsBuffer> rptr) {
+  //for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
+//#pragma HLS unroll
+    return wptr==rptr;
+  //}
 }
 
 template<int kNBitsBuffer>
@@ -135,7 +167,7 @@ static const ap_uint<1 << 2*nbits> isLessThanSize() {
 }
 
 template<int nbits, int max, bool lessThan, int proj, int stub>
-bool isLessThanSizeBool(ap_uint<nbits> projphi, ap_uint<nbits> stubphi) {
+static bool isLessThanSizeBool(ap_uint<nbits> projphi, ap_uint<nbits> stubphi) {
   ap_uint<nbits> Max(max);
   ap_uint<nbits> Min(-max);
   ap_uint<nbits> result = projphi - stubphi;

--- a/TrackletAlgorithm/MatchEngineUnit_parameters.h
+++ b/TrackletAlgorithm/MatchEngineUnit_parameters.h
@@ -5,6 +5,7 @@
 // each MEU and that come directly from the wiring.
 //
 
+/* REPLACED BY bool version
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFullUnit() {
   ap_uint<(1 << (2 * kNBitsBuffer))> lut;
@@ -20,6 +21,7 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFullUnit() {
   }
   return lut;
 }
+*/
 
 template<int kNBitsBuffer>
 static bool nearFullUnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> wptr) {
@@ -28,6 +30,7 @@ static bool nearFullUnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> w
   return wptr1==rptr || wptr2==rptr;
 }
 
+/* REPLACED BY bool version
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull3Unit() {
   ap_uint<(1 << (2 * kNBitsBuffer))> lut;
@@ -44,6 +47,7 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull3Unit() {
   }
   return lut;
 }
+*/
 
 template<int kNBitsBuffer>
 static bool nearFull3UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> wptr) {
@@ -53,6 +57,7 @@ static bool nearFull3UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> 
   return wptr1==rptr || wptr2==rptr || wptr3==rptr;
 }
 
+/* REPLACED BY bool version
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull4Unit() {
   ap_uint<(1 << (2 * kNBitsBuffer))> lut;
@@ -70,6 +75,7 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull4Unit() {
   }
   return lut;
 }
+*/
 
 template<int kNBitsBuffer>
 static bool nearFull4UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> wptr) {
@@ -80,6 +86,7 @@ static bool nearFull4UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> 
   return wptr1==rptr || wptr2==rptr || wptr3==rptr || wptr4==rptr;
 }
 
+/* REPLACED BY bool version
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> emptyUnit() {
   ap_uint<(1 << (2 * kNBitsBuffer))> lut;
@@ -93,6 +100,7 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> emptyUnit() {
   }
   return lut;
 }
+*/
 
 template<int kNBitsBuffer>
 static bool emptyUnitBool(ap_uint<kNBitsBuffer> wptr, ap_uint<kNBitsBuffer> rptr) {
@@ -144,6 +152,7 @@ static const ap_uint<1 << nbits> isLessThanSize() {
   return tab;
 }
 
+/* REPLACED BY bool version
 template<int nbits, int max, bool lessThan, int proj, int stub>
 static const ap_uint<1 << 2*nbits> isLessThanSize() {
   ap_uint<1 << 2*nbits> tab(0);
@@ -165,6 +174,7 @@ static const ap_uint<1 << 2*nbits> isLessThanSize() {
   }
   return tab;
 }
+*/
 
 template<int nbits, int max, bool lessThan, int proj, int stub>
 static bool isLessThanSizeBool(ap_uint<nbits> projphi, ap_uint<nbits> stubphi) {

--- a/TrackletAlgorithm/MatchEngineUnit_parameters.h
+++ b/TrackletAlgorithm/MatchEngineUnit_parameters.h
@@ -133,4 +133,21 @@ static const ap_uint<1 << 2*nbits> isLessThanSize() {
   }
   return tab;
 }
+
+template<int nbits, int max, bool lessThan, int proj, int stub>
+bool isLessThanSizeBool(ap_uint<nbits> projphi, ap_uint<nbits> stubphi) {
+  ap_uint<nbits> Max(max);
+  ap_uint<nbits> Min(-max);
+  ap_uint<nbits> result = projphi - stubphi;
+  //for(int i = 0; i < 1<<2*nbits; ++i) {
+//#pragma HLS unroll
+    if(lessThan) {
+      if(result <= Max || result >= Min) return true;
+    }
+    else {
+      if(result < Max || result > Min) return true;
+    }
+  //}
+  return false;
+}
 #endif

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -1302,9 +1302,8 @@ void MatchProcessor(BXType bx,
 
     auto readptr = projbufferarray.getReadPtr();
     auto writeptr = projbufferarray.getWritePtr();
-    bool empty = emptyUnit<nPRBAbits>()[(readptr,writeptr)];
-    bool projBuffNearFull = nearFull3Unit<nPRBAbits>()[(readptr,writeptr)];
-    bool projBuffNearFullB = nearFull3UnitBool<nPRBAbits>(readptr,writeptr);
+    bool empty = emptyUnitBool<nPRBAbits>(readptr,writeptr);
+    bool projBuffNearFull = nearFull3UnitBool<nPRBAbits>(readptr,writeptr);
     
     ap_uint<3> iphi = 0;
 

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -1302,8 +1302,8 @@ void MatchProcessor(BXType bx,
 
     auto readptr = projbufferarray.getReadPtr();
     auto writeptr = projbufferarray.getWritePtr();
-    bool empty = emptyUnitBool<nPRBAbits>(readptr,writeptr);
-    bool projBuffNearFull = nearFull3UnitBool<nPRBAbits>(readptr,writeptr);
+    bool empty = emptyUnit<nPRBAbits>()[(readptr,writeptr)];
+    bool projBuffNearFull = nearFull3Unit<nPRBAbits>()[(readptr,writeptr)];
     
     ap_uint<3> iphi = 0;
 

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -1304,6 +1304,7 @@ void MatchProcessor(BXType bx,
     auto writeptr = projbufferarray.getWritePtr();
     bool empty = emptyUnit<nPRBAbits>()[(readptr,writeptr)];
     bool projBuffNearFull = nearFull3Unit<nPRBAbits>()[(readptr,writeptr)];
+    bool projBuffNearFullB = nearFull3UnitBool<nPRBAbits>(readptr,writeptr);
     
     ap_uint<3> iphi = 0;
 

--- a/TrackletAlgorithm/ProjectionRouterBufferArray.h
+++ b/TrackletAlgorithm/ProjectionRouterBufferArray.h
@@ -67,6 +67,8 @@ private:
   ap_uint<kNBitsBuffer> readptr_ = 0;
   ap_uint<kNBitsBuffer> writeptr_ = 0;
   ProjectionRouterBuffer<VMProjType,AllProjectionType> projbuffer_[1<<kNBitsBuffer];
+  ap_uint<(1 << (2 * kNBitsBuffer))> nearFullLUT = nearFullUnit<kNBitsBuffer>();
+  ap_uint<(1 << (2 * kNBitsBuffer))> emptyLUT = emptyUnit<kNBitsBuffer>();
 
 };
 

--- a/TrackletAlgorithm/ProjectionRouterBufferArray.h
+++ b/TrackletAlgorithm/ProjectionRouterBufferArray.h
@@ -67,8 +67,6 @@ private:
   ap_uint<kNBitsBuffer> readptr_ = 0;
   ap_uint<kNBitsBuffer> writeptr_ = 0;
   ProjectionRouterBuffer<VMProjType,AllProjectionType> projbuffer_[1<<kNBitsBuffer];
-  ap_uint<(1 << (2 * kNBitsBuffer))> nearFullLUT = nearFullUnit<kNBitsBuffer>();
-  ap_uint<(1 << (2 * kNBitsBuffer))> emptyLUT = emptyUnit<kNBitsBuffer>();
 
 };
 

--- a/TrackletAlgorithm/ProjectionRouterBufferArray.h
+++ b/TrackletAlgorithm/ProjectionRouterBufferArray.h
@@ -38,11 +38,11 @@ public:
   }
 
   inline bool empty() { 
-    return emptyLUT[(readptr_, writeptr_)];
+    return emptyUnitBool<kNBitsBuffer>(readptr_, writeptr_);
   }
 
   bool nearFull() {
-    return nearFullLUT[(readptr_, writeptr_)];
+    return nearFullUnitBool<kNBitsBuffer>(readptr_, writeptr_);
   }
 
   ap_uint<kNBitsBuffer> getReadPtr() {


### PR DESCRIPTION
Looking into the large number of LUTs @jasonfan393 pointed out, I tried to change some of our LUT arrays to simple functions. This seems to greatly improve the post-implementation timing and reduce the number of LUTs. I wanted to run the full vivado simulation for the `ReducedCombinedConfig` and if all looks good, I can do this with other functions as well.

```
#=== Post-Implementation Resource usage ===
CLB:            725
LUT:           2822
FF:            3973
DSP:              2
BRAM:             0
SRL:              1
URAM:             0
#=== Final timing ===
CP required:    4.000
CP achieved post-synthesis:    3.188
CP achieved post-implementation:    3.195
Timing met
```