### PR TITLE
Optimize MP for CMSSW CPU resources

### DIFF
--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -282,7 +282,7 @@ inline void step(const VMStub<VMSType> stubmem[4][1<<(kNbitsrzbinMP+kNbitsphibin
 #endif
 
  inline void set_empty() {
-   static const emptyUnitClass<MatchEngineUnitBase<VMProjType>::kNBitsBuffer> EmptyUnitClass;
+   static const EmptyUnitClass<MatchEngineUnitBase<VMProjType>::kNBitsBuffer> EmptyUnitClass;
    empty_ = EmptyUnitClass.lut[(readindex_,writeindex_)];
    //empty_ = emptyUnit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
  }
@@ -293,7 +293,7 @@ inline void step(const VMStub<VMSType> stubmem[4][1<<(kNbitsrzbinMP+kNbitsphibin
  }
  
  inline bool nearFull() {
-   static const nearFull3Class<MatchEngineUnitBase<VMProjType>::kNBitsBuffer> NearFull3Class;
+   static const NearFull3Class<MatchEngineUnitBase<VMProjType>::kNBitsBuffer> NearFull3Class;
    return NearFull3Class.lut[(readindex_,writeindex_)];
    //return nearFull3Unit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
  }

--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -282,7 +282,8 @@ inline void step(const VMStub<VMSType> stubmem[4][1<<(kNbitsrzbinMP+kNbitsphibin
 #endif
 
  inline void set_empty() {
-   empty_ = emptyUnit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
+   empty_ = EmptyUnit[(readindex_,writeindex_)];
+   //empty_ = emptyUnit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
  }
 
  inline bool empty() const {
@@ -291,7 +292,8 @@ inline void step(const VMStub<VMSType> stubmem[4][1<<(kNbitsrzbinMP+kNbitsphibin
  }
  
  inline bool nearFull() {
-   return nearFull3Unit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
+   return NearFull[(readindex_,writeindex_)];
+   //return nearFull3Unit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
  }
 
  inline bool idle() {
@@ -426,6 +428,8 @@ inline void advance() {
  static constexpr int projfinezbits = VMProjectionBase<VMProjType>::kVMProjFineZSize;
  static constexpr int stubfinephibits = VMStubBase<VMSType>::kVMSFinePhiSize;
  static constexpr int stubfinezbits = VMStubBase<VMSType>::kVMSFineZSize;
+ const ap_uint<(1 << (2 * MatchEngineUnitBase<VMProjType>::kNBitsBuffer))> EmptyUnit = emptyUnit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>();
+ const ap_uint<(1 << (2 * MatchEngineUnitBase<VMProjType>::kNBitsBuffer))> NearFull = nearFull3Unit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>();
 
 
 #ifndef __SYNTHESIS__

--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -284,7 +284,6 @@ inline void step(const VMStub<VMSType> stubmem[4][1<<(kNbitsrzbinMP+kNbitsphibin
  inline void set_empty() {
    static const EmptyUnitClass<MatchEngineUnitBase<VMProjType>::kNBitsBuffer> EmptyUnitClass;
    empty_ = EmptyUnitClass.lut[(readindex_,writeindex_)];
-   //empty_ = emptyUnit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
  }
 
  inline bool empty() const {
@@ -295,7 +294,6 @@ inline void step(const VMStub<VMSType> stubmem[4][1<<(kNbitsrzbinMP+kNbitsphibin
  inline bool nearFull() {
    static const NearFull3Class<MatchEngineUnitBase<VMProjType>::kNBitsBuffer> NearFull3Class;
    return NearFull3Class.lut[(readindex_,writeindex_)];
-   //return nearFull3Unit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
  }
 
  inline bool idle() {

--- a/TrackletAlgorithm/MatchEngineUnit.h
+++ b/TrackletAlgorithm/MatchEngineUnit.h
@@ -282,7 +282,8 @@ inline void step(const VMStub<VMSType> stubmem[4][1<<(kNbitsrzbinMP+kNbitsphibin
 #endif
 
  inline void set_empty() {
-   empty_ = EmptyUnit[(readindex_,writeindex_)];
+   static const emptyUnitClass<MatchEngineUnitBase<VMProjType>::kNBitsBuffer> EmptyUnitClass;
+   empty_ = EmptyUnitClass.lut[(readindex_,writeindex_)];
    //empty_ = emptyUnit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
  }
 
@@ -292,7 +293,8 @@ inline void step(const VMStub<VMSType> stubmem[4][1<<(kNbitsrzbinMP+kNbitsphibin
  }
  
  inline bool nearFull() {
-   return NearFull[(readindex_,writeindex_)];
+   static const nearFull3Class<MatchEngineUnitBase<VMProjType>::kNBitsBuffer> NearFull3Class;
+   return NearFull3Class.lut[(readindex_,writeindex_)];
    //return nearFull3Unit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>()[(readindex_,writeindex_)];
  }
 
@@ -428,8 +430,6 @@ inline void advance() {
  static constexpr int projfinezbits = VMProjectionBase<VMProjType>::kVMProjFineZSize;
  static constexpr int stubfinephibits = VMStubBase<VMSType>::kVMSFinePhiSize;
  static constexpr int stubfinezbits = VMStubBase<VMSType>::kVMSFineZSize;
- const ap_uint<(1 << (2 * MatchEngineUnitBase<VMProjType>::kNBitsBuffer))> EmptyUnit = emptyUnit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>();
- const ap_uint<(1 << (2 * MatchEngineUnitBase<VMProjType>::kNBitsBuffer))> NearFull = nearFull3Unit<MatchEngineUnitBase<VMProjType>::kNBitsBuffer>();
 
 
 #ifndef __SYNTHESIS__

--- a/TrackletAlgorithm/MatchEngineUnit_parameters.h
+++ b/TrackletAlgorithm/MatchEngineUnit_parameters.h
@@ -48,23 +48,6 @@ class NearFull3Class {
 };
 
 template<int kNBitsBuffer>
-static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull3Unit() {
-  static ap_uint<(1 << (2 * kNBitsBuffer))> lut;
-  for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
-#pragma HLS unroll
-    ap_uint<kNBitsBuffer> wptr, rptr;
-    ap_uint<2 * kNBitsBuffer> address(i);
-    (rptr,wptr) = address;
-    ap_uint<kNBitsBuffer> wptr1 = wptr+1;
-    ap_uint<kNBitsBuffer> wptr2 = wptr+2;
-    ap_uint<kNBitsBuffer> wptr3 = wptr+3;
-    bool result = wptr1==rptr || wptr2==rptr || wptr3==rptr;
-    lut[i] = result;
-  }
-  return lut;
-}
-
-template<int kNBitsBuffer>
 static bool nearFull3UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> wptr) {
   ap_uint<kNBitsBuffer> wptr1 = wptr+1;
   ap_uint<kNBitsBuffer> wptr2 = wptr+2;
@@ -114,20 +97,6 @@ class EmptyUnitClass {
       }
     }
 };
-
-template<int kNBitsBuffer>
-static const ap_uint<(1 << (2 * kNBitsBuffer))> emptyUnit() {
-  ap_uint<(1 << (2 * kNBitsBuffer))> lut;
-  for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
-#pragma HLS unroll
-    ap_uint<kNBitsBuffer> wptr, rptr;
-    ap_uint<2 * kNBitsBuffer> address(i);
-    (rptr,wptr) = address;
-    bool result = wptr==rptr;
-    lut[i] = result;
-  }
-  return lut;
-}
 
 template<int kNBitsBuffer>
 static bool emptyUnitBool(ap_uint<kNBitsBuffer> wptr, ap_uint<kNBitsBuffer> rptr) {

--- a/TrackletAlgorithm/MatchEngineUnit_parameters.h
+++ b/TrackletAlgorithm/MatchEngineUnit_parameters.h
@@ -29,8 +29,27 @@ static bool nearFullUnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> w
 }
 
 template<int kNBitsBuffer>
+class nearFull3Class {
+  public:
+    ap_uint<(1 << (2 * kNBitsBuffer))> lut;
+    nearFull3Class() {
+      for (unsigned int i = 0; i < (1 << (2 * kNBitsBuffer)); i++)  {
+         // Store complicated calculation in LUT array
+         ap_uint<kNBitsBuffer> wptr, rptr;
+         ap_uint<2 * kNBitsBuffer> address(i);
+         (rptr,wptr) = address;
+         ap_uint<kNBitsBuffer> wptr1 = wptr+1;
+         ap_uint<kNBitsBuffer> wptr2 = wptr+2;
+         ap_uint<kNBitsBuffer> wptr3 = wptr+3;
+         bool result = wptr1==rptr || wptr2==rptr || wptr3==rptr;
+         lut[i] = result;
+      }
+    }
+};
+
+template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull3Unit() {
-  ap_uint<(1 << (2 * kNBitsBuffer))> lut;
+  static ap_uint<(1 << (2 * kNBitsBuffer))> lut;
   for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
 #pragma HLS unroll
     ap_uint<kNBitsBuffer> wptr, rptr;
@@ -79,6 +98,22 @@ static bool nearFull4UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> 
   ap_uint<kNBitsBuffer> wptr4 = wptr+4;
   return wptr1==rptr || wptr2==rptr || wptr3==rptr || wptr4==rptr;
 }
+
+template<int kNBitsBuffer>
+class emptyUnitClass {
+  public:
+    ap_uint<(1 << (2 * kNBitsBuffer))> lut;
+    emptyUnitClass() {
+      for (unsigned int i = 0; i < (1 << (2 * kNBitsBuffer)); i++)  {
+         // Store complicated calculation in LUT array
+         ap_uint<kNBitsBuffer> wptr, rptr;
+         ap_uint<2 * kNBitsBuffer> address(i);
+         (rptr,wptr) = address;
+         bool result = wptr==rptr;
+         lut[i] = result;
+      }
+    }
+};
 
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> emptyUnit() {

--- a/TrackletAlgorithm/MatchEngineUnit_parameters.h
+++ b/TrackletAlgorithm/MatchEngineUnit_parameters.h
@@ -29,7 +29,7 @@ static bool nearFullUnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> w
 }
 
 template<int kNBitsBuffer>
-class nearFull3Class {
+class NearFull3Class {
   public:
     ap_uint<(1 << (2 * kNBitsBuffer))> lut;
     nearFull3Class() {
@@ -100,7 +100,7 @@ static bool nearFull4UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> 
 }
 
 template<int kNBitsBuffer>
-class emptyUnitClass {
+class EmptyUnitClass {
   public:
     ap_uint<(1 << (2 * kNBitsBuffer))> lut;
     emptyUnitClass() {

--- a/TrackletAlgorithm/MatchEngineUnit_parameters.h
+++ b/TrackletAlgorithm/MatchEngineUnit_parameters.h
@@ -32,7 +32,7 @@ template<int kNBitsBuffer>
 class NearFull3Class {
   public:
     ap_uint<(1 << (2 * kNBitsBuffer))> lut;
-    nearFull3Class() {
+    NearFull3Class() {
       for (unsigned int i = 0; i < (1 << (2 * kNBitsBuffer)); i++)  {
          // Store complicated calculation in LUT array
          ap_uint<kNBitsBuffer> wptr, rptr;
@@ -103,7 +103,7 @@ template<int kNBitsBuffer>
 class EmptyUnitClass {
   public:
     ap_uint<(1 << (2 * kNBitsBuffer))> lut;
-    emptyUnitClass() {
+    EmptyUnitClass() {
       for (unsigned int i = 0; i < (1 << (2 * kNBitsBuffer)); i++)  {
          // Store complicated calculation in LUT array
          ap_uint<kNBitsBuffer> wptr, rptr;

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -1351,7 +1351,9 @@ void MatchProcessor(BXType bx,
 
     auto readptr = projbufferarray.getReadPtr();
     auto writeptr = projbufferarray.getWritePtr();
-    bool empty = emptyUnit<nPRBAbits>()[(readptr,writeptr)];
+    //bool empty = emptyUnit<nPRBAbits>()[(readptr,writeptr)];
+    static const EmptyUnitClass<nPRBAbits> EmptyUnitClass;
+    bool empty = EmptyUnitClass.lut[(readptr,writeptr)];
 
     bool projBuffNearFull = nearFull4Unit<nPRBAbits>()[(readptr,writeptr)];
 

--- a/TrackletAlgorithm/ProjectionRouterBufferArray.h
+++ b/TrackletAlgorithm/ProjectionRouterBufferArray.h
@@ -38,7 +38,9 @@ public:
   }
 
   inline bool empty() { 
-    return emptyUnitBool<kNBitsBuffer>(readptr_, writeptr_);
+    static const EmptyUnitClass<kNBitsBuffer> EmptyUnitClass;
+    return EmptyUnitClass.lut[(readptr_, writeptr_)];
+    //return emptyUnitBool<kNBitsBuffer>(readptr_, writeptr_);
   }
 
   bool nearFull() {
@@ -68,7 +70,6 @@ private:
   ap_uint<kNBitsBuffer> writeptr_ = 0;
   ProjectionRouterBuffer<VMProjType,AllProjectionType> projbuffer_[1<<kNBitsBuffer];
   ap_uint<(1 << (2 * kNBitsBuffer))> nearFullLUT = nearFullUnit<kNBitsBuffer>();
-  ap_uint<(1 << (2 * kNBitsBuffer))> emptyLUT = emptyUnit<kNBitsBuffer>();
 
 };
 


### PR DESCRIPTION
This PR addresses an issue where CMSSW wastes CPU cycles for emptyUnit and nearFull3Unit. They are not loaded in static classes, and should only be initialized once.