### PR TITLE
Remove static from non-const variables

### DIFF
--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -1303,11 +1303,11 @@ void MatchProcessor(BXType bx,
   IMemType imem = 0;
   IPageType ipage = 0;
 
-  static ap_uint<2*MEBinsBits> zbinLUT[128];
+  ap_uint<2*MEBinsBits> zbinLUT[128];
 #pragma HLS ARRAY_PARTITION variable=zbinLUT complete
   zbinLUTinit(zbinLUT, zbins_adjust_PSseed, zbins_adjust_2Sseed);
   constexpr int nRbinBits = VMProjection<VMPTYPE>::kVMProjFineZSize + VMProjectionBase<VMPTYPE>::kVMProjZBinSize;
-  static ap_uint<nRbinBits> rbinLUT[256];//1<<TrackletProjection<PROJTYPE>::kTProjRZSize];
+  ap_uint<nRbinBits> rbinLUT[256];//1<<TrackletProjection<PROJTYPE>::kTProjRZSize];
 #pragma HLS ARRAY_PARTITION variable=rbinLUT complete
   readRbin_LUT<LAYER,nRbinBits,256>(rbinLUT);
 


### PR DESCRIPTION
Addressing Issue #357 for the Match Processor. There are no changes to the timing and resource utilization.

```
#=== Post-Implementation Resource usage ===
CLB:            580
LUT:           2250
FF:            2827
DSP:              2
BRAM:             2
SRL:             13
URAM:             0
#=== Final timing ===
CP required:    4.000
CP achieved post-synthesis:    3.227
CP achieved post-implementation:    3.202
Timing met
```