### PR TITLE
Allow FPGA2 to generate BX internally via a counter

### DIFF
--- a/IntegrationTests/DualFPGA/firmware/hdl/linktosecproc2.vhd
+++ b/IntegrationTests/DualFPGA/firmware/hdl/linktosecproc2.vhd
@@ -18,7 +18,8 @@ entity linktosecproc2 is
     bx_link_data       : out std_logic_vector(2 downto 0);
     AS_36_link_valid   : out t_arr_AS_36_1b;
     MPAR_73_link_valid : out t_arr_MTPAR_73_1b;
-    bx_link_valid      : out std_logic
+    bx_link_valid      : out std_logic;
+    bx_src_internal     : out std_logic
     );
 
 end linktosecproc2;
@@ -27,6 +28,10 @@ architecture rtl of linktosecproc2 is
 
   signal AS_signals       : std_logic_vector(48*37 - 1 downto 0);
   signal MTPAR_signals    : std_logic_vector(15*76 - 1 downto 0);
+
+  signal bx_src_valid        : std_logic := '0';
+  signal bx_src_internal_in   : std_logic := '0';
+  signal bx_src_internal_lock : std_logic := '0';
 
 begin
 
@@ -230,5 +235,11 @@ begin
 
   bx_link_data <= d(9).data(2 downto 0);
   bx_link_valid <= d(9).valid;
-    
+
+  bx_src_valid <= d(8).data(1);
+  bx_src_internal_in <= d(8).data(0);
+
+  bx_src_internal_lock <= bx_src_internal_in when bx_src_valid = '1' else bx_src_internal_lock;
+  bx_src_internal <= bx_src_internal_lock;
+
 end rtl;

--- a/IntegrationTests/DualFPGA/firmware/hdl/payload_f2.vhd
+++ b/IntegrationTests/DualFPGA/firmware/hdl/payload_f2.vhd
@@ -52,6 +52,7 @@ architecture rtl of emp_payload is
   signal MPAR_73_link_valid    : t_arr_MTPAR_73_1b;
   signal bx_link_data          : std_logic_vector(2 downto 0);
   signal bx_link_valid         : std_logic;
+  signal bx_src_internal        : std_logic;
   signal PC_start              : std_logic;
   signal PC_bx_in              : std_logic_vector(2 downto 0);
   signal HLS_reset             : std_logic;
@@ -90,7 +91,8 @@ begin
       bx_link_data       => bx_link_data,
       AS_36_link_valid   => AS_36_link_valid,
       MPAR_73_link_valid => MPAR_73_link_valid,
-      bx_link_valid      => bx_link_valid
+      bx_link_valid      => bx_link_valid,
+      bx_src_internal     => bx_src_internal
       );
 
   -----------------------------------------------------------------------------
@@ -106,6 +108,7 @@ begin
       AS_36_link_valid   => AS_36_link_valid,
       MPAR_73_link_valid => MPAR_73_link_valid,
       bx_link_valid      => bx_link_valid,
+      bx_src_internal     => bx_src_internal,
       AS_36_wea          => AS_36_wea,
       AS_36_writeaddr    => AS_36_writeaddr,
       AS_36_din          => AS_36_din,

--- a/IntegrationTests/DualFPGA/firmware/hdl/secproc1tolink.vhd
+++ b/IntegrationTests/DualFPGA/firmware/hdl/secproc1tolink.vhd
@@ -192,6 +192,9 @@ begin
                                               and sr_valid_prev='0') else
                      x"000000000000000";
 
+  -- Configure FPGA2 to read BX value from data stream
+  q(55).data(1 downto 0) <= "10";
+
   --debug
   --q(55).data(2 downto 0) <= bx_in;
   --q(55).data(3) <= '0';

--- a/IntegrationTests/DualFPGA/firmware/hdl/secproc1tolink.vhd
+++ b/IntegrationTests/DualFPGA/firmware/hdl/secproc1tolink.vhd
@@ -153,7 +153,7 @@ begin
     q(i).last <= sr(sr'high).last;
     q(i).valid <= sr(sr'high).valid;
   end generate;
-  control_signals2 : for i in 20 to 54 generate
+  control_signals2 : for i in 20 to 55 generate
     q(i).start_of_orbit <= sr(sr'high).start_of_orbit;
     q(i).start <= sr(sr'high).start;
     q(i).last <= sr(sr'high).last;

--- a/IntegrationTests/DualFPGA/firmware/hdl/sp2_mem_writer.vhd
+++ b/IntegrationTests/DualFPGA/firmware/hdl/sp2_mem_writer.vhd
@@ -23,6 +23,7 @@ entity sp2_mem_writer is
     AS_36_link_valid          : in t_arr_AS_36_1b;
     MPAR_73_link_valid        : in t_arr_MTPAR_73_1b;
     bx_link_valid             : in std_logic;
+    bx_src_internal           : in std_logic;
     AS_36_wea                 : out t_arr_AS_36_1b;
     AS_36_writeaddr           : out t_arr_AS_36_ADDR;
     AS_36_din                 : out t_arr_AS_36_DATA;
@@ -51,6 +52,8 @@ architecture rtl of sp2_mem_writer is
 
   signal MPAR_73_pge     : t_arr_MTPAR_73_2b            := (others => "00");
   signal bx_prev         : std_logic_vector(2 downto 0) := "000";
+  signal bx_counter      : unsigned(2 downto 0)         := (others => '0');
+  signal bx_next         : unsigned(2 downto 0)         := (others => '0');
   signal AS_36_wea_int   : t_arr_AS_36_1b               := (others => '0');
   signal MPAR_73_wea_int : t_arr_MTPAR_73_1b            := (others => '0');
   signal AS_36_din_int   : t_arr_AS_36_DATA             := (others => (others => '0'));
@@ -128,19 +131,21 @@ begin -- architecture rtl
           --generate start when BX rolls from 0 to 1
           if (bx_link_valid='1' and bx_link_data="001" and bx_prev="000") then
             sync_counter <= (others => '0');
+            bx_counter <= to_unsigned(1, 3);
             PC_start_int <= '1';
             sectorprocessor_ctrl <= S_ACTIVE;
           end if;
 
         when S_ACTIVE =>
           --generate reset if BX change is not sync'd w/ counter
-          if (to_integer(sync_counter) = 107) then 
+          if (to_integer(sync_counter) = 107) then
             sync_counter <= (others => '0');
+            bx_counter <= bx_counter + 1;
           else
             sync_counter <= sync_counter+1;
           end if;
           if ((bx_link_valid='1' and bx_link_data /= bx_prev
-              and to_integer(sync_counter) /= 107) or rst = '1') then 
+              and to_integer(sync_counter) /= 107) or rst = '1') then
             sync_counter <= (others => '0');
             PC_start_int <= '0';
             HLS_reset_int <= '1';
@@ -159,6 +164,12 @@ begin -- architecture rtl
 
       end case;
 
+      if (bx_src_internal = '1') then
+        bx_next <= bx_counter - 1;
+      else
+        bx_next <= unsigned(bx_prev) - 1;
+      end if;
+
     end if; --rising clock edge
   end process p_writemem;
 
@@ -171,7 +182,7 @@ begin -- architecture rtl
   MPAR_73_wea_pipeline0 <= MPAR_73_wea_int;
   AS_36_din_pipeline0 <= AS_36_din_int;
   MPAR_73_din_pipeline0 <= MPAR_73_din_int;
-  PC_bx_in_pipeline <= std_logic_vector(unsigned(bx_prev)-1);
+  PC_bx_in_pipeline <= std_logic_vector(bx_next);
   PC_start_pipeline <= PC_start_int;
   HLS_reset <= HLS_reset_int;
   AS_36_writeaddr <= AS_36_writeaddr_pipeline;


### PR DESCRIPTION
This change fixes an issue that occurs when testing FPGA2 in isolation cause by a difference in BX sources for the `mem_reader` and `tf_mem` modules. The `tf_mem` module maintains its own BX value internally via a counter. the `mem_reader` module receives its BX value externally, and in the context of FPGA2, this ultimately comes from the input data links (sent from FPGA1).

When testing FPGA2 in isolation, these become out of sync when an LHC orbit rolls over. This is because the orbit (198 events) does not divide evenly into the number of pages in the memory (8). Namely, 198 % 8 = 6. So, when the orbit rolls over, the `tf_mem` module will start writing to page 6, whereas the `mem_reader` module will start reading from page 0 since the input data is static (from a file).

This change allows the BX sent to the `mem_reader` module to come from both the input data stream OR generated via a counter. It is configured using link 8, which was previously unused. Sending `11` on the LSBs of link 8 configures FPGA2 to use an internal counter, whereas `10` configures it to use the input data stream. The first bit is a "valid" bit and the second bit is what actually determines the BX source.