### PR TITLE
Number of events for PC and VMSMER

### DIFF
--- a/TestBenches/ProjectionCalculator_test.cpp
+++ b/TestBenches/ProjectionCalculator_test.cpp
@@ -31,9 +31,13 @@
 #endif
 #if !defined TOP_FUNC_
   #define TOP_FUNC_ ProjectionCalculator_L1L2ABC
-#endif
 
-const int nevents = 10;  //number of events to run
+  // number of events to run during C/RTL cosimulation
+  const int nevents = 10;
+#else
+  // number of events to run during C-simulation
+  const int nevents = 100;
+#endif
 
 using namespace std;
 

--- a/TestBenches/VMStubMERouter_test.cpp
+++ b/TestBenches/VMStubMERouter_test.cpp
@@ -10,6 +10,12 @@
 #if !defined TOP_FUNC_
   #define TOP_FUNC_ VMStubMERouterTop_L1PHIA
   #define HEADER_FILE_ "VMStubMERouterTop_L1PHIA.h"
+
+  // number of events to run during C/RTL cosimulation
+  const int nEvents = 10;
+#else
+  // number of events to run during C-simulation
+  const int nEvents = 100;
 #endif
 
 #include HEADER_FILE_
@@ -20,8 +26,6 @@
 #include "FileReadUtility.h"
 
 using namespace std;
-
-const int nEvents = 10;  //number of events to run
 
 int main() {
 


### PR DESCRIPTION
Currently, only ten events are used in the test benches for the PC and VMSMER for both C-simulation and C/RTL cosimulation because the latter takes a very long time to run. This PR just updates the number for C-simulation to 100, as are used in the test benches for the other modules.