### PR TITLE
Future SW CMSSW Fix

### DIFF
--- a/TrackletAlgorithm/AllStubInnerMemory.h
+++ b/TrackletAlgorithm/AllStubInnerMemory.h
@@ -462,7 +462,7 @@ public:
     str += "|"+decodeToBits(getZ());
     str += "|"+decodeToBits(getPhi());
     str += "|"+decodeToBits(getBend());
-    if (ASType == DISKPS || ASType == DISK2S) str += "|"+decodeToBits(getNegDisk());
+    str += "|"+decodeToBits(getNegDisk());
     str += "|"+decodeToBits(getIndex());
     str += "|"+decodeToBits(getFinePhi());
     return str;


### PR DESCRIPTION
Remove the ASType dependence from the getBitStr function in the new AllStubInner DISKPS type