### PR TITLE
Fixed disk projections extra entries

### DIFF
--- a/TrackletAlgorithm/ProjectionCalculator.h
+++ b/TrackletAlgorithm/ProjectionCalculator.h
@@ -154,10 +154,10 @@ template<
       constexpr int itcut = 1.0/kt;
 
       const TrackletProjection<DISK> tproj_D1(TCID, trackletIndex, iphi_D1, ir_D1, ider_phiD, ider_rD);
-      bool validD1 = true;
+      bool validD1 = ir_D1 >= irmindisk && ir_D1 < irmaxdisk && ((t > itcut) || (t<-itcut)) && !addL6;
 
       const TrackletProjection<DISK> tproj_D2(TCID, trackletIndex, iphi_D2, ir_D2, ider_phiD, ider_rD);
-      bool validD2 = true;
+      bool validD2 = ir_D2 >= irmindisk && ir_D2 < irmaxdisk && ((t > itcut) || (t<-itcut)) && !addL5;
 
       const TrackletProjection<DISK> tproj_D3(TCID, trackletIndex, iphi_D3, ir_D3, ider_phiD, ider_rD);
       bool validD3 = ir_D3 >= irmindisk && ir_D3 < irmaxdisk && ((t > itcut) || (t<-itcut)) && !addL4;


### PR DESCRIPTION
This commit adds a valid check for disks 1 & 2 following the logic in TrackletCalculator.h, the code no longer produces extra entries in disks 1 and 2. 