### PR TITLE
Fix for high BX fanout

### DIFF
--- a/IntegrationTests/DualFPGA/firmware/hdl/sp2_mem_writer.vhd
+++ b/IntegrationTests/DualFPGA/firmware/hdl/sp2_mem_writer.vhd
@@ -75,6 +75,12 @@ architecture rtl of sp2_mem_writer is
 
   signal HLS_reset_int              : std_logic                    := '0';
 
+  attribute dont_touch : string;
+  attribute dont_touch of AS_36_writeaddr_pipeline0 : signal is "yes";
+  attribute dont_touch of AS_36_writeaddr_pipeline : signal is "yes";
+  attribute dont_touch of MPAR_73_writeaddr_pipeline0 : signal is "yes";
+  attribute dont_touch of MPAR_73_writeaddr_pipeline : signal is "yes";
+
 begin -- architecture rtl
   
   p_writemem : process (clk) is


### PR DESCRIPTION
#### PR Description

This is an easy fix that seems to help timing for FPGA2.

Vivado is smart enough to realize the highest three bits (the page number) are the same for all addresses output by the `sp2_mem_writer`, so after synthesis, the highest three bits from the first address are fanned out to all the address ports on the `SectorProcessor` (see first schematic below). As we've seen in the past, these kinds of nets can limit placement and negatively impact timing.

The fix is just to tell Vivado to not touch the addresses constructed by `sp2_mem_writer`, so that it properly duplicates the page number (see second schematic below). In my testing this helped the FPGA2 project to meet timing more reliably.

#### Schematics

Before this PR (`f2_in_1` is my first attempt at a pipeline for the inputs to `SectorProcessor`; the fanout behavior is the same even without this module):
![schematic](https://github.com/user-attachments/assets/74846225-d27a-4d37-a620-2dd328bfba06)

After this PR (the same net highlighted above, carrying the first address from `sp2_mem_writer`, is highlighted here):
![schematic_after](https://github.com/user-attachments/assets/488a30a4-e017-403a-b31a-ef28fbf634b3)