### PR TITLE
FPGA1 debug rebase

### DIFF
--- a/IntegrationTests/common/hdl/tf_pkg.vhd
+++ b/IntegrationTests/common/hdl/tf_pkg.vhd
@@ -105,6 +105,7 @@ package tf_pkg is
   type t_arr_7b  is array(integer range<>) of std_logic_vector(6 downto 0);
   type t_arr_6b  is array(integer range<>) of std_logic_vector(5 downto 0);
   subtype t_arr2_7b is t_arr_7b(0 to 1);
+  subtype t_arr4_7b is t_arr_7b(0 to 3);
   subtype t_arr2_6b is t_arr_6b(0 to 1);
   subtype t_arr2_4b is t_arr_4b(0 to 1);
   subtype t_arr8_7b is t_arr_7b(0 to 7);

--- a/TrackletAlgorithm/DTCStubMemory.h
+++ b/TrackletAlgorithm/DTCStubMemory.h
@@ -60,6 +60,6 @@ private:
 };
 
 // Memory definition
-using DTCStubMemory = MemoryTemplate<DTCStub, 1, kNBits_MemAddr>;
+using DTCStubMemory = MemoryTemplate<DTCStub, 2, kNBits_MemAddr>;
 
 #endif

--- a/TrackletAlgorithm/InputStubMemory.h
+++ b/TrackletAlgorithm/InputStubMemory.h
@@ -288,6 +288,6 @@ private:
 
 
 // Memory definition
-template<int ISType> using InputStubMemory = MemoryTemplate<InputStub<ISType>, 1, kNBits_MemAddr>;
+template<int ISType> using InputStubMemory = MemoryTemplate<InputStub<ISType>, 2, kNBits_MemAddr>;
 
 #endif


### PR DESCRIPTION

 This PR consists of a set of updates to both project_generation_scripts and firmware_hls to solve several disagreements between the reduced FPGA1 project and the CMSSW C++ emulation. Many of the fixes here should be considered "patches" - e.g. the file writing should be moved into the memory modules to make sure that we accurately print the correct debug information. Now there is a fair bit of manual adjustment to get the debug printout to align with the memory writing.

 project_generation_scripts:

  - To avoid an overwrite of the InputLink memories I changed them to use 4 pages instead of two. Could probably have used two page after adding delays in the memory writing. This is particularly a problem here as we read multiple input memories in the VMR and the last memory to be read was over written in one of the 100 events.

 - Add delay in the FileWriterFIFO modules to align debug writing with correct BX. Similarly align debug printout for VMSTE, IL, and AS

 firmware_hls:

  - Add delay in the FileWriterFIFO.vhd

  - tf_merge_streamer.vhd has some significant rewrites to process data on each BX. The logic is a bit convoluted as the bx_in_vld signal is not aligned with the change in bx. A delay of three clocks has been added to fix this. This should probably be fixed in a cleaner way.

 - Fixes to CompareMemPrintsFW.py to handle MPAR and AS memories. This could be avoided if the debug printout followed the memory writing.

 - Make the IL memory use 4 pages instead of 2.

 
