### PR TITLE
Remove Memory copies in CMSSW

### DIFF
--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -15,7 +15,6 @@ template<int> class AllStub;
 #endif
 
 #ifdef CMSSW_GIT_HASH
-#define NBIT_BX 0
 template<class DataType, unsigned int DUMMY, unsigned int NBIT_ADDR>
 #else
 template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR>
@@ -28,6 +27,10 @@ template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR>
 // (1<<NBIT_ADDR): depth of the memory for each BX
 class MemoryTemplate
 {
+#ifdef CMSSW_GIT_HASH
+  static constexpr unsigned int NBIT_BX = 0;
+#endif
+
 public:
   typedef typename DataType::BitWidths BitWidths;
   typedef ap_uint<NBIT_BX> BunchXingT;

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -14,7 +14,7 @@
 #endif
 
 #ifdef CMSSW_GIT_HASH
-template<class DataType, unsigned int DUMMYA, unsigned int NBIT_ADDR, unsigned int NBIT_BIN, unsigned int kNBitsphibinCM, unsigned int NCOPY>
+template<class DataType, unsigned int DUMMY, unsigned int NBIT_ADDR, unsigned int NBIT_BIN, unsigned int kNBitsphibinCM, unsigned int NCOPY>
 #else
 template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR, unsigned int NBIT_BIN, unsigned int kNBitsphibinCM, unsigned int NCOPY>
 #endif


### PR DESCRIPTION
MemoryTemplateBinnedCM creates NCOPY identical copies of each memory. Whilst needed in FW, these are a waste of memory in CMSSW. The change to MemoryTemplateBinnedCM proposed here, (which should only affect CMSSW use), makes it pretend to the outside world that it has NCOPY copies, whilst internally it actually only has a single copy. I've checked that the Future SW is unaffected by this. (Though I believe this change is needed to allow it to be migrated to CMSSW 14).
P.S. Also made a small change to MemoryTemplate.h, to stop NBIT_BX appearing in the global space when running within CMSSW. It is now contained inside the class.