### PR TITLE
Reverting changes to unsigned variables causing Future SW CI crash

### DIFF
--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -158,7 +158,7 @@ void TrackBuilder(
     // object.
     ap_uint<3> nMatches = 0; // there can be up to eight matches (3 bits)
 
-    barrel_stub_association : for (short j = 0; j < NBarrelStubs; j++) {
+    barrel_stub_association : for (short j = 0; j < int(NBarrelStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
 
       const unsigned nFM = (j == 0 ? NFMPerStubBarrel0 : NFMPerStubBarrel);
       const unsigned nFMCumulative = (j == 0 ? 0 : (j == 1 ? NFMPerStubBarrel0 : NFMPerStubBarrel0 + (j - 1) * NFMPerStubBarrel));
@@ -227,10 +227,10 @@ void TrackBuilder(
       }
     }
 
-    disk_stub_association : for (short j = 0; j < NDiskStubs; j++) {
+    disk_stub_association : for (short j = 0; j < int(NDiskStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
 
       ap_uint<1> disk_stub_valid = false;
-      disk_stub_valid : for (short k = 0; k < NFMPerStubDisk; k++)
+      disk_stub_valid : for (short k = 0; k < int(NFMPerStubDisk); k++) // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
         disk_stub_valid = (disk_stub_valid || disk_valid[j * NFMPerStubDisk + k]);
       nMatches += (disk_stub_valid ? 1 : 0);
 
@@ -292,7 +292,7 @@ void TrackBuilder(
     // object that was constructed.
     if (track.getTrackValid()) {
       trackWord[nTracks] = track.getTrackWord();
-      barrel_stub_words: for (short j = 0 ; j < NBarrelStubs; j++) {
+      barrel_stub_words: for (short j = 0 ; j < int(NBarrelStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
         switch (j) {
           case 0:
             barrelStubWords[j][nTracks] = track.template getStubValid<0>() ? track.template getBarrelStubWord<0>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
@@ -308,7 +308,7 @@ void TrackBuilder(
             break;
         }
       }
-      disk_stub_words: for (short j = 0 ; j < NDiskStubs; j++) {
+      disk_stub_words: for (short j = 0 ; j < int(NDiskStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
         switch (j) {
           case 0:
             diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -158,7 +158,7 @@ void TrackBuilder(
     // object.
     ap_uint<3> nMatches = 0; // there can be up to eight matches (3 bits)
 
-    barrel_stub_association : for (short j = 0; j < int(NBarrelStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
+    barrel_stub_association : for (short j = 0; j < NBarrelStubs; j++) {
 
       const unsigned nFM = (j == 0 ? NFMPerStubBarrel0 : NFMPerStubBarrel);
       const unsigned nFMCumulative = (j == 0 ? 0 : (j == 1 ? NFMPerStubBarrel0 : NFMPerStubBarrel0 + (j - 1) * NFMPerStubBarrel));
@@ -227,10 +227,10 @@ void TrackBuilder(
       }
     }
 
-    disk_stub_association : for (short j = 0; j < int(NDiskStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
+    disk_stub_association : for (short j = 0; j < NDiskStubs; j++) {
 
       ap_uint<1> disk_stub_valid = false;
-      disk_stub_valid : for (short k = 0; k < int(NFMPerStubDisk); k++) // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
+      disk_stub_valid : for (short k = 0; k < NFMPerStubDisk; k++)
         disk_stub_valid = (disk_stub_valid || disk_valid[j * NFMPerStubDisk + k]);
       nMatches += (disk_stub_valid ? 1 : 0);
 
@@ -292,7 +292,7 @@ void TrackBuilder(
     // object that was constructed.
     if (track.getTrackValid()) {
       trackWord[nTracks] = track.getTrackWord();
-      barrel_stub_words: for (short j = 0 ; j < int(NBarrelStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
+      barrel_stub_words: for (short j = 0 ; j < NBarrelStubs; j++) {
         switch (j) {
           case 0:
             barrelStubWords[j][nTracks] = track.template getStubValid<0>() ? track.template getBarrelStubWord<0>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
@@ -308,7 +308,7 @@ void TrackBuilder(
             break;
         }
       }
-      disk_stub_words: for (short j = 0 ; j < int(NDiskStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
+      disk_stub_words: for (short j = 0 ; j < NDiskStubs; j++) {
         switch (j) {
           case 0:
             diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -68,14 +68,14 @@ void TrackBuilder(
 #pragma HLS array_partition variable=barrel_write_index complete dim=0
 #pragma HLS array_partition variable=disk_write_index complete dim=0
 
-  initialize_barrel_indices : for (short i = 0; i < NFMBarrel; i++) {
+  initialize_barrel_indices : for (short i = 0; NFMBarrel > 0 && i < NFMBarrel; i++) {
 #pragma HLS unroll
     barrel_mem_index[i] = 0;
     barrel_read_index[i] = 0;
     barrel_write_index[i] = 0;
   }
 
-  initialize_disk_indices : for (short i = 0; i < NFMDisk; i++) {
+  initialize_disk_indices : for (short i = 0; NFMDisk > 0 && i < NFMDisk; i++) {
 #pragma HLS unroll
     disk_mem_index[i] = 0;
     disk_read_index[i] = 0;
@@ -292,7 +292,7 @@ void TrackBuilder(
     // object that was constructed.
     if (track.getTrackValid()) {
       trackWord[nTracks] = track.getTrackWord();
-      barrel_stub_words: for (short j = 0 ; j < NBarrelStubs; j++) {
+      barrel_stub_words: for (short j = 0 ; NBarrelStubs > 0 && j < NBarrelStubs; j++) {
         switch (j) {
           case 0:
             barrelStubWords[j][nTracks] = track.template getStubValid<0>() ? track.template getBarrelStubWord<0>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
@@ -308,7 +308,7 @@ void TrackBuilder(
             break;
         }
       }
-      disk_stub_words: for (short j = 0 ; j < NDiskStubs; j++) {
+      disk_stub_words: for (short j = 0 ; NDiskStubs > 0 && j < NDiskStubs; j++) {
         switch (j) {
           case 0:
             diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -227,10 +227,10 @@ void TrackBuilder(
       }
     }
 
-    disk_stub_association : for (short j = 0; j < int(NDiskStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
+    disk_stub_association : for (short j = 0; j < int(NDiskStubs); j++) { // casting NDiskStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
 
       ap_uint<1> disk_stub_valid = false;
-      disk_stub_valid : for (short k = 0; k < int(NFMPerStubDisk); k++) // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
+      disk_stub_valid : for (short k = 0; k < int(NFMPerStubDisk); k++) // casting NFMPerStubDisk as signed for loop to prevent compilation error due to comparing signed and unsigned values
         disk_stub_valid = (disk_stub_valid || disk_valid[j * NFMPerStubDisk + k]);
       nMatches += (disk_stub_valid ? 1 : 0);
 
@@ -295,32 +295,32 @@ void TrackBuilder(
       barrel_stub_words: for (short j = 0 ; j < int(NBarrelStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
         switch (j) {
           case 0:
-            barrelStubWords[j][nTracks] = track.template getStubValid<0>() ? track.template getBarrelStubWord<0>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
+            barrelStubWords[j][nTracks] = track.template getStubValid<0>() ? track.template getBarrelStubWord<0>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::BarrelStubWord(0);
             break;
           case 1:
-            barrelStubWords[j][nTracks] = track.template getStubValid<1>() ? track.template getBarrelStubWord<1>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
+            barrelStubWords[j][nTracks] = track.template getStubValid<1>() ? track.template getBarrelStubWord<1>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::BarrelStubWord(0);
             break;
           case 2:
-            barrelStubWords[j][nTracks] = track.template getStubValid<2>() ? track.template getBarrelStubWord<2>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
+            barrelStubWords[j][nTracks] = track.template getStubValid<2>() ? track.template getBarrelStubWord<2>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::BarrelStubWord(0);
             break;
           case 3:
-            barrelStubWords[j][nTracks] = track.template getStubValid<3>() ? track.template getBarrelStubWord<3>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
+            barrelStubWords[j][nTracks] = track.template getStubValid<3>() ? track.template getBarrelStubWord<3>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::BarrelStubWord(0);
             break;
         }
       }
-      disk_stub_words: for (short j = 0 ; j < int(NDiskStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
+      disk_stub_words: for (short j = 0 ; j < int(NDiskStubs); j++) { // casting NDiskStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
         switch (j) {
           case 0:
-            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::DiskStubWord(0);
             break;
           case 1:
-            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 1>() ? track.template getDiskStubWord<NBarrelStubs + 1>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 1>() ? track.template getDiskStubWord<NBarrelStubs + 1>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::DiskStubWord(0);
             break;
           case 2:
-            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 2>() ? track.template getDiskStubWord<NBarrelStubs + 2>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 2>() ? track.template getDiskStubWord<NBarrelStubs + 2>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::DiskStubWord(0);
             break;
           case 3:
-            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 3>() ? track.template getDiskStubWord<NBarrelStubs + 3>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 3>() ? track.template getDiskStubWord<NBarrelStubs + 3>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::DiskStubWord(0);
             break;
         }
       }

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -158,7 +158,7 @@ void TrackBuilder(
     // object.
     ap_uint<3> nMatches = 0; // there can be up to eight matches (3 bits)
 
-    barrel_stub_association : for (unsigned short j = 0; j < NBarrelStubs; j++) {
+    barrel_stub_association : for (short j = 0; j < NBarrelStubs; j++) {
 
       const unsigned nFM = (j == 0 ? NFMPerStubBarrel0 : NFMPerStubBarrel);
       const unsigned nFMCumulative = (j == 0 ? 0 : (j == 1 ? NFMPerStubBarrel0 : NFMPerStubBarrel0 + (j - 1) * NFMPerStubBarrel));
@@ -227,10 +227,10 @@ void TrackBuilder(
       }
     }
 
-    disk_stub_association : for (unsigned short j = 0; j < NDiskStubs; j++) {
+    disk_stub_association : for (short j = 0; j < NDiskStubs; j++) {
 
       ap_uint<1> disk_stub_valid = false;
-      disk_stub_valid : for (unsigned short k = 0; k < NFMPerStubDisk; k++)
+      disk_stub_valid : for (short k = 0; k < NFMPerStubDisk; k++)
         disk_stub_valid = (disk_stub_valid || disk_valid[j * NFMPerStubDisk + k]);
       nMatches += (disk_stub_valid ? 1 : 0);
 
@@ -292,7 +292,7 @@ void TrackBuilder(
     // object that was constructed.
     if (track.getTrackValid()) {
       trackWord[nTracks] = track.getTrackWord();
-      barrel_stub_words: for (unsigned short j = 0 ; j < NBarrelStubs; j++) {
+      barrel_stub_words: for (short j = 0 ; j < NBarrelStubs; j++) {
         switch (j) {
           case 0:
             barrelStubWords[j][nTracks] = track.template getStubValid<0>() ? track.template getBarrelStubWord<0>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
@@ -308,7 +308,7 @@ void TrackBuilder(
             break;
         }
       }
-      disk_stub_words: for (unsigned short j = 0 ; j < NDiskStubs; j++) {
+      disk_stub_words: for (short j = 0 ; j < NDiskStubs; j++) {
         switch (j) {
           case 0:
             diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -308,7 +308,7 @@ void TrackBuilder(
             break;
         }
       }
-      disk_stub_words: for (short j = 0 ; j < static_cast<int>(NDiskStubs); j++) {
+      disk_stub_words: for (short j = 0 ; j < NDiskStubs; j++) {
         switch (j) {
           case 0:
             diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -68,14 +68,14 @@ void TrackBuilder(
 #pragma HLS array_partition variable=barrel_write_index complete dim=0
 #pragma HLS array_partition variable=disk_write_index complete dim=0
 
-  initialize_barrel_indices : for (short i = 0; NFMBarrel > 0 && i < NFMBarrel; i++) {
+  initialize_barrel_indices : for (short i = 0; NFMBarrel > 0 && i < NFMBarrel; i++) { // Note: need to have NFMBarrel > 0 to prevent compilation error due to -Werror=type-limits flag in CMSSW
 #pragma HLS unroll
     barrel_mem_index[i] = 0;
     barrel_read_index[i] = 0;
     barrel_write_index[i] = 0;
   }
 
-  initialize_disk_indices : for (short i = 0; NFMDisk > 0 && i < NFMDisk; i++) {
+  initialize_disk_indices : for (short i = 0; NFMDisk > 0 && i < NFMDisk; i++) { // Note: need to have NFMDisk > 0 to prevent compilation error due to -Werror=type-limits flag in CMSSW
 #pragma HLS unroll
     disk_mem_index[i] = 0;
     disk_read_index[i] = 0;
@@ -96,7 +96,7 @@ void TrackBuilder(
 
     // First determine the minimum tracklet ID from the current set of full
     // matches.
-    barrel_min_id : for (short j = 0; j < NFMBarrel; j++) {
+    barrel_min_id : for (short j = 0; j < NFMBarrel; j++) { 
 
       const auto &barrel_stub_0 = barrel_fm[j][barrel_read_index[j]];
       const auto &barrel_id_0 = barrel_stub_0.getTrackletID();
@@ -292,7 +292,7 @@ void TrackBuilder(
     // object that was constructed.
     if (track.getTrackValid()) {
       trackWord[nTracks] = track.getTrackWord();
-      barrel_stub_words: for (short j = 0 ; NBarrelStubs > 0 && j < NBarrelStubs; j++) {
+      barrel_stub_words: for (short j = 0 ; NBarrelStubs > 0 && j < NBarrelStubs; j++) { // Note: need to have NBarrelStubs > 0 to prevent compilation error due to -Werror=type-limits flag in CMSSW
         switch (j) {
           case 0:
             barrelStubWords[j][nTracks] = track.template getStubValid<0>() ? track.template getBarrelStubWord<0>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
@@ -308,7 +308,7 @@ void TrackBuilder(
             break;
         }
       }
-      disk_stub_words: for (short j = 0 ; NDiskStubs > 0 && j < NDiskStubs; j++) {
+      disk_stub_words: for (short j = 0 ; NDiskStubs > 0 && j < NDiskStubs; j++) { // Note: need to have NDiskStubs > 0 to prevent compilation error due to -Werror=type-limits flag in CMSSW
         switch (j) {
           case 0:
             diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -227,10 +227,10 @@ void TrackBuilder(
       }
     }
 
-    disk_stub_association : for (short j = 0; j < int(NDiskStubs); j++) { // casting NDiskStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
+    disk_stub_association : for (short j = 0; j < int(NDiskStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
 
       ap_uint<1> disk_stub_valid = false;
-      disk_stub_valid : for (short k = 0; k < int(NFMPerStubDisk); k++) // casting NFMPerStubDisk as signed for loop to prevent compilation error due to comparing signed and unsigned values
+      disk_stub_valid : for (short k = 0; k < int(NFMPerStubDisk); k++) // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
         disk_stub_valid = (disk_stub_valid || disk_valid[j * NFMPerStubDisk + k]);
       nMatches += (disk_stub_valid ? 1 : 0);
 
@@ -295,32 +295,32 @@ void TrackBuilder(
       barrel_stub_words: for (short j = 0 ; j < int(NBarrelStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
         switch (j) {
           case 0:
-            barrelStubWords[j][nTracks] = track.template getStubValid<0>() ? track.template getBarrelStubWord<0>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::BarrelStubWord(0);
+            barrelStubWords[j][nTracks] = track.template getStubValid<0>() ? track.template getBarrelStubWord<0>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
             break;
           case 1:
-            barrelStubWords[j][nTracks] = track.template getStubValid<1>() ? track.template getBarrelStubWord<1>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::BarrelStubWord(0);
+            barrelStubWords[j][nTracks] = track.template getStubValid<1>() ? track.template getBarrelStubWord<1>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
             break;
           case 2:
-            barrelStubWords[j][nTracks] = track.template getStubValid<2>() ? track.template getBarrelStubWord<2>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::BarrelStubWord(0);
+            barrelStubWords[j][nTracks] = track.template getStubValid<2>() ? track.template getBarrelStubWord<2>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
             break;
           case 3:
-            barrelStubWords[j][nTracks] = track.template getStubValid<3>() ? track.template getBarrelStubWord<3>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::BarrelStubWord(0);
+            barrelStubWords[j][nTracks] = track.template getStubValid<3>() ? track.template getBarrelStubWord<3>() : typename TrackFit<NBarrelStubs, NDiskStubs>::BarrelStubWord(0);
             break;
         }
       }
-      disk_stub_words: for (short j = 0 ; j < int(NDiskStubs); j++) { // casting NDiskStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
+      disk_stub_words: for (short j = 0 ; j < int(NDiskStubs); j++) { // casting NBarrelStubs as signed for loop to prevent compilation error due to comparing signed and unsigned values
         switch (j) {
           case 0:
-            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
             break;
           case 1:
-            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 1>() ? track.template getDiskStubWord<NBarrelStubs + 1>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 1>() ? track.template getDiskStubWord<NBarrelStubs + 1>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
             break;
           case 2:
-            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 2>() ? track.template getDiskStubWord<NBarrelStubs + 2>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 2>() ? track.template getDiskStubWord<NBarrelStubs + 2>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
             break;
           case 3:
-            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 3>() ? track.template getDiskStubWord<NBarrelStubs + 3>() : typename TrackFit<unsigned(NBarrelStubs), unsigned(NDiskStubs)>::DiskStubWord(0);
+            diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs + 3>() ? track.template getDiskStubWord<NBarrelStubs + 3>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);
             break;
         }
       }

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -308,7 +308,7 @@ void TrackBuilder(
             break;
         }
       }
-      disk_stub_words: for (short j = 0 ; j < NDiskStubs; j++) {
+      disk_stub_words: for (short j = 0 ; j < static_cast<int>(NDiskStubs); j++) {
         switch (j) {
           case 0:
             diskStubWords[j][nTracks] = track.template getStubValid<NBarrelStubs>() ? track.template getDiskStubWord<NBarrelStubs>() : typename TrackFit<NBarrelStubs, NDiskStubs>::DiskStubWord(0);


### PR DESCRIPTION
Reverts changes made in [PR #304](https://github.com/cms-L1TK/firmware-hls/commit/ef302d560796da50d762637c4ae688c29d46caa8) that changes various looped over variables in TrackBuilder.h to signed, causing `error: comparison is always false due to limited range of data type [-Werror=type-limits]` in [future SW CI](https://gitlab.cern.ch/ejclemen/cmssw_trackfinding_hlsframework/-/jobs/34803045). Because this warning has been flagged as an error centrally in CMSSW, the only current fix for this is to revert these variables to not being unsigned.