### PR TITLE
MP timing improvement

### DIFF
--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -1274,7 +1274,6 @@ void MatchProcessor(BXType bx,
   MatchEngineUnit<VMSMEType, kNbitsrzbinMP, VMPTYPE, APTYPE, LAYER, ASTYPE> matchengine[kNMatchEngines];
 #pragma HLS ARRAY_PARTITION variable=matchengine complete
 #pragma HLS ARRAY_PARTITION variable=projin dim=1
-#pragma HLS ARRAY_PARTITION variable=numbersin complete
   
 
 

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -1654,9 +1654,6 @@ void MatchProcessor(BXType bx,
     read_inmem<TrackletProjection<PROJTYPE>, TrackletProjectionMemory<PROJTYPE>, nMEM>(projdata, bx, read_address, imem, ipage, projin);
 
     // read inputs
-    //validin = read_input_mems<TrackletProjection<PROJTYPE>, TrackletProjectionMemory<PROJTYPE>, nMEM, kNBits_MemAddr+1>
-    //(bx, mem_hasdata, numbersin, mem_read_addr, iMem, iPage, projin, projdata);
-
     validmem = !projBuffNearFull;
     read_address =  mem_read_addr;
     read_input_mems<TrackletProjection<PROJTYPE>, TrackletProjectionMemory<PROJTYPE>, nMEM, kNBits_MemAddr+1>


### PR DESCRIPTION
This PR includes a minor update to improve the timing of the MP, similar to what was described here:
https://indico.cern.ch/event/1449861/contributions/6104539/attachments/2916594/5118500/hlsChat_20240827.pdf#page=11
In contrast to what was shown there, this update has no effect on the results of the C-simulation for any of the modules tested.

The results of the out-of-context implementation for the standalone MP_D1PHIC are as follows:
|  | Before this update | After this update |
| ------------- | ------------- | ------------- |
| LUT | 4589 | 2784 |
| FF | 4127 | 3202 |
| DSP | 5 | 5 |
| BRAM | 4 | 4 |
| CP achieved | 3.596 ns | 3.375 ns |

As expected, the timing improves, and the resource utilization also improves quite a bit.