### PR TITLE
Change FileRead function to inline

### DIFF
--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -125,7 +125,7 @@ void writeMemFromFile(MemType& memory, std::ifstream& fin, int ievt, int base=16
   
 }
 
-std::string return_splitted(const std::string &data_string, const std::vector<int>& bit_widths,
+inline std::string return_splitted(const std::string &data_string, const std::vector<int>& bit_widths,
                             const std::vector<std::string> names,
                             const int start_index = 0)
 {


### PR DESCRIPTION
The return_splitted function in FileReadUtility.h is declared inline. This small change is needed in order to make the Future Software simulation code compile, and does not change anything on the firmware side.