### PR TITLE
Using static for LUTs

### DIFF
--- a/TrackletAlgorithm/MatchEngineUnit_parameters.h
+++ b/TrackletAlgorithm/MatchEngineUnit_parameters.h
@@ -7,7 +7,7 @@
 
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFullUnit() {
-  ap_uint<(1 << (2 * kNBitsBuffer))> lut;
+  static ap_uint<(1 << (2 * kNBitsBuffer))> lut;
   for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
 #pragma HLS unroll
     ap_uint<kNBitsBuffer> wptr, rptr;
@@ -30,7 +30,7 @@ static bool nearFullUnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> w
 
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull3Unit() {
-  ap_uint<(1 << (2 * kNBitsBuffer))> lut;
+  static ap_uint<(1 << (2 * kNBitsBuffer))> lut;
   for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
 #pragma HLS unroll
     ap_uint<kNBitsBuffer> wptr, rptr;
@@ -55,7 +55,7 @@ static bool nearFull3UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> 
 
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull4Unit() {
-  ap_uint<(1 << (2 * kNBitsBuffer))> lut;
+  static ap_uint<(1 << (2 * kNBitsBuffer))> lut;
   for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
 #pragma HLS unroll
     ap_uint<kNBitsBuffer> wptr, rptr;
@@ -82,7 +82,7 @@ static bool nearFull4UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> 
 
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> emptyUnit() {
-  ap_uint<(1 << (2 * kNBitsBuffer))> lut;
+  static ap_uint<(1 << (2 * kNBitsBuffer))> lut;
   for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
 #pragma HLS unroll
     ap_uint<kNBitsBuffer> wptr, rptr;
@@ -104,7 +104,7 @@ static bool emptyUnitBool(ap_uint<kNBitsBuffer> wptr, ap_uint<kNBitsBuffer> rptr
 
 template<int kNBitsBuffer>
 static const ap_uint<(1 << (2 * kNBitsBuffer))> geq() {
-  ap_uint<(1 << (2 * kNBitsBuffer))> lut;
+  static ap_uint<(1 << (2 * kNBitsBuffer))> lut;
   for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
 #pragma HLS unroll
     ap_uint<kNBitsBuffer> istub, nstubs;
@@ -118,7 +118,7 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> geq() {
 
 template<int kNBitsBuffer>
 static const ap_uint<(1 << kNBitsBuffer)> nextUnit() {
-  ap_uint<(1 << kNBitsBuffer)> lut;
+  static ap_uint<(1 << kNBitsBuffer)> lut;
   for(int i = 0; i < (1 << kNBitsBuffer); ++i) {
 #pragma HLS unroll
     ap_uint<kNBitsBuffer> ptr(i);

--- a/TrackletAlgorithm/MatchEngineUnit_parameters.h
+++ b/TrackletAlgorithm/MatchEngineUnit_parameters.h
@@ -10,13 +10,13 @@ static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFullUnit() {
   static ap_uint<(1 << (2 * kNBitsBuffer))> lut;
   for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
 #pragma HLS unroll
-    ap_uint<kNBitsBuffer> wptr, rptr;
-    ap_uint<2 * kNBitsBuffer> address(i);
-    (rptr,wptr) = address;
-    auto wptr1 = wptr+1;
-    auto wptr2 = wptr+2;
-    bool result = wptr1==rptr || wptr2==rptr;
-    lut[i] = result;
+   ap_uint<kNBitsBuffer> wptr, rptr;
+   ap_uint<2 * kNBitsBuffer> address(i);
+   (rptr,wptr) = address;
+   auto wptr1 = wptr+1;
+   auto wptr2 = wptr+2;
+   bool result = wptr1==rptr || wptr2==rptr;
+   lut[i] = result;
   }
   return lut;
 }
@@ -29,18 +29,22 @@ static bool nearFullUnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> w
 }
 
 template<int kNBitsBuffer>
-static const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull3Unit() {
+const ap_uint<(1 << (2 * kNBitsBuffer))> nearFull3Unit() {
   static ap_uint<(1 << (2 * kNBitsBuffer))> lut;
-  for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
+  static bool initialized = false;
+  if(!initialized) {
+    initialized = true;
+    for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
 #pragma HLS unroll
-    ap_uint<kNBitsBuffer> wptr, rptr;
-    ap_uint<2 * kNBitsBuffer> address(i);
-    (rptr,wptr) = address;
-    ap_uint<kNBitsBuffer> wptr1 = wptr+1;
-    ap_uint<kNBitsBuffer> wptr2 = wptr+2;
-    ap_uint<kNBitsBuffer> wptr3 = wptr+3;
-    bool result = wptr1==rptr || wptr2==rptr || wptr3==rptr;
-    lut[i] = result;
+      ap_uint<kNBitsBuffer> wptr, rptr;
+      ap_uint<2 * kNBitsBuffer> address(i);
+      (rptr,wptr) = address;
+      ap_uint<kNBitsBuffer> wptr1 = wptr+1;
+      ap_uint<kNBitsBuffer> wptr2 = wptr+2;
+      ap_uint<kNBitsBuffer> wptr3 = wptr+3;
+      bool result = wptr1==rptr || wptr2==rptr || wptr3==rptr;
+      lut[i] = result;
+    }
   }
   return lut;
 }
@@ -81,15 +85,19 @@ static bool nearFull4UnitBool(ap_uint<kNBitsBuffer> rptr, ap_uint<kNBitsBuffer> 
 }
 
 template<int kNBitsBuffer>
-static const ap_uint<(1 << (2 * kNBitsBuffer))> emptyUnit() {
+const ap_uint<(1 << (2 * kNBitsBuffer))> emptyUnit() {
   static ap_uint<(1 << (2 * kNBitsBuffer))> lut;
-  for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
+  static bool initialized = false;
+  if(!initialized) {
+    initialized = true;
+    for(int i = 0; i < (1 << (2 * kNBitsBuffer)); ++i) {
 #pragma HLS unroll
-    ap_uint<kNBitsBuffer> wptr, rptr;
-    ap_uint<2 * kNBitsBuffer> address(i);
-    (rptr,wptr) = address;
-    bool result = wptr==rptr;
-    lut[i] = result;
+      ap_uint<kNBitsBuffer> wptr, rptr;
+      ap_uint<2 * kNBitsBuffer> address(i);
+      (rptr,wptr) = address;
+      bool result = wptr==rptr;
+      lut[i] = result;
+    }
   }
   return lut;
 }


### PR DESCRIPTION
This is an alternative to #351 to address an issue where CMSSW wastes CPU cycles for emptyUnit and nearFull3Unit. All luts are now declared as static, so this _should_ fix the issue.