### PR TITLE
MP disk II fixes

### DIFF
--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -394,7 +394,7 @@ inline ap_uint<kNBits_MemAddr> getProjSeqOld() {
 
 inline ap_uint<kNBits_MemAddr> getProjSeq() {
 #pragma HLS inline
- 
+#pragma HLS array_partition variable=projseqs_ complete
   return empty()?(good____?projseq____:projseqcache_):projseqs_[readindex_];
 
 }
@@ -425,6 +425,7 @@ inline MATCH read() {
 
 inline MATCH peek() {
 #pragma HLS inline  
+#pragma HLS array_partition variable=matches_ complete
   return matches_[readindex_];
 }
  

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -230,8 +230,8 @@ void readTable(ap_uint<1> table[]){
   if (L==TF::D5) {
     bool tmp[768]=
 #include "../emData/MP/tables/METable_D5.tab"
-#pragma HLS unroll
     for (int i=0;i<768;++i){
+#pragma HLS unroll
       table[i]=tmp[i];
     }
   }


### PR DESCRIPTION
PR fixes a few pragmas related to II issues in the MP disks. MP_D5 now meets II = 2, same as the other MPs. There is still an II violation related to the calculations of best_delta_rphi, but this will require more reworking such as is in PR [334](https://github.com/cms-L1TK/firmware-hls/pull/334)