### PR TITLE
Fix of typo in TrackletEngineUnit

### DIFF
--- a/TrackletAlgorithm/TrackletEngineUnit.h
+++ b/TrackletAlgorithm/TrackletEngineUnit.h
@@ -15,8 +15,8 @@ class TrackletEngineUnit {
     kNBitsRZFine=3,
     kNBitsPhiBins=3,
     kNBitsNegDiskSize=1,
-    kNBitsPTLutInner=(Seed==TF::L5L6||Seed==TF::L1D1||Seed==TF::L2D1||Seed==TF::D1D2||Seed==TF::D3D4)?1024:(Seed==(TF::L1L2||Seed==TF::L2L3||Seed==TF::L3L4)?256:512),
-    kNBitsPTLutOuter=(Seed==TF::L5L6||Seed==TF::L1D1||Seed==TF::L2D1||Seed==TF::D1D2||Seed==TF::D3D4)?1024:(Seed==(TF::L1L2||Seed==TF::L2L3)?256:512)
+    kNBitsPTLutInner=(Seed==TF::L5L6||Seed==TF::L1D1||Seed==TF::L2D1||Seed==TF::D1D2||Seed==TF::D3D4)?1024:(Seed==TF::L1L2||Seed==TF::L2L3||Seed==TF::L3L4)?256:512,
+    kNBitsPTLutOuter=(Seed==TF::L5L6||Seed==TF::L1D1||Seed==TF::L2D1||Seed==TF::D1D2||Seed==TF::D3D4)?1024:(Seed==TF::L1L2||Seed==TF::L2L3)?256:512
   };
 
   typedef ap_uint<VMStubTEOuter<VMSTEType>::kVMSTEOIDSize+kNBits_MemAddr+AllStub<innerRegion>::kAllStubSize> STUBID;


### PR DESCRIPTION
I was a little too trigger-happy with the merge button, and missed a typo with the parentheses that was introduced in #303. This PR simply fixes the typo.

@jasonfan393 Could you please check this out and approve it if it looks OK? Hopefully everything still looks OK for the TPs.