### PR TITLE
ProjectionCalculator pragmas

### DIFF
--- a/emData/generate_PC.py
+++ b/emData/generate_PC.py
@@ -96,6 +96,8 @@ open(os.path.join(dirname, arguments.outputDirectory, "ProjectionCalculatorTop.c
       "    TrackletProjectionMemory<BARREL2S> projout_barrel_2s[TC::N_PROJOUT_BARREL2S],\n"
       "    TrackletProjectionMemory<DISK> projout_disk[TC::N_PROJOUT_DISK]\n"
       ") {\n"
+      "#pragma HLS pipeline II=1\n"
+      "#pragma HLS latency min=13 max=13\n"
       "#pragma HLS inline recursive\n"
       "#pragma HLS interface register port=bx_o\n"
       "#pragma HLS array_partition variable=projout_barrel_ps complete dim=1\n"


### PR DESCRIPTION
This PR adds pipeline and latency pragmas to the top function for the ProjectionCalculator. This reduces the max interval to one and makes the latency a consistent 13 clock cycles for all seeds (see performance estimates from HLS below).

The rewind option is not included with the pipeline pragma because it has no effect for function pipelining. HLS itself tells me so:
```
WARNING: [XFORM 203-532] Ignored the rewind option for Function 'ProjectionCalculator_L1L2C' (../TopFunctions/CombinedConfig/ProjectionCalculatorTop.cc:556) as the option is not applicable to function pipelining.
```

I also found that this seems to work without having to remove the control ports on the interface. As @tschuh mentioned, it's probably safest to not mess with those.

### Performance estimates for L1L2C
```
+ Timing: 
    * Summary: 
    +--------+---------+----------+------------+
    |  Clock |  Target | Estimated| Uncertainty|
    +--------+---------+----------+------------+
    |ap_clk  | 4.00 ns | 2.109 ns |   0.50 ns  |
    +--------+---------+----------+------------+

+ Latency: 
    * Summary: 
    +---------+---------+-----------+-----------+-----+-----+----------+
    |  Latency (cycles) |   Latency (absolute)  |  Interval | Pipeline |
    |   min   |   max   |    min    |    max    | min | max |   Type   |
    +---------+---------+-----------+-----------+-----+-----+----------+
    |       13|       13| 52.000 ns | 52.000 ns |    1|    1| function |
    +---------+---------+-----------+-----------+-----+-----+----------+
```

### Performance estimates for L5L6C
```
+ Timing: 
    * Summary: 
    +--------+---------+----------+------------+
    |  Clock |  Target | Estimated| Uncertainty|
    +--------+---------+----------+------------+
    |ap_clk  | 4.00 ns | 1.913 ns |   0.50 ns  |
    +--------+---------+----------+------------+

+ Latency: 
    * Summary: 
    +---------+---------+-----------+-----------+-----+-----+----------+
    |  Latency (cycles) |   Latency (absolute)  |  Interval | Pipeline |
    |   min   |   max   |    min    |    max    | min | max |   Type   |
    +---------+---------+-----------+-----------+-----+-----+----------+
    |       13|       13| 52.000 ns | 52.000 ns |    1|    1| function |
    +---------+---------+-----------+-----------+-----+-----+----------+
```