### PR TITLE
Removed NBIT_BX from global name space

### DIFF
--- a/TrackletAlgorithm/MemoryTemplateTPROJ.h
+++ b/TrackletAlgorithm/MemoryTemplateTPROJ.h
@@ -21,7 +21,6 @@ template<int> class AllStub;
 #endif
 
 #ifdef CMSSW_GIT_HASH
-#define NBIT_BX 0
 template<class DataType, unsigned int DUMMY, unsigned int NBIT_ADDR, unsigned int NPAGE = 4 >
 #else
 template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR, unsigned int NPAGE = 4 >
@@ -36,6 +35,10 @@ template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR, unsigned 
 // ordering of the different TP outputs
 class MemoryTemplateTPROJ
 {
+#ifdef CMSSW_GIT_HASH
+  static constexpr unsigned int NBIT_BX = 0;
+#endif
+
 public:
   typedef typename DataType::BitWidths BitWidths;
   typedef ap_uint<NBIT_BX> BunchXingT;


### PR DESCRIPTION
In MemoryTemplateTPROJ.h, the pragma variable NBIT_BX was defined in the global namespace, which led to clashes when this header file was used in the CMSSW code. I've moved it inside the class to avoid this, as is already done in MemoryTemplate.h.