### PR TITLE
VMRCM - Number of AllStubInner memories fix

### DIFF
--- a/TestBenches/VMRouterCM_test.cpp
+++ b/TestBenches/VMRouterCM_test.cpp
@@ -141,7 +141,7 @@ int main() {
     }
     // Allstub Inner memories
     if (nASInnerCopies) {
-      for (unsigned int i = 0; i < numASInnerCopies; i++) {
+      for (unsigned int i = 0; i < nASInnerCopies; i++) {
         err += compareMemWithFile<AllStubInnerMemory<outputType>>(memoriesASInner[i], fout_allstubs_inner[i], ievt, "AllStubInner", truncation);
       }
     }

--- a/TestBenches/VMRouterCM_test.cpp
+++ b/TestBenches/VMRouterCM_test.cpp
@@ -50,7 +50,7 @@ int main() {
   const auto nVMSTE = tb.nFiles(tePattern);
 
   // Make sure that the number of input and output memories are correct
-  assert((nInputStubs == numInputs) && (nInputStubsDisk2S == numInputsDisk2S) && (nASCopies == numASCopies) && (nVMSTE == numTEOCopies));
+  assert((nInputStubs == numInputs) && (nInputStubsDisk2S == numInputsDisk2S) && (nASCopies == numASCopies) && (nASInnerCopies == numASInnerCopies) && (nVMSTE == numTEOCopies));
 
   // Open the files
   cout << "Open files..." << endl;

--- a/TrackletAlgorithm/VMRouterCM.h
+++ b/TrackletAlgorithm/VMRouterCM.h
@@ -226,9 +226,11 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 #pragma HLS array_partition variable=addrCountME complete dim=0
 #pragma HLS array_partition variable=addrCountTE complete dim=0
 
-	for (int i = 0; i < nAllInnerCopies; i++) {
+	if (nAllInnerCopies) {
+		for (int i = 0; i < nAllInnerCopies; i++) {
 #pragma HLS unroll
-		addrCountASI[i] = 0;
+			addrCountASI[i] = 0;
+		}
 	}
 	for (int i = 0; i < 1 << (rzSizeME + phiRegSize); i++) {
 #pragma HLS unroll

--- a/emData/generate_VMRCM.py
+++ b/emData/generate_VMRCM.py
@@ -292,7 +292,7 @@ def writeParameterFile(vmr_list, mem_dict, output_dir):
             "  return " + str(len(mem_dict["AS_"+vmr])) + ";\n"
             "}\n"
             "template<> constexpr int getNumASInnerCopies<TF::" + layer_disk_char + str(layer_disk_num) + ", TF::" + phi_region + ">(){ // Allstub Inner memory\n"
-            "  return " + str(len(mem_dict["ASI_"+vmr]) if mem_dict["ASI_"+vmr] else 1) + ";\n"
+            "  return " + str(len(mem_dict["ASI_"+vmr])) + ";\n"
             "}\n"
             "template<> constexpr int getNumTEOCopies<TF::" + layer_disk_char + str(layer_disk_num) + ", TF::" + phi_region + ">(){ // TE Outer memories\n"
             "  return " + str(max_copy_count) + ";\n"

--- a/emData/generate_VMRCM.py
+++ b/emData/generate_VMRCM.py
@@ -362,7 +362,7 @@ def writeTopHeader(vmr, output_dir):
         "// Maximum number of memory \"copies\" for this Phi region\n"
         "constexpr int numASCopies = getNumASCopies<layerdisk, phiRegion>(); // Allstub memory\n"
         "constexpr int numASInnerCopies = getNumASInnerCopies<layerdisk, phiRegion>(); // Allstub Inner memory\n"
-        "constexpr int numTEOCopies = getNumTEOCopies<layerdisk, phiRegion>(); // TE Outer memories, can be 0 when no TEOuter memories\n"
+        "constexpr int numTEOCopies = getNumTEOCopies<layerdisk, phiRegion>(); // TE Outer memories\n"
         "// Number of bits for the RZ bins \n"
         "constexpr int kNbitsrzbinME = kNbitsrzbin%s; // For the VMSME memories\n" % ("MELayer" if layer else "MEDisk") +\
         "\n\n"


### PR DESCRIPTION
The number of AllStubInner memories could previously not be set to 0 or the HLS synthesis would crash, so it was set to 1 even though no AllStubInner memories were present in some modules. @tomalin implicitly requested a fix for this so here it is :-) 