### PR TITLE
Update Get Bit Str Functions

### DIFF
--- a/TrackletAlgorithm/FullMatchMemory.h
+++ b/TrackletAlgorithm/FullMatchMemory.h
@@ -259,6 +259,7 @@ public:
     std::string str = decodeToBits(getTCID());
     str += "|"+decodeToBits(getTrackletIndex());
     str += "|"+decodeToBits(getStubIndex());
+    str += "|"+decodeToBits(getStubR());
     str += "|"+decodeToBits(getPhiRes());
     str += "|"+decodeToBits(getZRes());
     return str;

--- a/TrackletAlgorithm/TrackletParameterMemory.h
+++ b/TrackletAlgorithm/TrackletParameterMemory.h
@@ -135,7 +135,8 @@ public:
   
 #ifdef CMSSW_GIT_HASH
   std::string getBitStr() const {
-    std::string str = decodeToBits(getStubIndexInner());
+    std::string str = decodeToBits(getPhiRegion());
+    str += "|"+decodeToBits(getStubIndexInner());
     str += "|"+decodeToBits(getStubIndexOuter());
     str += "|"+decodeToBits(getRinv());
     str += "|"+decodeToBits(getPhi0());


### PR DESCRIPTION
This PR updates two getBitStr functions for the CMSSW future SW.

This adds the stub R to the full match function and phi to TrackletParameter function.