### PR TITLE
Fix issue with memory counters and add reset signal instead

### DIFF
--- a/IntegrationTests/common/hdl/tf_mem.vhd
+++ b/IntegrationTests/common/hdl/tf_mem.vhd
@@ -112,7 +112,7 @@ begin
 assert (RAM_DEPTH  = NUM_PAGES*PAGE_LENGTH) report "User changed RAM_DEPTH" severity FAILURE;
 
 process(clka)
-  variable init   : std_logic := '1'; -- Clock counter
+  variable init   : std_logic := '1'; 
   --FIXME hardcoded number
   variable slv_clk_cnt   : std_logic_vector(6 downto 0) := (others => '0'); -- Clock counter
   variable slv_page_cnt_save  :  std_logic_vector(clogb2(NUM_PAGES)-1 downto 0) := (others => '0');  -- Page counter save
@@ -149,11 +149,11 @@ begin
       --report time'image(now)&" tf_mem "&NAME&" will zero nent";
       nent_o(to_integer(unsigned(slv_page_cnt))) <= (others => '0');
     end if;
-    --use sync_nent transition to synchronize at BX (page) 1
     if (rsta='1') then
       init := '1';
       slv_page_cnt := (others => '0');
     elsif (sync_nent='1') and (init='1') then
+      --use sync_nent transition to synchronize at BX (page) 1
       --report time'image(now)&" tf_mem "&NAME&" sync_nent";
       init := '0';
       slv_clk_cnt := (others => '0');

--- a/IntegrationTests/common/hdl/tf_mem_bin.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_bin.vhd
@@ -105,6 +105,8 @@ entity tf_mem_bin is
     --! Read Enable, for additional power savings, disable when not in use
     enb       : in  std_logic_vector(NUM_COPY-1 downto 0);          
 
+    --! Input reset
+    rsta      : in  std_logic;                                      
     --! Output reset (does not affect memory contents)
     rstb      : in  std_logic;
 
@@ -287,7 +289,7 @@ begin
 assert (RAM_DEPTH  = NUM_PAGES*PAGE_LENGTH) report "User changed RAM_DEPTH" severity FAILURE;
 
 process(clka)
-  variable sync_nent_prev : std_logic := '0'; 
+  variable init   : std_logic := '1'; -- Clock counter
   --FIXME hardcoded number
   variable slv_clk_cnt   : std_logic_vector(6 downto 0) := (others => '0'); -- Clock counter
   variable slv_page_cnt  : std_logic_vector(NUM_PAGES_BITS-1 downto 0) := (others => '0');  -- Page counter
@@ -316,7 +318,7 @@ process(clka)
 begin
   if rising_edge(clka) then
     slv_page_cnt_save := slv_page_cnt;
-    if (sync_nent = '1' and to_integer(unsigned(slv_clk_cnt)) < MAX_ENTRIES-1) then -- ####### Counter nent
+    if (init = '0' and to_integer(unsigned(slv_clk_cnt)) < MAX_ENTRIES-1) then -- ####### Counter nent
       slv_clk_cnt := std_logic_vector(unsigned(slv_clk_cnt)+1);
     elsif (to_integer(unsigned(slv_clk_cnt)) >= MAX_ENTRIES-1) then -- -1 not included
       slv_clk_cnt := (others => '0');
@@ -332,15 +334,18 @@ begin
       validbinmask(NUM_RZ_BINS*(to_integer(unsigned(slv_page_cnt))+1)-1 downto NUM_RZ_BINS*(to_integer(unsigned(slv_page_cnt)))) <= (others => '0');
     end if;
     --use sync_nent transition to synchronize at BX (page) 1
-    if (sync_nent='1') and (sync_nent_prev='0') then
+    if (rsta='1') then
+      init := '1';
+      slv_page_cnt := (others => '0');
+    elsif (sync_nent='1') and (init='1') then
       --report time'image(now)&" tf_mem_bin "&NAME&" sync_nent";
+      init := '0';
       slv_clk_cnt := (others => '0');
       slv_page_cnt := (0 => '1', others => '0');
       validbinmasktmp <= (others => '0');
       nentry_mask_tmp <= (others => '0'); -- Do we need this??? FIXME
       --report "tf_mem_bin "&time'image(now)&" "&NAME&" sync_nent set";
     end if;
-    sync_nent_prev := sync_nent;
 
     if (wea='1') then
       -- FIXME - this code is not yet protected from "wrapping" if there are

--- a/IntegrationTests/common/hdl/tf_mem_bin.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_bin.vhd
@@ -289,7 +289,7 @@ begin
 assert (RAM_DEPTH  = NUM_PAGES*PAGE_LENGTH) report "User changed RAM_DEPTH" severity FAILURE;
 
 process(clka)
-  variable init   : std_logic := '1'; -- Clock counter
+  variable init   : std_logic := '1'; 
   --FIXME hardcoded number
   variable slv_clk_cnt   : std_logic_vector(6 downto 0) := (others => '0'); -- Clock counter
   variable slv_page_cnt  : std_logic_vector(NUM_PAGES_BITS-1 downto 0) := (others => '0');  -- Page counter
@@ -333,11 +333,11 @@ begin
       --report "tf_mem_bin "&time'image(now)&" "&NAME&" validbinmask: "&to_bstring(slv_page_cnt);
       validbinmask(NUM_RZ_BINS*(to_integer(unsigned(slv_page_cnt))+1)-1 downto NUM_RZ_BINS*(to_integer(unsigned(slv_page_cnt)))) <= (others => '0');
     end if;
-    --use sync_nent transition to synchronize at BX (page) 1
     if (rsta='1') then
       init := '1';
       slv_page_cnt := (others => '0');
     elsif (sync_nent='1') and (init='1') then
+      --use sync_nent transition to synchronize at BX (page) 1
       --report time'image(now)&" tf_mem_bin "&NAME&" sync_nent";
       init := '0';
       slv_clk_cnt := (others => '0');

--- a/IntegrationTests/common/hdl/tf_mem_tpar.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_tpar.vhd
@@ -45,6 +45,7 @@ entity tf_mem_tpar is
     clkb      : in  std_logic;                                      --! Read clock
     wea       : in  std_logic;                                      --! Write enable
     enb       : in  std_logic;                                      --! Read Enable, for additional power savings, disable when not in use
+    rsta      : in  std_logic;                                      --! Input reset
     rstb      : in  std_logic;                                      --! Output reset (does not affect memory contents)
     regceb    : in  std_logic;                                      --! Output register enable
     addra     : in  std_logic_vector(clogb2(RAM_DEPTH)-1 downto 0); --! Write address bus, width determined from RAM_DEPTH
@@ -115,7 +116,7 @@ assert (PAGE_LENGTH = 128) report "PAGE_LENGTH in tf_mem_tpar has to be 128" sev
 
 
 process(clka)
-  variable sync_nent_prev : std_logic := '0';
+  variable init   : std_logic := '1'; -- Clock counter
   variable slv_clk_cnt   : std_logic_vector(clogb2(PAGE_LENGTH)-1 downto 0) := (others => '0'); -- Clock counter
   variable slv_page_cnt_save  :  std_logic_vector(clogb2(NUM_PAGES)-1 downto 0) := (others => '0');  -- Page counter save
   variable slv_page_cnt  : std_logic_vector(clogb2(NUM_PAGES)-1 downto 0) := (others => '0'); 
@@ -144,7 +145,7 @@ begin
     --end if;
 
     slv_page_cnt_save := slv_page_cnt;
-    if (sync_nent = '1' and to_integer(unsigned(slv_clk_cnt)) < MAX_ENTRIES-1) then
+    if (init = '0' and to_integer(unsigned(slv_clk_cnt)) < MAX_ENTRIES-1) then
       slv_clk_cnt := std_logic_vector(unsigned(slv_clk_cnt)+1);     
     elsif (to_integer(unsigned(slv_clk_cnt)) >= MAX_ENTRIES-1) then 
       slv_clk_cnt := (others => '0');
@@ -158,12 +159,15 @@ begin
       -- reset the nent_o counter if the mask is zero
     end if;
     --use sync_nent transition to synchronize at BX (page) 1
-    if (sync_nent='1') and (sync_nent_prev='0') then
-      --report time'image(now)&" tf_mem_tpar "&NAME&" sync_nent";
+    if (rsta='1') then
+      init := '1';
+      slv_page_cnt := (others => '0');
+    elsif (sync_nent='1') and (init='1') then
+      --report time'image(now)&" tf_mem "&NAME&" sync_nent";
+      init := '0';
       slv_clk_cnt := (others => '0');
       slv_page_cnt := (0 => '1', others => '0');
     end if;
-    sync_nent_prev := sync_nent;
 
     if (wea='1') then
       tpage := addra(clogb2(NUM_TPAGES)-1 downto 0);

--- a/IntegrationTests/common/hdl/tf_mem_tpar.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_tpar.vhd
@@ -116,7 +116,7 @@ assert (PAGE_LENGTH = 128) report "PAGE_LENGTH in tf_mem_tpar has to be 128" sev
 
 
 process(clka)
-  variable init   : std_logic := '1'; -- Clock counter
+  variable init   : std_logic := '1'; 
   variable slv_clk_cnt   : std_logic_vector(clogb2(PAGE_LENGTH)-1 downto 0) := (others => '0'); -- Clock counter
   variable slv_page_cnt_save  :  std_logic_vector(clogb2(NUM_PAGES)-1 downto 0) := (others => '0');  -- Page counter save
   variable slv_page_cnt  : std_logic_vector(clogb2(NUM_PAGES)-1 downto 0) := (others => '0'); 
@@ -158,11 +158,11 @@ begin
       -- Note that we don't zero the nent_o counters here. When adding entry we
       -- reset the nent_o counter if the mask is zero
     end if;
-    --use sync_nent transition to synchronize at BX (page) 1
     if (rsta='1') then
       init := '1';
       slv_page_cnt := (others => '0');
     elsif (sync_nent='1') and (init='1') then
+      --use sync_nent transition to synchronize at BX (page) 1
       --report time'image(now)&" tf_mem "&NAME&" sync_nent";
       init := '0';
       slv_clk_cnt := (others => '0');

--- a/IntegrationTests/common/hdl/tf_mem_tproj.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_tproj.vhd
@@ -115,7 +115,7 @@ assert (RAM_DEPTH  = NUM_TPAGES*NUM_PAGES*PAGE_LENGTH) report "User changed RAM_
 assert (PAGE_LENGTH = 64) report "PAGE_LENGTH in tf_mem_tproj has to be 64" severity FAILURE;
 
 process(clka)
-  variable init   : std_logic := '1'; -- Clock counter
+  variable init   : std_logic := '1'; 
   variable slv_clk_cnt   : std_logic_vector(clogb2(PAGE_LENGTH*2)-1 downto 0) := (others => '0'); -- Hack...
   variable slv_page_cnt_save  :  std_logic_vector(clogb2(NUM_PAGES)-1 downto 0) := (others => '0');  
   variable slv_page_cnt  : std_logic_vector(clogb2(NUM_PAGES)-1 downto 0) := (others => '0'); 
@@ -155,11 +155,11 @@ begin
       -- Note that we don't zero the nent_o counters here. When adding entry we
       -- reset the nent_o counter if the mask is zero
     end if;
-    --use sync_nent transition to synchronize at BX (page) 1
     if (rsta='1') then
       init := '1';
       slv_page_cnt := (others => '0');
     elsif (sync_nent='1') and (init='1') then
+      --use sync_nent transition to synchronize at BX (page) 1
       --report time'image(now)&" tf_mem "&NAME&" sync_nent";
       init := '0';
       slv_clk_cnt := (others => '0');

--- a/IntegrationTests/common/hdl/tf_mem_tproj.vhd
+++ b/IntegrationTests/common/hdl/tf_mem_tproj.vhd
@@ -45,6 +45,7 @@ entity tf_mem_tproj is
     clkb      : in  std_logic;                                      --! Read clock
     wea       : in  std_logic;                                      --! Write enable
     enb       : in  std_logic;                                      --! Read Enable, for additional power savings, disable when not in use
+    rsta      : in  std_logic;                                      --! Input reset
     rstb      : in  std_logic;                                      --! Output reset (does not affect memory contents)
     regceb    : in  std_logic;                                      --! Output register enable
     addra     : in  std_logic_vector(clogb2(RAM_DEPTH)-1 downto 0); --! Write address bus, width determined from RAM_DEPTH
@@ -114,7 +115,7 @@ assert (RAM_DEPTH  = NUM_TPAGES*NUM_PAGES*PAGE_LENGTH) report "User changed RAM_
 assert (PAGE_LENGTH = 64) report "PAGE_LENGTH in tf_mem_tproj has to be 64" severity FAILURE;
 
 process(clka)
-  variable sync_nent_prev : std_logic := '0';
+  variable init   : std_logic := '1'; -- Clock counter
   variable slv_clk_cnt   : std_logic_vector(clogb2(PAGE_LENGTH*2)-1 downto 0) := (others => '0'); -- Hack...
   variable slv_page_cnt_save  :  std_logic_vector(clogb2(NUM_PAGES)-1 downto 0) := (others => '0');  
   variable slv_page_cnt  : std_logic_vector(clogb2(NUM_PAGES)-1 downto 0) := (others => '0'); 
@@ -141,7 +142,7 @@ begin
     --end if;
     --end if;
     slv_page_cnt_save := slv_page_cnt;
-    if (sync_nent = '1' and to_integer(unsigned(slv_clk_cnt)) < MAX_ENTRIES-1) then
+    if (init = '0' and to_integer(unsigned(slv_clk_cnt)) < MAX_ENTRIES-1) then
       slv_clk_cnt := std_logic_vector(unsigned(slv_clk_cnt)+1);     
     elsif (to_integer(unsigned(slv_clk_cnt)) >= MAX_ENTRIES-1) then 
       slv_clk_cnt := (others => '0');
@@ -155,12 +156,15 @@ begin
       -- reset the nent_o counter if the mask is zero
     end if;
     --use sync_nent transition to synchronize at BX (page) 1
-    if (sync_nent='1') and (sync_nent_prev='0') then
-      --report time'image(now)&" tf_mem_tproj "&NAME&" sync_nent";
+    if (rsta='1') then
+      init := '1';
+      slv_page_cnt := (others => '0');
+    elsif (sync_nent='1') and (init='1') then
+      --report time'image(now)&" tf_mem "&NAME&" sync_nent";
+      init := '0';
       slv_clk_cnt := (others => '0');
       slv_page_cnt := (0 => '1', others => '0');
     end if;
-    sync_nent_prev := sync_nent;
 
     if (wea='1') then
       tpage := addra(clogb2(NUM_TPAGES)-1 downto 0);


### PR DESCRIPTION
Previous implementation of memory reset in #367 introduced bug where memory page never updates. This PR now restores the initialization logic to fix the page bug wile propagating a reset signal from SectorProcessor top to enable memory resets. Corresponds to project_generation_scripts [#73](https://github.com/cms-L1TK/project_generation_scripts/pull/73).

Double-checked that the output of both FPGAs are bitwise identical to that before the bug introduced by #367.