### PR TITLE
Attempt to fix Future L1 Track SW + bugs in HLS memory classes.

### DIFF
--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -256,9 +256,9 @@ unsigned int compareMemWithMemPage(const MemType& memory_ref, const MemType& mem
   constexpr int lsb = (LSB >= 0 && MSB >= LSB) ? LSB : 0;
   constexpr int msb = (LSB >= 0 && MSB >= LSB) ? MSB : MemType::getWidth() - 1;
 
-  for (unsigned int ipage = 0; ipage < 4; ++ipage) {
+  for (unsigned int ipage = 0; ipage < memory_ref.getNPage(); ++ipage) {
     //FIXME
-    for (unsigned int i = 0; i < memory_ref.getDepth()/4; ++i) {
+    for (unsigned int i = 0; i < memory_ref.getDepth(); ++i) {
       const auto data_ref_raw = memory_ref.read_mem(ievt,i,ipage).raw();
       const auto data_com_raw = memory.read_mem(ievt,i,ipage).raw();
       const auto data_ref = data_ref_raw.range(msb,lsb);

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -901,7 +901,7 @@ template<TF::layerDisk Layer, TF::phiRegion PHI> constexpr uint32_t NPageSum();
 
 #include "MatchProcessor_parameters.h"
 
-template<regionType ASTYPE, regionType APTYPE, regionType VMSMEType, regionType FMTYPE, int maxFullMatchCopies, TF::layerDisk LAYER=TF::L1, TF::phiRegion PHISEC=TF::A>
+template<regionType ASTYPE, regionType APTYPE, regionType VMSMEType, regionType FMTYPE, int maxFullMatchVariants, TF::layerDisk LAYER=TF::L1, TF::phiRegion PHISEC=TF::A>
 void MatchCalculator(BXType bx,
                      ap_uint<1> newtracklet,
                      ap_uint<1>& isMatch,
@@ -913,7 +913,7 @@ void MatchCalculator(BXType bx,
                      const AllStubMemory<ASTYPE>* allstub,
                      const AllProjection<APTYPE>& proj,
                      ap_uint<VMStubMECMBase<VMSMEType>::kVMSMEIDSize> stubid,
-                     FullMatchMemory<FMTYPE> fullmatch[maxFullMatchCopies]
+                     FullMatchMemory<FMTYPE> fullmatch[maxFullMatchVariants]
 ){
 
 #pragma HLS inline
@@ -1180,7 +1180,7 @@ constexpr unsigned kNbitsrzbinMPDisk = kNbitsrzbin + 1;
 
 //////////////////////////////
 // MatchProcessor
-template<regionType PROJTYPE, regionType VMSMEType, unsigned kNbitsrzbinMP, regionType VMPTYPE, regionType ASTYPE, regionType FMTYPE, unsigned int nINMEM, int maxFullMatchCopies,
+template<regionType PROJTYPE, regionType VMSMEType, unsigned kNbitsrzbinMP, regionType VMPTYPE, regionType ASTYPE, regionType FMTYPE, unsigned int nINMEM, int maxFullMatchVariants,
          TF::layerDisk LAYER=TF::L1, TF::phiRegion PHISEC=TF::A>
 void MatchProcessor(BXType bx,
                       // because Vivado HLS cannot synthesize an array of
@@ -1190,7 +1190,7 @@ void MatchProcessor(BXType bx,
                       const VMStubMEMemoryCM<VMSMEType, kNbitsrzbinMP, kNbitsphibin, kNMatchEngines>& instubdata,
                       const AllStubMemory<ASTYPE>* allstub,
                       BXType& bx_o,
-                      FullMatchMemory<FMTYPE> fullmatch[maxFullMatchCopies]
+                      FullMatchMemory<FMTYPE> fullmatch[maxFullMatchVariants]
 ){
 #pragma HLS inline
 
@@ -1458,7 +1458,7 @@ void MatchProcessor(BXType bx,
 
     if (hasMatch_save) {
       isMatch = newtracklet_save ? ap_uint<1>(0) : isMatch;
-      MatchCalculator<ASTYPE, APTYPE, VMSMEType, FMTYPE, maxFullMatchCopies, LAYER, PHISEC>
+      MatchCalculator<ASTYPE, APTYPE, VMSMEType, FMTYPE, maxFullMatchVariants, LAYER, PHISEC>
         (bx, newtracklet_save, isMatch, savedMatch, best_delta_z, best_delta_phi, best_delta_rphi, best_delta_r, allstub, allproj_save, stubindex_save,
          fullmatch);
     }
@@ -1483,7 +1483,6 @@ void MatchProcessor(BXType bx,
       newtracklet_save = newtracklet;
       allproj_save = allproj;
       stubindex_save = stubindex;
-
     } //end MC if
     
 

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -56,16 +56,16 @@ public:
 
   NEntryT getEntries(BunchXingT bx) const {
 #pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
-	return nentries_[bx];
+    return nentries_[bx];
   }
 
   const DataType (&get_mem() const)[DEPTH_BX][DEPTH_ADDR] {return dataarray_;}
 
   DataType read_mem(BunchXingT ibx, ap_uint<NBIT_ADDR> index) const
   {
-	// TODO: check if valid
-	if(!NBIT_BX) ibx = 0;
-	return dataarray_[ibx][index];
+    // TODO: check if valid
+    if(!NBIT_BX) ibx = 0;
+    return dataarray_[ibx][index];
   }
 
   template<class SpecType>
@@ -76,7 +76,7 @@ public:
 #ifdef __SYNTHESIS__
       0;
 #else
-      nentries_[ibx];
+    nentries_[ibx];
 #endif
     return write_mem(ibx,data,addr_index);
   }
@@ -87,10 +87,10 @@ public:
 #pragma HLS inline
     if(!NBIT_BX) ibx = 0;
     static_assert(
-      std::is_same<DataType, SpecType>::value
-      || (std::is_same<DataType, AllStub<DISK> >::value && std::is_same<SpecType, AllStub<DISKPS> >::value)
-      || (std::is_same<DataType, AllStub<DISK> >::value && std::is_same<SpecType, AllStub<DISK2S> >::value)
-      , "Invalid conversion between data types");
+                  std::is_same<DataType, SpecType>::value
+                  || (std::is_same<DataType, AllStub<DISK> >::value && std::is_same<SpecType, AllStub<DISKPS> >::value)
+                  || (std::is_same<DataType, AllStub<DISK> >::value && std::is_same<SpecType, AllStub<DISK2S> >::value)
+                  , "Invalid conversion between data types");
     DataType sameData(data.raw());
     return write_mem(ibx,sameData,addr_index);
   }
@@ -102,7 +102,7 @@ public:
 #ifdef __SYNTHESIS__
       0;
 #else
-      nentries_[ibx];
+    nentries_[ibx];
 #endif
     return write_mem(ibx,data,addr_index);
   }
@@ -130,7 +130,7 @@ public:
     }
   }
 
-    bool write_mem_new(BunchXingT ibx, DataType data, ap_uint<1> overwrite)
+  bool write_mem_new(BunchXingT ibx, DataType data, ap_uint<1> overwrite)
   {
 #pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
 #pragma HLS inline
@@ -141,9 +141,9 @@ public:
       dataarray_[ibx][0] = data;
 #else
       if(overwrite == 0) {
-	dataarray_[ibx][nentries_[ibx]++] = data;
+        dataarray_[ibx][nentries_[ibx]++] = data;
       } else {
-	dataarray_[ibx][nentries_[ibx]-1] = data;
+        dataarray_[ibx][nentries_[ibx]-1] = data;
       }
 #endif
 
@@ -157,7 +157,7 @@ public:
 #ifndef __SYNTHESIS__
   MemoryTemplate()
   {
-       clear();
+    clear();
   }
 
   ~MemoryTemplate(){}
@@ -165,7 +165,7 @@ public:
   void clear()
   {
     DataType data("0",16);
-    MEM_RST: for (size_t ibx=0; ibx<DEPTH_BX; ++ibx) {
+  MEM_RST: for (size_t ibx=0; ibx<DEPTH_BX; ++ibx) {
       nentries_[ibx] = 0;
       for (size_t addr=0; addr<DEPTH_ADDR; ++addr) {
         write_mem(ibx,data,addr);
@@ -176,47 +176,47 @@ public:
   // write memory from text file
   bool write_mem(BunchXingT ibx, const char* datastr, int base=16)
   { 
-        if(!NBIT_BX) ibx = 0;
-	DataType data(datastr, base);
-	NEntryT nent = nentries_[ibx]; 
-	bool success = write_mem(ibx, data, nent);
+    if(!NBIT_BX) ibx = 0;
+    DataType data(datastr, base);
+    NEntryT nent = nentries_[ibx]; 
+    bool success = write_mem(ibx, data, nent);
 
-	return success;
+    return success;
   }
 
   bool write_mem(BunchXingT ibx, const std::string& datastr, int base=16)
   {
-	return write_mem(ibx, datastr.c_str(), base);
+    return write_mem(ibx, datastr.c_str(), base);
   }
 
   // print memory contents
   void print_data(const DataType data) const
   {
     edm::LogVerbatim("L1trackHLS") << std::hex << data.raw() << std::endl;
-        // TODO: overload '<<' in data class
+    // TODO: overload '<<' in data class
   }
 
   void print_entry(BunchXingT bx, NEntryT index) const
   {
-	print_data(dataarray_[bx][index]);
+    print_data(dataarray_[bx][index]);
   }
 
   void print_mem(BunchXingT bx) const
   {
-	for (unsigned int i = 0; i <  nentries_[bx]; ++i) {
-	  edm::LogVerbatim("L1trackHLS") << bx << " " << i << " ";
-	  print_entry(bx,i);
-	}
+    for (unsigned int i = 0; i <  nentries_[bx]; ++i) {
+      edm::LogVerbatim("L1trackHLS") << bx << " " << i << " ";
+      print_entry(bx,i);
+    }
   }
 
   void print_mem() const
   {
-	for (unsigned int ibx = 0; ibx < DEPTH_BX; ++ibx) {
-	  for (unsigned int i = 0; i < nentries_[ibx]; ++i) {
-	    edm::LogVerbatim("L1trackHLS") << ibx << " " << i << " ";
-	    print_entry(ibx,i);
-	  }
-	}
+    for (unsigned int ibx = 0; ibx < DEPTH_BX; ++ibx) {
+      for (unsigned int i = 0; i < nentries_[ibx]; ++i) {
+        edm::LogVerbatim("L1trackHLS") << ibx << " " << i << " ";
+        print_entry(ibx,i);
+      }
+    }
   }
 
   static constexpr int getWidth() {return DataType::getWidth();}

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -35,11 +35,11 @@ private:
 #ifdef CMSSW_GIT_HASH
   static constexpr unsigned int NBIT_BX = 0;
 #endif
-
-  constexpr unsigned int DEPTH_BX = 1<<NBIT_BX;
-  constexpr unsigned int DEPTH_ADDR = 1<<NBIT_ADDR;
   
 public:
+  static constexpr unsigned int DEPTH_BX = 1<<NBIT_BX;
+  static constexpr unsigned int DEPTH_ADDR = 1<<NBIT_ADDR;
+
   typedef typename DataType::BitWidths BitWidths;
   typedef ap_uint<NBIT_BX> BunchXingT;
   typedef ap_uint<NBIT_ADDR> NEntryT;

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -184,7 +184,7 @@ public:
 	return success;
   }
 
-  bool write_mem(BunchXingT ibx, const std::string datastr, int base=16)
+  bool write_mem(BunchXingT ibx, const std::string& datastr, int base=16)
   {
 	return write_mem(ibx, datastr.c_str(), base);
   }

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -36,7 +36,7 @@ template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR, unsigned 
 
 class MemoryTemplateBinnedCM{
 
- private:
+private:
 #ifdef CMSSW_GIT_HASH
   static constexpr bool isCMSSW = true;
   static constexpr unsigned int NBIT_BX = 0;
@@ -46,7 +46,7 @@ class MemoryTemplateBinnedCM{
   static constexpr unsigned int NCP = NCOPY;
 #endif
 
- public:
+public:
   static constexpr unsigned int DEPTH_BX = 1<<NBIT_BX;
   static constexpr unsigned int DEPTH_ADDR = 1<<NBIT_ADDR;
   static constexpr unsigned int DEPTH_BIN = 1<<NBIT_BIN;
@@ -54,7 +54,7 @@ class MemoryTemplateBinnedCM{
   typedef ap_uint<NBIT_BX> BunchXingT;
   typedef ap_uint<NBIT_ADDR-NBIT_BIN> NEntryT;
 
- protected:
+protected:
   enum BitWidths {
     kNBxBins = DEPTH_BX,
     kNSlots = DEPTH_BIN,
@@ -69,7 +69,7 @@ class MemoryTemplateBinnedCM{
   ap_uint<8> binmask8_[kNBxBins][1<<kNBitsRZBinCM];
   ap_uint<64> nentries_[slots];
 
- public:
+public:
 
   unsigned int getDepth() const {return kNMemDepth;}
   unsigned int getNBX() const {return kNBxBins;}
@@ -89,7 +89,7 @@ class MemoryTemplateBinnedCM{
   }
 
   ap_uint<8> getBinMask8(BunchXingT bx, ap_uint<kNBitsRZBinCM> ibin) const {
-    #pragma HLS ARRAY_PARTITION variable=binmask8_ complete dim=0
+#pragma HLS ARRAY_PARTITION variable=binmask8_ complete dim=0
     return binmask8_[bx][ibin];
   }
 
@@ -121,7 +121,7 @@ class MemoryTemplateBinnedCM{
   }
   
   DataType read_mem(unsigned int icopy, BunchXingT ibx, ap_uint<NBIT_BIN> slot,
-		    ap_uint<NBIT_ADDR> index) const {
+                    ap_uint<NBIT_ADDR> index) const {
 #pragma HLS ARRAY_PARTITION variable=dataarray_ dim=1
     // TODO: check if valid
     if (isCMSSW) {ibx = 0; icopy = 0;}
@@ -153,24 +153,24 @@ class MemoryTemplateBinnedCM{
 
       if (nentry == ((1 << (NBIT_ADDR-NBIT_BIN)) - 1)) return false;
 
-    	nentries_[ibx*kNBinsRZ+ibin].range(ireg*4+3,ireg*4)=nentry+1;
-    	if (ibin!=0) {
-	      nentries_[ibx*kNBinsRZ+ibin-1].range((ireg+8)*4+3,(ireg+8)*4)=nentry+1;
-    	}
-	    binmask8_[ibx][ibin].set_bit(ireg,true);
+      nentries_[ibx*kNBinsRZ+ibin].range(ireg*4+3,ireg*4)=nentry+1;
+      if (ibin!=0) {
+        nentries_[ibx*kNBinsRZ+ibin-1].range((ireg+8)*4+3,(ireg+8)*4)=nentry+1;
+      }
+      binmask8_[ibx][ibin].set_bit(ireg,true);
 
-    	//icopy comparison must be signed int or future SW fails
-      writememloop:for (signed int icopy=0;icopy< (signed) NCP;icopy++) {
+      //icopy comparison must be signed int or future SW fails
+    writememloop:for (signed int icopy=0;icopy< (signed) NCP;icopy++) {
 #pragma HLS unroll
-	      dataarray_[icopy][ibx][getNEntryPerBin()*slot+nentry] = data;
-    	}
+        dataarray_[icopy][ibx][getNEntryPerBin()*slot+nentry] = data;
+      }
 #endif      
       return true;
     }
     else {
 #ifndef __SYNTHESIS__
       if (data.raw() != 0) { // To avoid lots of prints when we're clearing the memories
-	edm::LogVerbatim("L1trackHLS") << "Warning out of range. nentry_ibx = "<<nentry_ibx<<" NBIT_ADDR-NBIT_BIN = "<<NBIT_ADDR-NBIT_BIN << std::endl;
+        edm::LogVerbatim("L1trackHLS") << "Warning out of range. nentry_ibx = "<<nentry_ibx<<" NBIT_ADDR-NBIT_BIN = "<<NBIT_ADDR-NBIT_BIN << std::endl;
       }
 #endif
       return false;
@@ -191,13 +191,13 @@ class MemoryTemplateBinnedCM{
     DataType data("0",16);
     for (size_t ibx=0; ibx<(kNBxBins); ++ibx) {
       for (size_t icopy=0; icopy < NCP; icopy++) {
-       	for (size_t ibin=0; ibin < kNMemDepth; ibin++) {
-	        dataarray_[icopy][ibx][ibin] = data;
-      	}
+        for (size_t ibin=0; ibin < kNMemDepth; ibin++) {
+          dataarray_[icopy][ibx][ibin] = data;
+        }
       }
       // Clear nentries and binmask8
       for (unsigned int ibin = 0; ibin < getNBins()/8; ++ibin) {
-	nentries_[ibx*kNBinsRZ+ibin] = 0;
+        nentries_[ibx*kNBinsRZ+ibin] = 0;
         binmask8_[ibx][ibin] = 0;
       }
     }
@@ -212,7 +212,7 @@ class MemoryTemplateBinnedCM{
     std::istringstream sstream(s);
     while (getline(sstream, token, delimiter))
       {
-	tokens.push_back(token);
+        tokens.push_back(token);
       }
     return tokens;
   }
@@ -244,37 +244,35 @@ class MemoryTemplateBinnedCM{
   void print_data(const DataType data) const
   {
     edm::LogVerbatim("L1trackHLS") << std::hex << data.raw() << std::endl;
-	// TODO: overload '<<' in data class
+    // TODO: overload '<<' in data class
   }
 
   void print_entry(BunchXingT bx, ap_uint<NBIT_ADDR> index) const
   {
-	print_data(dataarray_[bx][index]);
+    print_data(dataarray_[bx][index]);
   }
 
   //These are broken - comment out for now (ryd, 2024-10-27)
   /*
-  void print_mem(BunchXingT bx) const
-  {
-    for(unsigned int ibin=0;ibin<8;ibin++) {
-      for(unsigned int ireg=0;ireg<8;ireg++) {
-	for (unsigned int i = 0; i < nentries_[ibx*kNBinsRZ+ibin].range(ireg*4+3,ireg*4); ++i) {
-	  edm::LogVerbatim("L1trackHLS") << bx << " " << i << " ";
-	  print_entry(bx, i + slot*getNEntryPerBin() );
-	}
+    void print_mem(BunchXingT bx) const {
+      for(unsigned int ibin=0;ibin<8;ibin++) {
+        for(unsigned int ireg=0;ireg<8;ireg++) {
+          for (unsigned int i = 0; i < nentries_[ibx*kNBinsRZ+ibin].range(ireg*4+3,ireg*4); ++i) {
+            edm::LogVerbatim("L1trackHLS") << bx << " " << i << " ";
+            print_entry(bx, i + slot*getNEntryPerBin() );
+          }
+        }
       }
     }
-  }
 
-  void print_mem() const
-  {
-	for (unsigned int ibx = 0; ibx < kNBxBins; ++ibx) {
-	  for (unsigned int i = 0; i < 8; ++i) {
-	    edm::LogVerbatim("L1trackHLS") << ibx << " " << i << " ";
-	    print_entry(ibx,i);
-	  }
-	}
-  }
+    void print_mem() const {
+      for (unsigned int ibx = 0; ibx < kNBxBins; ++ibx) {
+        for (unsigned int i = 0; i < 8; ++i) {
+          edm::LogVerbatim("L1trackHLS") << ibx << " " << i << " ";
+          print_entry(ibx,i);
+        }
+      }
+    }
   */
   
   static constexpr int getWidth() {return DataType::getWidth();}

--- a/TrackletAlgorithm/MemoryTemplateBinnedCM.h
+++ b/TrackletAlgorithm/MemoryTemplateBinnedCM.h
@@ -37,7 +37,6 @@ template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR, unsigned 
 class MemoryTemplateBinnedCM{
 
  private:
-
 #ifdef CMSSW_GIT_HASH
   static constexpr bool isCMSSW = true;
   static constexpr unsigned int NBIT_BX = 0;
@@ -47,11 +46,11 @@ class MemoryTemplateBinnedCM{
   static constexpr unsigned int NCP = NCOPY;
 #endif
 
-  constexpr unsigned int DEPTH_BX = 1<<NBIT_BX;
-  constexpr unsigned int DEPTH_ADDR = 1<<NBIT_ADDR;
-  constexpr unsigned int DEPTH_BIN = 1<<NBIT_BIN;
- 
  public:
+  static constexpr unsigned int DEPTH_BX = 1<<NBIT_BX;
+  static constexpr unsigned int DEPTH_ADDR = 1<<NBIT_ADDR;
+  static constexpr unsigned int DEPTH_BIN = 1<<NBIT_BIN;
+ 
   typedef ap_uint<NBIT_BX> BunchXingT;
   typedef ap_uint<NBIT_ADDR-NBIT_BIN> NEntryT;
 

--- a/TrackletAlgorithm/MemoryTemplateTPROJ.h
+++ b/TrackletAlgorithm/MemoryTemplateTPROJ.h
@@ -89,10 +89,10 @@ public:
 
   DataType read_mem(BunchXingT ibx, ap_uint<NBIT_ADDR> index, unsigned int page = 0) const
   {
-  assert(page < NPAGE);    
-	// TODO: check if valid
-	if(!NBIT_BX) ibx = 0;
- 	return dataarray_[ibx][DEPTH_ADDR*page+index];
+    //assert(page < NPAGE);    
+  	// TODO: check if valid  
+	  if(!NBIT_BX) ibx = 0;
+ 	  return dataarray_[ibx][DEPTH_ADDR*page+index];
   }
 
   template<class SpecType>
@@ -111,7 +111,7 @@ public:
 
   bool write_mem(BunchXingT ibx, DataType data, NEntryT addr_index, unsigned int page = 0)
   {
-  assert(page < NPAGE);        
+    //assert(page < NPAGE);        
 #pragma HLS inline
     if(!NBIT_BX) ibx = 0;
     if (addr_index < DEPTH_ADDR) {

--- a/TrackletAlgorithm/MemoryTemplateTPROJ.h
+++ b/TrackletAlgorithm/MemoryTemplateTPROJ.h
@@ -2,10 +2,6 @@
 #ifndef TrackletAlgorithm_MemoryTemplateTPROJ_h
 #define TrackletAlgorithm_MemoryTemplateTPROJ_h
 
-// L1 Track CMSSW Future SW currently assumes only 1 FPGA used,
-// and hence 1 page of memory.
-#define CMSSW_1FPGA
-
 #include <iostream>
 #include "../TestBenches/FileReadUtility.h"
 
@@ -25,6 +21,12 @@ template<int> class AllStub;
 #endif
 
 #ifdef CMSSW_GIT_HASH
+// L1 Track CMSSW Future SW currently assumes only 1 FPGA used,
+// and hence 1 page of memory.
+#define CMSSW_1FPGA
+#endif
+
+#ifdef CMSSW_GIT_HASH
 #ifdef CMSSW_1FPGA
 template<class DataType, unsigned int DUMMYA, unsigned int NBIT_ADDR, unsigned int DUMMYB >
 #else
@@ -39,8 +41,8 @@ template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR, unsigned 
 // (1<<NBIT_BIN): number of BXs the memory is keeping track of
 // NBIT_ADDR: number of bits for memory address space per BX;
 // (1<<NBIT_ADDR): depth of the memory for each BX
-// NPAGE is number of pages used within BX. This is used for the TPROJ memory to allow
-// ordering of the different TP outputs
+// NPAGE is number of pages used within BX. This is used for the TPROJ memory
+// to allow ordering of the different TP outputs
 class MemoryTemplateTPROJ
 {
 private:

--- a/TrackletAlgorithm/MemoryTemplateTPROJ.h
+++ b/TrackletAlgorithm/MemoryTemplateTPROJ.h
@@ -180,23 +180,18 @@ public:
 
   bool write_mem(BunchXingT ibx, const std::string& line, int base=16)
   {
-#ifdef CMSSW_1FPGA
-    const std::string& datastr = line;
-    unsigned int page = 0;
-#else
     assert(split(line,' ').size()==4);
 
     const std::string datastr = split(line,' ').back();
 
     const std::string pagestr = split(line,' ').front();
 
-    unsigned int page = 4;
+    unsigned int page = NPAGE;
     if (pagestr=="0x00") page = 0;
     if (pagestr=="0x01") page = 1;
     if (pagestr=="0x02") page = 2;
     if (pagestr=="0x03") page = 3;
-    assert(page<4);
-#endif
+    assert(page < NPAGE);
 
     if(!NBIT_BX) ibx = 0;
     DataType data(datastr.c_str(), base);

--- a/TrackletAlgorithm/MemoryTemplateTPROJ.h
+++ b/TrackletAlgorithm/MemoryTemplateTPROJ.h
@@ -90,21 +90,21 @@ public:
   DataType read_mem(BunchXingT ibx, ap_uint<NBIT_ADDR> index, unsigned int page = 0) const
   {
     //assert(page < NPAGE);    
-  	// TODO: check if valid  
-	  if(!NBIT_BX) ibx = 0;
- 	  return dataarray_[ibx][DEPTH_ADDR*page+index];
+    // TODO: check if valid  
+    if(!NBIT_BX) ibx = 0;
+    return dataarray_[ibx][DEPTH_ADDR*page+index];
   }
 
   template<class SpecType>
-    bool write_mem(BunchXingT ibx, SpecType data, NEntryT addr_index, unsigned int page)
+  bool write_mem(BunchXingT ibx, SpecType data, NEntryT addr_index, unsigned int page)
   {
 #pragma HLS inline
     if(!NBIT_BX) ibx = 0;
     static_assert(
-      std::is_same<DataType, SpecType>::value
-      || (std::is_same<DataType, AllStub<DISK> >::value && std::is_same<SpecType, AllStub<DISKPS> >::value)
-      || (std::is_same<DataType, AllStub<DISK> >::value && std::is_same<SpecType, AllStub<DISK2S> >::value)
-      , "Invalid conversion between data types");
+                  std::is_same<DataType, SpecType>::value
+                  || (std::is_same<DataType, AllStub<DISK> >::value && std::is_same<SpecType, AllStub<DISKPS> >::value)
+                  || (std::is_same<DataType, AllStub<DISK> >::value && std::is_same<SpecType, AllStub<DISK2S> >::value)
+                  , "Invalid conversion between data types");
     DataType sameData(data.raw());
     return write_mem(ibx, sameData, addr_index, page);
   }
@@ -142,13 +142,13 @@ public:
   void clear()
   {
     DataType data("0",16);
-    MEM_RST: for (size_t ibx=0; ibx<DEPTH_BX; ++ibx) {
+  MEM_RST: for (size_t ibx=0; ibx<DEPTH_BX; ++ibx) {
       mask_[ibx]=0;
       for (size_t page = 0; page < NPAGE; page++) {
-      	nentries_[ibx*NPAGE+page] = 0;
-      	for (size_t addr=0; addr<DEPTH_ADDR; ++addr) {
-	        dataarray_[ibx][DEPTH_ADDR*page+addr] = data;
-      	}
+        nentries_[ibx*NPAGE+page] = 0;
+        for (size_t addr=0; addr<DEPTH_ADDR; ++addr) {
+          dataarray_[ibx][DEPTH_ADDR*page+addr] = data;
+        }
       }
     }
   }
@@ -205,19 +205,19 @@ public:
   void print_data(const DataType data) const
   {
     edm::LogVerbatim("L1trackHLS") << std::hex << data.raw() << std::endl;
-        // TODO: overload '<<' in data class
+    // TODO: overload '<<' in data class
   }
 
   void print_entry(BunchXingT bx, NEntryT index, unsigned int page = 0) const
   {
-  	print_data(dataarray_[bx][DEPTH_ADDR*page+index]);
+    print_data(dataarray_[bx][DEPTH_ADDR*page+index]);
   }
 
   void print_mem(BunchXingT bx) const {
     for (unsigned int page = 0; page < NPAGE; ++page) {
       for (unsigned int i = 0; i <  nentries_[bx*NPAGE+page]; ++i) {
-	edm::LogVerbatim("L1trackHLS") << bx << " " << i << " ";
-	print_entry(bx, i, page);
+        edm::LogVerbatim("L1trackHLS") << bx << " " << i << " ";
+        print_entry(bx, i, page);
       }
     }
   }
@@ -226,10 +226,10 @@ public:
   {
     for (unsigned int ibx = 0; ibx < DEPTH_BX; ++ibx) {
       for (unsigned int page = 0; page < NPAGE; ++page) {
-	for (unsigned int i = 0; i < nentries_[ibx*NPAGE+page]; ++i) {
-	  edm::LogVerbatim("L1trackHLS") << ibx << " " << page << " " << i << " ";
-	  print_entry(ibx, i, page);
-	}
+        for (unsigned int i = 0; i < nentries_[ibx*NPAGE+page]; ++i) {
+          edm::LogVerbatim("L1trackHLS") << ibx << " " << page << " " << i << " ";
+          print_entry(ibx, i, page);
+        }
       }
     }
   }

--- a/TrackletAlgorithm/MemoryTemplateTPROJ.h
+++ b/TrackletAlgorithm/MemoryTemplateTPROJ.h
@@ -87,9 +87,10 @@ public:
 
   DataType read_mem(BunchXingT ibx, ap_uint<NBIT_ADDR> index, unsigned int page = 0) const
   {
+  assert(page < NPAGE);    
 	// TODO: check if valid
 	if(!NBIT_BX) ibx = 0;
-	return dataarray_[ibx][DEPTH_ADDR*page+index];
+ 	return dataarray_[ibx][DEPTH_ADDR*page+index];
   }
 
   template<class SpecType>
@@ -108,6 +109,7 @@ public:
 
   bool write_mem(BunchXingT ibx, DataType data, NEntryT addr_index, unsigned int page = 0)
   {
+  assert(page < NPAGE);        
 #pragma HLS inline
     if(!NBIT_BX) ibx = 0;
     if (addr_index < DEPTH_ADDR) {
@@ -174,10 +176,10 @@ public:
     return success;
   }
 
-  bool write_mem(BunchXingT ibx, const std::string line, int base=16)
+  bool write_mem(BunchXingT ibx, const std::string& line, int base=16)
   {
 #ifdef CMSSW_1FPGA
-    const std::string datastr = line;
+    const std::string& datastr = line;
     unsigned int page = 0;
 #else
     assert(split(line,' ').size()==4);

--- a/TrackletAlgorithm/SWLUTReader.h
+++ b/TrackletAlgorithm/SWLUTReader.h
@@ -1,6 +1,5 @@
 #include <fstream>
 #include <string>
-#include <iostream>
 
 // The following function provides a more compiler efficient method for reading
 // look up table arrays (currently used in TP), this is only used in C simulations and not synthesis

--- a/TrackletAlgorithm/SWLUTReader.h
+++ b/TrackletAlgorithm/SWLUTReader.h
@@ -29,6 +29,6 @@ template<class lutType, int lutsize> bool readSWLUT(lutType lut[lutsize],const s
     if (lutIndex < lutsize) lut[lutIndex]=lutval;
     ++lutIndex;
   }
-  assert(lutIndex == lutsize + 1); // Allows for final bracket.
+  assert(lutIndex == lutsize || lutIndex == lutsize + 1); // Allow for optional final bracket.
   return true;
 }

--- a/TrackletAlgorithm/SWLUTReader.h
+++ b/TrackletAlgorithm/SWLUTReader.h
@@ -1,5 +1,6 @@
 #include <fstream>
 #include <string>
+#include <iostream>
 
 // The following function provides a more compiler efficient method for reading
 // look up table arrays (currently used in TP), this is only used in C simulations and not synthesis
@@ -25,8 +26,9 @@ template<class lutType, int lutsize> bool readSWLUT(lutType lut[lutsize],const s
       skipfirst = false;
       continue;
     }
-    lut[lutIndex]=lutval;
+    if (lutIndex < lutsize) lut[lutIndex]=lutval;
     ++lutIndex;
   }
+  assert(lutIndex == lutsize + 1); // Allows for final bracket.
   return true;
 }

--- a/TrackletAlgorithm/TrackBuilder.h
+++ b/TrackletAlgorithm/TrackBuilder.h
@@ -104,7 +104,7 @@ class Merger {
 };
 
 // TrackBuilder top template function
-template<unsigned Seed, int NFMPerStubBarrel0, int NFMPerStubBarrel, int NFMPerStubDisk, int NBarrelStubs, int NDiskStubs, int TPARMask>
+template<TF::seed Seed, int NFMPerStubBarrel0, int NFMPerStubBarrel, int NFMPerStubDisk, int NBarrelStubs, int NDiskStubs, int TPARMask>
 void TrackBuilder(
     const BXType bx,
     const TrackletParameterMemory1 trackletParameters1[],

--- a/TrackletAlgorithm/VMRouterCM.h
+++ b/TrackletAlgorithm/VMRouterCM.h
@@ -172,7 +172,7 @@ inline T createVMStub(const InputStub<InType> inputStub,
 // Main function
 
 // Two input region types InType and DISK2S due to the disks having both 2S and PS inputs.
-template<int nInputMems, int nInputDisk2SMems, int nAllCopies, int nAllInnerCopies, int Layer, int Disk, regionType InType, regionType OutType, int rzSizeME, int rzSizeTE, int phiRegSize, int nTEOCopies>
+template<int nInputMems, int nInputDisk2SMems, int nAllCopies, int nAllInnerVariants, int Layer, int Disk, regionType InType, regionType OutType, int rzSizeME, int rzSizeTE, int phiRegSize, int nTEOCopies>
 void VMRouterCM(const BXType bx, BXType& bx_o,
 		// LUTs
 		const int METable[],
@@ -219,15 +219,15 @@ void VMRouterCM(const BXType bx, BXType& bx_o,
 
 	//Create variables that keep track of which memory address to read and write to
 	ap_uint<kNBits_MemAddr> read_addr(0); // Reading of input stubs
-	ap_uint<kNBits_MemAddr> addrCountASI[nAllInnerCopies]; // Writing of Inner Allstubs
+	ap_uint<kNBits_MemAddr> addrCountASI[nAllInnerVariants]; // Writing of Inner Allstubs
 	ap_uint<5> addrCountME[1 << (rzSizeME + phiRegSize)]; // Writing of ME stubs, number of bits taken from whatever is defined in the memories: (4+rzSize + phiRegSize)-(rzSize + phiRegSize)+1
 	ap_uint<5> addrCountTE[1 << (rzSizeTE + phiRegSize)]; // Writing of TE stubs
 #pragma HLS array_partition variable=addrCountASI complete dim=0
 #pragma HLS array_partition variable=addrCountME complete dim=0
 #pragma HLS array_partition variable=addrCountTE complete dim=0
 
-	if (nAllInnerCopies) {
-		for (int i = 0; i < nAllInnerCopies; i++) {
+	if (nAllInnerVariants) {
+		for (int i = 0; i < nAllInnerVariants; i++) {
 #pragma HLS unroll
 			addrCountASI[i] = 0;
 		}

--- a/emData/download.sh
+++ b/emData/download.sh
@@ -97,7 +97,8 @@ mkdir -p ../TopFunctions/CombinedConfig
 ./generate_IR.py       -w LUTsCM/wires.dat -o ../TopFunctions/CombinedConfig
 ./generate_VMRCM.py -a -w LUTsCM/wires.dat -o ../TopFunctions/CombinedConfig
 ./generate_VMSMER.py -a -w LUTsCM/wires.dat -o ../TopFunctions/CombinedConfig
-./generate_TP.py       -w LUTsCM/wires.dat -o ../TopFunctions/CombinedConfig
+# All other modules use LUTsSplit LUTS, & it's best, as LUTsCM out of date.
+./generate_TP.py       -w LUTsCM/wires.dat -l LUTsSplit -o ../TopFunctions/CombinedConfig
 ./generate_PC.py       -w LUTsCM/wires.dat -o ../TopFunctions/CombinedConfig
 ./generate_MP.py       -w LUTsCM/wires.dat -o ../TopFunctions/CombinedConfig
 ./generate_TB.py       -w LUTsCM/wires.dat -o ../TopFunctions/CombinedConfig

--- a/emData/generate_TB.py
+++ b/emData/generate_TB.py
@@ -123,8 +123,8 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
         "template<TF::seed Seed> constexpr int getNumBarrelStub();\n"
         "template<TF::seed Seed> constexpr int getNumDiskStub();\n"
         "template<TF::seed Seed> constexpr int getMPARNPages(const ITCType &);\n"
-        "template<TF::seed Seed> inline int getMPARMem(const ITCType &);\n"
-        "template<TF::seed Seed> constexpr int getMPARPage(const ITCType &);\n"
+        "template<TF::seed Seed> inline    int getMPARMem(const ITCType &);\n"
+        "template<TF::seed Seed> inline    int getMPARPage(const ITCType &);\n"
     )
 
     # Calculate parameters and print out top function for each TB.

--- a/emData/generate_TB.py
+++ b/emData/generate_TB.py
@@ -122,7 +122,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
         "template<TF::seed Seed> constexpr int getNumDiskFMMemPerStub();\n"
         "template<TF::seed Seed> constexpr int getNumBarrelStub();\n"
         "template<TF::seed Seed> constexpr int getNumDiskStub();\n"
-        "template<TF::seed Seed> constexpr int getMPARNPages(const ITCType &);\n"
+        "template<TF::seed Seed> inline    int getMPARNPages(const ITCType &);\n"
         "template<TF::seed Seed> inline    int getMPARMem(const ITCType &);\n"
         "template<TF::seed Seed> inline    int getMPARPage(const ITCType &);\n"
     )
@@ -177,7 +177,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
         nParentheses = 0
         first = True
         maxNPages = max([len(tpar) - len("MPAR_L1L2") for tpar in tparMems[tbName]])
-        getMPARNPages = "template<> constexpr int\n"
+        getMPARNPages = "template<> inline int\n"
         getMPARNPages += "getMPARNPages<TF::" + seed + ">(const ITCType &iTC) {\n"
         getMPARNPages += "  return "
         for i in range(1, maxNPages):

--- a/emData/generate_TB.py
+++ b/emData/generate_TB.py
@@ -122,9 +122,9 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
         "template<TF::seed Seed> constexpr int getNumDiskFMMemPerStub();\n"
         "template<TF::seed Seed> constexpr int getNumBarrelStub();\n"
         "template<TF::seed Seed> constexpr int getNumDiskStub();\n"
-        "template<unsigned Seed> int getMPARNPages(const ITCType &);\n"
-        "template<unsigned Seed> int getMPARMem(const ITCType &);\n"
-        "template<unsigned Seed> int getMPARPage(const ITCType &);\n"
+        "template<TF::seed Seed> constexpr int getMPARNPages(const ITCType &);\n"
+        "template<TF::seed Seed> inline int getMPARMem(const ITCType &);\n"
+        "template<TF::seed Seed> constexpr int getMPARPage(const ITCType &);\n"
     )
 
     # Calculate parameters and print out top function for each TB.
@@ -177,7 +177,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
         nParentheses = 0
         first = True
         maxNPages = max([len(tpar) - len("MPAR_L1L2") for tpar in tparMems[tbName]])
-        getMPARNPages = "template<> int\n"
+        getMPARNPages = "template<> constexpr int\n"
         getMPARNPages += "getMPARNPages<TF::" + seed + ">(const ITCType &iTC) {\n"
         getMPARNPages += "  return "
         for i in range(1, maxNPages):
@@ -201,7 +201,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
 
         # definition of getMPARMem function
         nParentheses = 0
-        getMPARMem = "template<> int\n"
+        getMPARMem = "template<> inline int\n"
         getMPARMem += "getMPARMem<TF::" + seed + ">(const ITCType &iTC) {\n"
         getMPARMem += "  return "
         for i in range(0, max(nTPARMem) - 1):
@@ -226,7 +226,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
 
         # definition of getMPARPage function
         nParentheses = 0
-        getMPARPage = "template<> int\n"
+        getMPARPage = "template<> constexpr int\n"
         getMPARPage += "getMPARPage<TF::" + seed + ">(const ITCType &iTC) {\n"
         getMPARPage += "  return "
         for i in range(0, maxNPages - 1):

--- a/emData/generate_TB.py
+++ b/emData/generate_TB.py
@@ -226,7 +226,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
 
         # definition of getMPARPage function
         nParentheses = 0
-        getMPARPage = "template<> constexpr int\n"
+        getMPARPage = "template<> inline int\n"
         getMPARPage += "getMPARPage<TF::" + seed + ">(const ITCType &iTC) {\n"
         getMPARPage += "  return "
         for i in range(0, maxNPages - 1):


### PR DESCRIPTION
The Future L1Trk CMSSW SW has not yet migrated to the 2FPGA solution. I'm therefore trying to bodge it so it continues to work (for now) with the 1FPGA solution.

1) The three functions in TrackBuilder_parameters.h with names getMPAR*() caused the CMSSW compiler to fail because of "duplicate function definitions". I fixed this by declaring them to be "constexpr" or "inline" in generate_TB.py. I also (on style grounds) changed their template parameter from type int to TF::seed.
2) MemoryTemplateBinnedCM::clear() used constant NCOPY, which caused array-out-of-bounds errors in CMSSW, where NCOPY can be zero. Replaced NCOPY with NCP.
3) CMSSW compiler errors about "duplicate code", solved by deleting the calculation of nentries withing CMSSW_GIT_HASH that was in MemoryTemplateBinnedCM & MemoryTemplateBinned & MemoryTemplatePROJ.
4) Added constants DEPTH_BX and DEPTH_ADDR to MemoryTemplate.h, MemoryTemplateBinnedCM.h and MemoryTemplateTPROJ.h, to simplify them. In MemoryTemplateTPROJ.h, replaced magic number 128 by DEPTH_ADDR.
5) Modified MemoryTemplateTPROJ to it instantiates only one page of memory when used inside CMSSW.
6) Replaced argument addr_index of MemoryTemplate::write_mem_new() by argument "ap_uint<1> overwrite", with the same number of bits used by MatchProcessor.h [HERE](https://github.com/cms-L1TK/firmware-hls/blob/master/TrackletAlgorithm/MatchProcessor.h#L1139) when it calls write_mem_new(). 
Howver, [this code](https://github.com/cms-L1TK/firmware-hls/blob/master/TrackletAlgorithm/MemoryTemplate.h#L134) inside write_mem_new(), which should protect the memory against having too many entries does nothing, since addr_index is a 1 bit number. This is a BUG. I replaced it by a check that nentries_[ibx] is than than (1<<NBIT_ADDR). However, array access can be slow in FW, so one should check if this causes FW timing errors.
8) Besides the style issue that it's hard-wiring the number of pages to 4, https://github.com/cms-L1TK/firmware-hls/blob/master/TestBenches/FileReadUtility.h#L259 seems to incorrectly assume that MemoryTemplateTPROJ::getDepth() returns the total depth of the memory, whereas it can be seen from https://github.com/cms-L1TK/firmware-hls/blob/master/TrackletAlgorithm/MemoryTemplateTPROJ.h#L49 that it returns a number that is a factor NPAGE less than this. I believe this is a BUG and that compareMemWithMemPage() is only checking one quarter of the memory. Fixed.
9) SWLUTReader.h was writing by 1 unit beyond the array bounds of the input "lut" array, because it neglected that the input .tab files contain a final line with a "close bracket" but no number.  This BUG had horrible consequences, causing all LUT contents to become zero in CMSSW. Now fixed.
10) Modified download.sh, so that when running the CombinedCM chain, the TP takes its LUT tables from LUTsSplit/ instead of LUTsCM/ . This reduces the rate of memory errors, as LUTsCM/ is out-of-date. All other modules in the chain already used LUTsSplit/.
11) To improve clarity of VMRouterCM.h & MatchProcessor.h, renamed nAllInnerCopies to nAllInnerVariants, since the versions of the AllStubsInner memories that are produced are not copies of each other, but are different from each other. Similarly, renamed maxFullMatchCopies to maxFullMatchVariants.

THIS PR NEEDS DISCUSSION WITH @aehart and @aryd BEFORE MERGING.