### PR TITLE
enable fully-registered DSPs for timing improvement

### DIFF
--- a/project/settings_hls.tcl
+++ b/project/settings_hls.tcl
@@ -31,8 +31,9 @@ switch -glob -- $exe {
         config_schedule -relax_ii_for_timing=0 -verbose
     }
 }
-
+#enable HLS to use fully registered DSPs
+config_schedule -enable_dsp_full_reg
 # Encourage HLS to make more effort to find best solution.
 # (Worth trying, but increases CPU use, so not enabled by default)
-#config_bind -effort high
-#config_schedule -effort high -relax_ii_for_timing=0 -verbose
+#config_bind -effort high -enable_dsp_full_reg
+#config_schedule -effort high -relax_ii_for_timing=0 -enable_dsp_full_reg -verbose


### PR DESCRIPTION
PR enables option to fully register DSPs, worsening their latency in exchange for improved timing performance. Primarily affects TPs as the vast majority of DSP usage is in TP. TP timing  is improved across the board, MP is largely unaffected.

In L1L2C TP latency goes from 125 -> 147 clocks

Timing/resources:

Current | CLB | LUT | FF | DSP | BRAM | SRL | synth timing | imp timing
-- | -- | -- | -- | -- | -- | -- | -- | --
D1D2C | 863 | 3424 | 5507 | 52 | 6 | 107 | 3.294 | 3.74
D3D4C | 752 | 2999 | 4934 | 44 | 6 | 117 | 3.301 | 3.98
L1D1C | 940 | 3646 | 5091 | 42 | 8 | 158 | 3.322 | 3.693
L1L2C | 1078 | 4490 | 5632 | 74 | 8 | 164 | 3.528 | 3.655
L2D1C | 764 | 3171 | 4686 | 44 | 8 | 125 | 3.329 | 3.819
L2L3C | 725 | 2981 | 3879 | 74 | 7 | 164 | 3.289 | 3.697
L3L4C | 1073 | 4695 | 5491 | 62 | 8 | 143 | 3.586 | 3.72
L5L6C | 780 | 3379 | 4217 | 48 | 5 | 88 | 3.214 | 3.847
enable reg |   |   |   |   |   |   |   |  
D1D2C | 851 | 3544 | 5436 | 52 | 6 | 247 | 2.563 | 3.179
D3D4C | 739 | 3101 | 4907 | 44 | 6 | 236 | 2.362 | 3.074
L1D1C | 837 | 3616 | 5091 | 42 | 8 | 238 | 2.487 | 3.553
L1L2C | 1067 | 4619 | 5609 | 74 | 8 | 347 | 2.721 | 3.546
L2D1C | 777 | 3314 | 4768 | 44 | 8 | 213 | 2.341 | 3.44
L2L3C | 702 | 3115 | 3842 | 74 | 7 | 337 | 2.666 | 3.06
L3L4C | 1058 | 4575 | 5522 | 62 | 8 | 293 | 2.823 | 3.285
L5L6C | 807 | 3501 | 4330 | 48 | 5 | 189 | 2.92 | 3.335