### PR TITLE
CI4FPGA

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,322 +1,282 @@
+################################################################################
+# Global definitions
+#-------------------------------------------------------------------------------
 variables:
-  GIT_SUBMODULE_STRATEGY: recursive
-  VIVADO_PATH_SH: '/nfs/data41/software/Xilinx/Vivado/${VIVADO_VERSION}/settings64.sh'
-  CLANG_TIDY_PATH: '/opt/rh/llvm-toolset-7.0/root/bin/clang-tidy'
-  CLANG_TIDY_OPTIONS: '-format-style=file' #-config='' does not work because of the quotes; -header-filter in .clang-tidy
-  CLANG_TIDY_COMP_OPTIONS: '-std=c++11 -I../TrackletAlgorithm -I../TrackletAlgorithm/TestBench -I../TopFunctions/CombinedConfig_FPGA2 -I../TopFunctions/CombinedConfig -I../TestBenches -I/nfs/data41/software/Xilinx/Vivado/${VIVADO_VERSION}/include'
+  VIVADO_VERSION: "2019.2"
+  HLS_COMMAND: "vivado_hls"
 
-stages: # ---------------------------------------------------------------------
-  - lint
-  - download
-  - quality-check
-  - hls-build
-  - topTF-sim
-  - check-results
-  - topTF-synth
+stages:
+  - Python checks
+  - Setup
+  - HLS checks
+  - Create projects
+  - Simulate
+  - Check simulation results
+  - Synthesize
+  - Implement
+################################################################################
 
-# Job templates ---------------------------------------------------------------
-.job_template: &template_base
+################################################################################
+# Job templates
+#-------------------------------------------------------------------------------
+.vivado-job:
+  image: registry.cern.ch/ci4fpga/vivado:$VIVADO_VERSION
   tags:
-    - xilinx-tools
-  before_script:
-    - source $VIVADO_PATH_SH
-
-.job_template: &template_static-check-python
-  tags:
-    - xilinx-tools
-  stage: lint
-  before_script:
-    - which python3
-    - python3 --version
-    - python3 -m pylint --version
-
-.job_template: &template_quality-check
-  needs: ["download"]
-  tags:
-    - xilinx-tools
-  stage: quality-check
-  before_script:
-    # Needed for new tool version
-    - source /opt/rh/llvm-toolset-7.0/enable
-  script:
-    - pwd; ls -la; ls -la TrackletAlgorithm/;
-    - cd project
-    - pwd; ls -la; # Debug
-    # Hard coded -config='' because the quotes do not work in the variable
-    - ${CLANG_TIDY_PATH} -config='' ${CLANG_TIDY_OPTIONS} ${CLANG_TIDY_FILES} -- ${CLANG_TIDY_COMP_OPTIONS} ${CLANG_TIDY_INCLUDES}
-
-.job_template: &template_hls-build
-  <<: *template_base
-  stage: hls-build
-  script:
-    - cd project
-    - pwd; ls -la; # Debug
-    - ${EXECUTABLE} -f "script_${PROJ_NAME}.tcl"
+    - fpga-mid
+  dependencies:
+    - download
+  after_script:
+    - cd emData/
+    - ./clean.sh > /dev/null 2>&1
   artifacts:
-    when: on_success
-    name: "$CI_JOB_NAME-$CI_JOB_STAGE-$CI_COMMIT_REF_NAME"
-    paths:
-      - ./project/
+    name: "$CI_JOB_STAGE-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA"
+    untracked: true
     expire_in: 1 week
 
-.job_template: &template_topTF-sim
-  <<: *template_base
-  stage: topTF-sim
+.hls-job:
+  extends: .vivado-job
+  stage: HLS checks
+  variables:
+    NOUSE: Synthesis,Implementation
   script:
-    - cd IntegrationTests/${PROJ_NAME}/script
-    - pwd; ls -la; #debug
+    - cd project/
+    - $HLS_COMMAND -f script_$MODULE.tcl
+
+.create-project:
+  extends: .vivado-job
+  stage: Create projects
+  tags:
+    - fpga-large
+  variables:
+    NOUSE: Synthesis,Implementation
+  script:
+    - cd IntegrationTests/$PROJECT/script/
     - make -j`nproc` Work
-    - vivado -mode batch -source ./runSim.tcl | awk 'BEGIN{IGNORECASE=1} /^error/ {exit_code=1;} // {print $0;} END{exit exit_code}'
-  artifacts:
-    when: on_success
-    name: "$CI_JOB_NAME-$CI_JOB_STAGE-$CI_COMMIT_REF_NAME"
-    paths:
-      - ./IntegrationTests/${PROJ_NAME}/script/
-    expire_in: 1 week
+  after_script:
+    - cd IntegrationTests/$PROJECT/script/
+    - rm -rf Work vivado*
+    - cd -
+    - cd emData/
+    - ./clean.sh > /dev/null 2>&1
 
-.job_template: &template_check-results
-  <<: *template_base
-  stage: check-results
+.sim-project:
+  extends: .vivado-job
+  stage: Simulate
+  variables:
+    NOUSE: Synthesis,Implementation
   script:
-    - cd IntegrationTests/${PROJ_NAME}/script
-    # Compare HDL sim output with Mem/Prints
+    - cd IntegrationTests/$PROJECT/script/
+    - vivado -mode batch -source ./makeProject.tcl
+    - vivado -mode batch -source ./runSim.tcl
+  after_script:
+    - cd IntegrationTests/$PROJECT/script/
+    - find -mindepth 1 -maxdepth 1 -type d ! -regex ".*\/dataOut$" -exec rm -rf {} \;
+    - cd -
+    - cd emData/
+    - ./clean.sh > /dev/null 2>&1
+
+.check-project:
+  stage: Check simulation results
+  image: registry.cern.ch/docker.io/library/python
+  before_script:
+    - pip install --root-user-action=ignore pandas
+  script:
+    - cd IntegrationTests/$PROJECT/script/
     - python3 common/script/CompareMemPrintsFW.py -p -s
+  after_script:
+    - cd IntegrationTests/$PROJECT/script/
+    - find -mindepth 1 -maxdepth 1 -type l -exec rm -f {} \;
+    - rm -f vivado*
+    - cd -
+    - cd emData/
+    - ./clean.sh > /dev/null 2>&1
   artifacts:
-    when: on_success
-    name: "$CI_JOB_NAME-$CI_JOB_STAGE-$CI_COMMIT_REF_NAME"
-    paths:
-      - ./IntegrationTests/${PROJ_NAME}/script/dataOut/*.txt
-    expire_in: 10 week
-
-.job_template: &template_topTF-synth
-  <<: *template_base
-  stage: topTF-synth
-  script:
-    - cd IntegrationTests/${PROJ_NAME}/script
-    - pwd; ls -la; #debug
-    - make Work/Work.runs/synth_1 | awk 'BEGIN{IGNORECASE=1} /^error/ {exit_code=1;} // {print $0;} END{exit exit_code}'
-  artifacts:
-    when: on_success
-    name: "$CI_JOB_NAME-$CI_JOB_STAGE-$CI_COMMIT_REF_NAME"
-    paths:
-      - ./IntegrationTests/${PROJ_NAME}/script/Work/Work.runs/synth_1/*.rpt
+    name: "$CI_JOB_STAGE-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA"
+    untracked: true
     expire_in: 1 week
-    
-# Jobs ------------------------------------------------------------------------
-# Lint ------------
-py3check:
-  <<: *template_static-check-python
-  script:
-    # If changes need to be made you might refer to: https://portingguide.readthedocs.io/en/latest/tools.html#automated-fixer-python-modernize
-    - python3 -m pylint --py3k emData/*.py # Check for python3 compatibility
-lint:
-  <<: *template_static-check-python
-  allow_failure: true
-  script:
-    - python3 -m pylint emData/*.py # Static code checker
-# Download ------------
-download:
+
+.synth-project:
+  extends: .vivado-job
+  stage: Synthesize
   tags:
-    - xilinx-tools
-  stage: download
-  needs: ["py3check", "lint"]
+    - fpga-large
+  variables:
+    NOUSE: Implementation
   script:
-    - cd emData
+    - cd IntegrationTests/$PROJECT/script/
+    - vivado -mode batch -source ./makeProject.tcl
+    - vivado -mode batch -source ./common/script/synth.tcl
+  after_script:
+    - cd IntegrationTests/$PROJECT/script/
+    - find -mindepth 1 -maxdepth 1 -type d ! -regex ".*\/Work$" -exec rm -rf {} \;
+    - find -mindepth 1 -maxdepth 1 -type l -exec rm -f {} \;
+    - cd -
+    - cd emData/
+    - ./clean.sh > /dev/null 2>&1
+
+.impl-project:
+  extends: .vivado-job
+  stage: Implement
+  tags:
+    - fpga-large
+  variables:
+    NOUSE: Synthesis
+  script:
+    - cd IntegrationTests/$PROJECT/script/
+    - vivado -mode batch -source ./common/script/impl.tcl
+  after_script:
+    - cd IntegrationTests/$PROJECT/script/
+    - find -mindepth 1 -maxdepth 1 -type d ! -regex ".*\/Work$" -exec rm -rf {} \;
+    - find -mindepth 1 -maxdepth 1 -type l -exec rm -f {} \;
+    - cd -
+    - cd emData/
+    - ./clean.sh > /dev/null 2>&1
+################################################################################
+
+################################################################################
+# Job definitions
+#-------------------------------------------------------------------------------
+pylint:
+  stage: Python checks
+  image: registry.cern.ch/docker.io/library/python
+  before_script:
+    - pip install --root-user-action=ignore pylint
+  script:
+    - python3 -m pylint emData/*.py
+
+download:
+  stage: Setup
+  image: registry.cern.ch/docker.io/library/python
+  script:
+    - cd emData/
     - ./download.sh
   artifacts:
-    when: on_success
-    name: "$CI_JOB_NAME-$CI_JOB_STAGE-$CI_COMMIT_REF_NAME"
-    paths:
-      - ./emData/
-      - ./TopFunctions/
-      - ./IntegrationTests/
+    name: "$CI_JOB_STAGE-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA"
+    untracked: true
     expire_in: 1 week
-# Quality checks ------------
-IR-quality-check:
-  <<: *template_quality-check
+
+### HLS checks
+
+build-IR:
+  extends: .hls-job
   variables:
-    VIVADO_VERSION: "2019.2"
-    CLANG_TIDY_FILES: '../TestBenches/InputRouter_test.cpp ../TopFunctions/CombinedConfig_FPGA2/InputRouterTop.cc'
-VMRCM-quality-check:
-  <<: *template_quality-check
+    MODULE: "IR"
+
+build-MP:
+  extends: .hls-job
+  tags:
+    - fpga-large
   variables:
-    VIVADO_VERSION: "2019.2"
-    CLANG_TIDY_FILES: '../TestBenches/VMRouterCM_test.cpp ../TopFunctions/CombinedConfig_FPGA2/VMRouterCMTop_L2PHIA.cc'
-VMSMER-quality-check:
-  <<: *template_quality-check
+    MODULE: "MP"
+
+build-PC:
+  extends: .hls-job
   variables:
-    VIVADO_VERSION: "2019.2"
-    CLANG_TIDY_FILES: '../TestBenches/VMStubMERouter_test.cpp ../TopFunctions/CombinedConfig_FPGA2/VMStubMERouterTop_D1PHIA.cc'    
-TP-quality-check:
-  <<: *template_quality-check
+    MODULE: "PC"
+
+build-TB:
+  extends: .hls-job
   variables:
-    VIVADO_VERSION: "2019.2"
-    CLANG_TIDY_FILES: '../TestBenches/TrackletProcessor_test.cpp ../TopFunctions/CombinedConfig_FPGA2/TrackletProcessorTop.cc'
-PC-quality-check:
-  <<: *template_quality-check
+    MODULE: "TB"
+
+build-TP:
+  extends: .hls-job
   variables:
-    VIVADO_VERSION: "2019.2"
-    CLANG_TIDY_FILES: '../TestBenches/ProjectionCalculator_test.cpp ../TopFunctions/CombinedConfig_FPGA2/ProjectionCalculatorTop.cc'
-MP-quality-check:
-  <<: *template_quality-check
+    MODULE: "TP"
+
+build-VMRCM:
+  extends: .hls-job
   variables:
-    VIVADO_VERSION: "2019.2"
-    CLANG_TIDY_FILES: '../TestBenches/MatchProcessor_test.cpp ../TopFunctions/CombinedConfig_FPGA2/MatchProcessorTop.cc'
-TB-quality-check:
-  <<: *template_quality-check
+    MODULE: "VMRCM"
+
+build-VMSMER:
+  extends: .hls-job
   variables:
-    VIVADO_VERSION: "2019.2"
-    CLANG_TIDY_FILES: '../TestBenches/TrackBuilder_test.cpp ../TopFunctions/CombinedConfig_FPGA2/TrackBuilderTop.cc'
-TM-quality-check:
-  <<: *template_quality-check
+    MODULE: "VMSMER"
+
+### Create projects
+
+create-ReducedCombinedConfig_FPGA1:
+  extends: .create-project
   variables:
-    VIVADO_VERSION: "2019.2"
-    CLANG_TIDY_FILES: '../TestBenches/TrackMerger_test.cpp ../TopFunctions/TrackMergerTop.cc'
-# HLS builds ---------------
-IR-vivado-hls-build:
-  <<: *template_hls-build
-  needs: ["download", "IR-quality-check"]
+    PROJECT: "ReducedCombinedConfig_FPGA1"
+
+create-ReducedCombinedConfig_FPGA2:
+  extends: .create-project
   variables:
-    EXECUTABLE: 'vivado_hls'
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "IR"
-VMRCM-vivado-hls-build:
-  <<: *template_hls-build
-  needs: ["download", "VMRCM-quality-check"]
-  variables:
-    EXECUTABLE: 'vivado_hls'
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "VMRCM"
-VMSMER-vivado-hls-build:
-  <<: *template_hls-build
-  needs: ["download", "VMSMER-quality-check"]
-  variables:
-    EXECUTABLE: 'vivado_hls'
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "VMSMER"
-TP-vivado-hls-build:
-  <<: *template_hls-build
-  needs: ["download", "TP-quality-check"]
-  variables:
-    EXECUTABLE: 'vivado_hls'
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "TP"
-PC-vivado-hls-build:
-  <<: *template_hls-build
-  needs: ["download", "PC-quality-check"]
-  variables:
-    EXECUTABLE: 'vivado_hls'
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "PC"
-MP-vivado-hls-build:
-  <<: *template_hls-build
-  needs: ["download", "MP-quality-check"]
-  variables:
-    EXECUTABLE: 'vivado_hls'
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "MP"
-TB-vivado-hls-build:
-  <<: *template_hls-build
-  needs: ["download", "TB-quality-check"]
-  variables:
-    EXECUTABLE: 'vivado_hls'
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "TB"
-TM-vivado-hls-build:
-  <<: *template_hls-build
-  needs: ["download", "TM-quality-check"]
-  allow_failure: false # FIXME: testbench currently always passes
-  variables:
-    EXECUTABLE: 'vivado_hls'
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "TM"
-# FW simulation ---------------
-topReducedCombinedFPGA1-sim:
-  <<: *template_topTF-sim
-  allow_failure: false
-  variables:
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "ReducedCombinedConfig_FPGA1"
-  needs:
-    - job: download
-    - job: IR-vivado-hls-build
-      artifacts: false
-    - job: VMRCM-vivado-hls-build
-      artifacts: false
-    - job: VMSMER-vivado-hls-build
-      artifacts: false  
-    - job: TP-vivado-hls-build
-      artifacts: false
-    - job: PC-vivado-hls-build
-      artifacts: false
-    - job: MP-vivado-hls-build
-      artifacts: false
-    - job: TB-vivado-hls-build
-      artifacts: false
-# Check FW results ---------------
-topReducedCombinedFPGA1-check-results:
-  <<: *template_check-results
-  allow_failure: false
-  variables:
-    VIVADO_VERSION: "2019.2" # Vivado not needed but it is part of the path that is called
-    PROJ_NAME: "ReducedCombinedConfig_FPGA1"
-  needs:
+    PROJECT: "ReducedCombinedConfig_FPGA2"
+
+### Simulate
+
+sim-ReducedCombinedConfig_FPGA1:
+  extends: .sim-project
+  dependencies:
     - download
-    - topReducedCombinedFPGA1-sim
-# FW synthesis ---------------
-topReducedCombinedFPGA1-synth:
-  <<: *template_topTF-synth
-  allow_failure: false
+    - create-ReducedCombinedConfig_FPGA1
   variables:
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "ReducedCombinedConfig_FPGA1"
-  needs:
-    - job: download
-    - job: topReducedCombinedFPGA1-sim
-    - job: topReducedCombinedFPGA1-check-results
-      artifacts: false
-# FW simulation ---------------
-topReducedCombinedFPGA2-sim:
-  <<: *template_topTF-sim
-  allow_failure: false
-  variables:
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "ReducedCombinedConfig_FPGA2"
-  needs:
-    - job: download
-    - job: IR-vivado-hls-build
-      artifacts: false
-    - job: VMRCM-vivado-hls-build
-      artifacts: false
-    - job: VMSMER-vivado-hls-build
-      artifacts: false  
-    - job: TP-vivado-hls-build
-      artifacts: false
-    - job: PC-vivado-hls-build
-      artifacts: false
-    - job: MP-vivado-hls-build
-      artifacts: false
-    - job: TB-vivado-hls-build
-      artifacts: false
-# Check FW results ---------------
-topReducedCombinedFPGA2-check-results:
-  <<: *template_check-results
-  allow_failure: false
-  variables:
-    VIVADO_VERSION: "2019.2" # Vivado not needed but it is part of the path that is called
-    PROJ_NAME: "ReducedCombinedConfig_FPGA2"
-  needs:
+    PROJECT: "ReducedCombinedConfig_FPGA1"
+
+sim-ReducedCombinedConfig_FPGA2:
+  extends: .sim-project
+  dependencies:
     - download
-    - topReducedCombinedFPGA2-sim
-# FW synthesis ---------------
-topReducedCombinedFPGA2-synth:
-  <<: *template_topTF-synth
-  allow_failure: false
+    - create-ReducedCombinedConfig_FPGA2
   variables:
-    VIVADO_VERSION: "2019.2"
-    PROJ_NAME: "ReducedCombinedConfig_FPGA2"
-  needs:
-    - job: download
-    - job: topReducedCombinedFPGA2-sim
-    - job: topReducedCombinedFPGA2-check-results
-      artifacts: false
+    PROJECT: "ReducedCombinedConfig_FPGA2"
+
+### Check simulation results
+
+check-ReducedCombinedConfig_FPGA1:
+  extends: .check-project
+  dependencies:
+    - download
+    - sim-ReducedCombinedConfig_FPGA1
+  variables:
+    PROJECT: "ReducedCombinedConfig_FPGA1"
+
+check-ReducedCombinedConfig_FPGA2:
+  extends: .check-project
+  dependencies:
+    - download
+    - sim-ReducedCombinedConfig_FPGA2
+  variables:
+    PROJECT: "ReducedCombinedConfig_FPGA2"
+
+### Synthesize
+
+synth-ReducedCombinedConfig_FPGA1:
+  extends: .synth-project
+  dependencies:
+    - download
+    - create-ReducedCombinedConfig_FPGA1
+  variables:
+    PROJECT: "ReducedCombinedConfig_FPGA1"
+
+synth-ReducedCombinedConfig_FPGA2:
+  extends: .synth-project
+  dependencies:
+    - download
+    - create-ReducedCombinedConfig_FPGA2
+  variables:
+    PROJECT: "ReducedCombinedConfig_FPGA2"
+
+### Implement
+
+impl-ReducedCombinedConfig_FPGA1:
+  extends: .impl-project
+  dependencies:
+    - download
+    - create-ReducedCombinedConfig_FPGA1
+    - synth-ReducedCombinedConfig_FPGA1
+  variables:
+    PROJECT: "ReducedCombinedConfig_FPGA1"
+
+impl-ReducedCombinedConfig_FPGA2:
+  extends: .impl-project
+  dependencies:
+    - download
+    - create-ReducedCombinedConfig_FPGA2
+    - synth-ReducedCombinedConfig_FPGA2
+  variables:
+    PROJECT: "ReducedCombinedConfig_FPGA2"
+################################################################################

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,197 +1,522 @@
-[MASTER]
-
-# A comma-separated list of package or module names from where C extensions may
-# be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code.
-extension-pkg-allow-list=
-
-# A comma-separated list of package or module names from where C extensions may
-# be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
-# for backward compatibility.)
-extension-pkg-whitelist=
-
-# Return non-zero exit code if any of these messages/categories are detected,
-# even if score is above --fail-under value. Syntax same as enable. Messages
-# specified are enabled, while categories only check already-enabled messages.
-fail-on=
-
-# Specify a score threshold to be exceeded before program exits with error.
-fail-under=10.0
-
-# Files or directories to be skipped. They should be base names, not paths.
-ignore=CVS
-
-# Add files or directories matching the regex patterns to the ignore-list. The
-# regex matches against paths.
-ignore-paths=
-
-# Files or directories matching the regex patterns are skipped. The regex
-# matches against base names, not paths.
-ignore-patterns=
+[MAIN]
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
 #init-hook=
 
+# Files or directories to be skipped. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths and can be in Posix or Windows format.
+ignore-paths=
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=^\.#
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+    pylint.extensions.check_elif,
+    pylint.extensions.bad_builtin,
+    pylint.extensions.docparams,
+    pylint.extensions.for_any_all,
+    pylint.extensions.set_membership,
+    pylint.extensions.code_style,
+    pylint.extensions.overlapping_exceptions,
+    pylint.extensions.typing,
+    pylint.extensions.redefined_variable_type,
+    pylint.extensions.comparison_placement,
+    pylint.extensions.broad_try_clause,
+    pylint.extensions.dict_init_mutate,
+    pylint.extensions.consider_refactoring_into_while_condition,
+
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.
 jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-allow-list=
+
+# Minimum supported python version
+py-version = 3.10.0
 
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or
 # complex, nested conditions.
 limit-inference-results=100
 
-# List of plugins (as comma separated values of python module names) to load,
-# usually to register additional checkers.
-load-plugins=
+# Specify a score threshold under which the program will exit with error.
+fail-under=10.0
 
-# Pickle collected data for later comparisons.
-persistent=yes
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
-# Allow loading of arbitrary C extensions. Extensions are imported into the
-# active Python interpreter and may run arbitrary code.
-unsafe-load-any-extension=no
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint in
+# a server-like mode.
+clear-cache-post-run=no
 
 
 [MESSAGES CONTROL]
 
 # Only show warnings with the listed confidence levels. Leave empty to show
-# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
-confidence=
-
-# Disable the message, report, category or checker with the given id(s). You
-# can either give multiple identifiers separated by comma (,) or put this
-# option multiple times (only on the command line, not in the configuration
-# file where it should appear only once). You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
-# you want to run only the similarities checker, you can use "--disable=all
-# --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use "--disable=all --enable=classes
-# --disable=W".
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
-        bad-inline-option,
-        locally-disabled,
-        file-ignored,
-        suppressed-message,
-        useless-suppression,
-        deprecated-pragma,
-        use-symbolic-message-instead,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        deprecated-operator-function,
-        deprecated-urllib-function,
-        xreadlines-attribute,
-        deprecated-sys-function,
-        exception-escape,
-        comprehension-escape,
-		# Disabled the following packages in addition to the default settings
-		line-too-long,
-		unspecified-encoding,
-		missing-module-docstring,
-		missing-class-docstring,
-		missing-function-docstring,
-		no-else-return,
-		no-else-continue
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+# confidence=
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=c-extension-no-member
+enable=
+    use-symbolic-message-instead,
+    useless-suppression,
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+
+disable=
+    attribute-defined-outside-init,
+    invalid-name,
+    missing-docstring,
+    protected-access,
+    too-few-public-methods,
+    # handled by black
+    format,
+    # We anticipate #3512 where it will become optional
+    fixme,
+    consider-using-assignment-expr,
+    # Disable the following checks in addition to the defaults
+    unspecified-encoding,
 
 
 [REPORTS]
 
-# Python expression which should return a score less than or equal to 10. You
-# have access to the variables 'error', 'warning', 'refactor', and 'convention'
-# which contain the number of messages in each category, as well as 'statement'
-# which is the total number of statements analyzed. This score is used by the
-# global evaluation report (RP0004).
-evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
-
-# Template used to display messages. This is a python new-style format string
-# used to format the message information. See doc for all details.
-#msg-template=
-
-# Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio). You can also give a reporter class, e.g.
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Tells whether to display a full report or only the messages.
+# Tells whether to display a full report or only the messages
 reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables 'fatal', 'error', 'warning', 'refactor', 'convention'
+# and 'info', which contain the number of messages in each category, as
+# well as 'statement', which is the total number of statements analyzed. This
+# score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
 
 # Activate the evaluation score.
 score=yes
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=6
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Maximum number of lines in a module
+max-module-lines=2000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,}$
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style.
+#class-const-rgx=
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,}$
+
+# Regular expression matching correct type variable names
+#typevar-rgx=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring. Use ^(?!__init__$)_ to also check __init__.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# List of decorators that define properties, such as abc.abstractproperty.
+property-classes=abc.abstractproperty
+
+
+[TYPECHECK]
+
+# Regex pattern to define which classes are considered mixins if ignore-mixin-
+# members is set to 'yes'
+mixin-class-rgx=.*MixIn
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well
+# as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=SQLObject, optparse.Values, thread._local, _thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent,argparse.Namespace
+
+# List of decorators that create context managers from functions, such as
+# contextlib.contextmanager.
+contextmanager-decorators=contextlib.contextmanager
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=subpkg,MyClass
+
+# List of comma separated words that should be considered directives if they
+# appear and the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:,pragma:,# noinspection
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=custom_dict.txt
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=2
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args = 9
+
+# Maximum number of locals for function / method body
+max-locals = 19
+
+# Maximum number of return / yield for function / method body
+max-returns=11
+
+# Maximum number of branch for function / method body
+max-branches = 20
+
+# Maximum number of statements in function / method body
+max-statements = 50
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=11
+
+# Maximum number of statements in a try-block
+max-try-statements = 7
+
+# Maximum number of positional arguments (see R0917).
+max-positional-arguments = 12
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp,__post_init__
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=_string
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=builtins.Exception
+
+
+[TYPING]
+
+# Set to ``no`` if the app / library does **NOT** need to support runtime
+# introspection of type annotations. If you use type annotations
+# **exclusively** for type checking of an application, you're probably fine.
+# For libraries, evaluate if some users what to access the type hints at
+# runtime first, e.g., through ``typing.get_type_hints``. Applies to Python
+# versions 3.7 - 3.9
+runtime-typing = no
+
+
+[DEPRECATED_BUILTINS]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,input
 
 
 [REFACTORING]
@@ -206,312 +531,6 @@ max-nested-blocks=5
 never-returning-functions=sys.exit,argparse.parse_error
 
 
-[VARIABLES]
-
-# List of additional names supposed to be defined in builtins. Remember that
-# you should avoid defining new builtins when possible.
-additional-builtins=
-
-# Tells whether unused global variables should be treated as a violation.
-allow-global-unused-variables=yes
-
-# List of names allowed to shadow builtins
-allowed-redefined-builtins=
-
-# List of strings which can identify a callback function by name. A callback
-# name must start or end with one of those strings.
-callbacks=cb_,
-          _cb
-
-# A regular expression matching the name of dummy variables (i.e. expected to
-# not be used).
-dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
-
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore.
-ignored-argument-names=_.*|^ignored_|^unused_
-
-# Tells whether we should check for unused import in __init__ files.
-init-import=no
-
-# List of qualified module names which can have objects that can redefine
-# builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
-
-
-[SIMILARITIES]
-
-# Comments are removed from the similarity computation
-ignore-comments=yes
-
-# Docstrings are removed from the similarity computation
-ignore-docstrings=yes
-
-# Imports are removed from the similarity computation
-ignore-imports=no
-
-# Signatures are removed from the similarity computation
-ignore-signatures=no
-
-# Minimum lines number of a similarity.
-min-similarity-lines=4
-
-
-[FORMAT]
-
-# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-expected-line-ending-format=
-
-# Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
-
-# Number of spaces of indent required inside a hanging or continued line.
-indent-after-paren=4
-
-# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
-# tab).
-indent-string='    '
-
-# Maximum number of characters on a single line.
-max-line-length=100
-
-# Maximum number of lines in a module.
-max-module-lines=1000
-
-# Allow the body of a class to be on the same line as the declaration if body
-# contains single statement.
-single-line-class-stmt=no
-
-# Allow the body of an if to be on the same line as the test if there is no
-# else.
-single-line-if-stmt=no
-
-
-[SPELLING]
-
-# Limits count of emitted suggestions for spelling mistakes.
-max-spelling-suggestions=4
-
-# Spelling dictionary name. Available dictionaries: none. To make it work,
-# install the 'python-enchant' package.
-spelling-dict=
-
-# List of comma separated words that should be considered directives if they
-# appear and the beginning of a comment and should not be checked.
-spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
-
-# List of comma separated words that should not be checked.
-spelling-ignore-words=
-
-# A path to a file that contains the private dictionary; one word per line.
-spelling-private-dict-file=
-
-# Tells whether to store unknown words to the private dictionary (see the
-# --spelling-private-dict-file option) instead of raising a message.
-spelling-store-unknown-words=no
-
-
-[MISCELLANEOUS]
-
-# List of note tags to take in consideration, separated by a comma.
-notes=FIXME,
-      XXX,
-      TODO
-
-# Regular expression of note tags to take in consideration.
-#notes-rgx=
-
-
-[BASIC]
-
-# Naming style matching correct argument names.
-argument-naming-style=snake_case
-
-# Regular expression matching correct argument names. Overrides argument-
-# naming-style.
-#argument-rgx=
-
-# Naming style matching correct attribute names.
-attr-naming-style=snake_case
-
-# Regular expression matching correct attribute names. Overrides attr-naming-
-# style.
-#attr-rgx=
-
-# Bad variable names which should always be refused, separated by a comma.
-bad-names=foo,
-          bar,
-          baz,
-          toto,
-          tutu,
-          tata
-
-# Bad variable names regexes, separated by a comma. If names match any regex,
-# they will always be refused
-bad-names-rgxs=
-
-# Naming style matching correct class attribute names.
-class-attribute-naming-style=any
-
-# Regular expression matching correct class attribute names. Overrides class-
-# attribute-naming-style.
-#class-attribute-rgx=
-
-# Naming style matching correct class constant names.
-class-const-naming-style=UPPER_CASE
-
-# Regular expression matching correct class constant names. Overrides class-
-# const-naming-style.
-#class-const-rgx=
-
-# Naming style matching correct class names.
-class-naming-style=PascalCase
-
-# Regular expression matching correct class names. Overrides class-naming-
-# style.
-#class-rgx=
-
-# Naming style matching correct constant names.
-const-naming-style=camelCase # Default: UPPER_CASE
-
-# Regular expression matching correct constant names. Overrides const-naming-
-# style.
-#const-rgx=
-
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length=-1
-
-# Naming style matching correct function names.
-function-naming-style=camelCase # Default: snake_case
-
-# Regular expression matching correct function names. Overrides function-
-# naming-style.
-#function-rgx=
-
-# Good variable names which should always be accepted, separated by a comma.
-good-names=i,
-           j,
-           k,
-           ex,
-           Run,
-           _
-
-# Good variable names regexes, separated by a comma. If names match any regex,
-# they will always be accepted
-good-names-rgxs=
-
-# Include a hint for the correct naming format with invalid-name.
-include-naming-hint=no
-
-# Naming style matching correct inline iteration names.
-inlinevar-naming-style=any
-
-# Regular expression matching correct inline iteration names. Overrides
-# inlinevar-naming-style.
-#inlinevar-rgx=
-
-# Naming style matching correct method names.
-method-naming-style=snake_case
-
-# Regular expression matching correct method names. Overrides method-naming-
-# style.
-#method-rgx=
-
-# Naming style matching correct module names.
-module-naming-style=any # default: snake_case
-
-# Regular expression matching correct module names. Overrides module-naming-
-# style.
-#module-rgx=
-
-# Colon-delimited sets of names that determine each other's naming style when
-# the name regexes allow several styles.
-name-group=
-
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx=^_
-
-# List of decorators that produce properties, such as abc.abstractproperty. Add
-# to this list to register other decorators that produce valid properties.
-# These decorators are taken in consideration only for invalid-name.
-property-classes=abc.abstractproperty
-
-# Naming style matching correct variable names.
-variable-naming-style=snake_case
-
-# Regular expression matching correct variable names. Overrides variable-
-# naming-style.
-#variable-rgx=
-
-
-[LOGGING]
-
-# The type of string formatting that logging methods do. `old` means using %
-# formatting, `new` is for `{}` formatting.
-logging-format-style=old
-
-# Logging modules to check that the string format arguments are in logging
-# function parameter format.
-logging-modules=logging
-
-
-[TYPECHECK]
-
-# List of decorators that produce context managers, such as
-# contextlib.contextmanager. Add to this list to register other decorators that
-# produce valid context managers.
-contextmanager-decorators=contextlib.contextmanager
-
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E1101 when accessed. Python regular
-# expressions are accepted.
-generated-members=
-
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members=yes
-
-# Tells whether to warn about missing members when the owner of the attribute
-# is inferred to be None.
-ignore-none=yes
-
-# This flag controls whether pylint should warn about no-member and similar
-# checks whenever an opaque object is returned when inferring. The inference
-# can return multiple potential results while evaluating a Python object, but
-# some branches might not be evaluated, which results in partial inference. In
-# that case, it might be useful to still emit no-member and other checks for
-# the rest of the inferred objects.
-ignore-on-opaque-inference=yes
-
-# List of class names for which member attributes should not be checked (useful
-# for classes with dynamically set attributes). This supports the use of
-# qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
-
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis). It
-# supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
-
-# Show a hint with possible names when a member name was not found. The aspect
-# of finding the hint is based on edit distance.
-missing-member-hint=yes
-
-# The minimum edit distance a name should have in order to be considered a
-# similar match for a missing member name.
-missing-member-hint-distance=1
-
-# The total number of similar names that should be taken in consideration when
-# showing a hint for a missing member.
-missing-member-max-choices=1
-
-# List of decorators that change the signature of a decorated function.
-signature-mutators=
-
-
 [STRING]
 
 # This flag controls whether inconsistent-quotes generates a warning when the
@@ -523,113 +542,9 @@ check-quote-consistency=no
 check-str-concat-over-line-jumps=no
 
 
-[CLASSES]
+[CODE_STYLE]
 
-# Warn about protected attribute access inside special methods
-check-protected-access-in-special-methods=no
-
-# List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,
-                      __new__,
-                      setUp,
-                      __post_init__
-
-# List of member names, which should be excluded from the protected access
-# warning.
-exclude-protected=_asdict,
-                  _fields,
-                  _replace,
-                  _source,
-                  _make
-
-# List of valid names for the first argument in a class method.
-valid-classmethod-first-arg=cls
-
-# List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg=cls
-
-
-[DESIGN]
-
-# List of qualified class names to ignore when countint class parents (see
-# R0901)
-ignored-parents=
-
-# Maximum number of arguments for function / method.
-max-args=5
-
-# Maximum number of attributes for a class (see R0902).
-max-attributes=7
-
-# Maximum number of boolean expressions in an if statement (see R0916).
-max-bool-expr=5
-
-# Maximum number of branch for function / method body.
-max-branches=20 # Default: 12
-
-# Maximum number of locals for function / method body.
-max-locals=15
-
-# Maximum number of parents for a class (see R0901).
-max-parents=7
-
-# Maximum number of public methods for a class (see R0904).
-max-public-methods=20
-
-# Maximum number of return / yield for function / method body.
-max-returns=6
-
-# Maximum number of statements in function / method body.
-max-statements=50
-
-# Minimum number of public methods for a class (see R0903).
-min-public-methods=2
-
-
-[IMPORTS]
-
-# List of modules that can be imported at any level, not just the top level
-# one.
-allow-any-import-level=
-
-# Allow wildcard imports from modules that define __all__.
-allow-wildcard-with-all=no
-
-# Analyse import fallback blocks. This can be used to support both Python 2 and
-# 3 compatible code, which means that the block might have code that exists
-# only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks=no
-
-# Deprecated modules which should not be used, separated by a comma.
-deprecated-modules=
-
-# Output a graph (.gv or any supported image format) of external dependencies
-# to the given file (report RP0402 must not be disabled).
-ext-import-graph=
-
-# Output a graph (.gv or any supported image format) of all (i.e. internal and
-# external) dependencies to the given file (report RP0402 must not be
-# disabled).
-import-graph=
-
-# Output a graph (.gv or any supported image format) of internal dependencies
-# to the given file (report RP0402 must not be disabled).
-int-import-graph=
-
-# Force import order to recognize a module as part of the standard
-# compatibility libraries.
-known-standard-library=
-
-# Force import order to recognize a module as part of a third party library.
-known-third-party=enchant
-
-# Couples of modules and preferred modules, separated by a comma.
-preferred-modules=
-
-
-[EXCEPTIONS]
-
-# Exceptions that will emit a warning when being caught. Defaults to
-# "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+# Max line length for which to sill emit suggestions. Used to prevent optional
+# suggestions which would get split by a code formatter (e.g., black). Will
+# default to the setting for ``max-line-length``.
+#max-line-length-suggestions=

--- a/IntegrationTests/common/script/compileHLS.tcl
+++ b/IntegrationTests/common/script/compileHLS.tcl
@@ -7,9 +7,14 @@ source $top_level/IntegrationTests/common/script/build_ip.tcl
 set top_path [lindex $argv 2]
 set top_function [lindex $argv 3]
 set top_dir [string range $top_path 0 [expr [string last "/" $top_path] - 1]]
+set CFLAGS ""
+if { [string first "MatchProcessor" $top_function] == 0 } {
+  set layerDisk [string range $top_function 15 16]
+  set CFLAGS "-D__${layerDisk}__"
+}
 
 # Build IP
-set CFLAGS "-std=c++11 -I$top_level/TrackletAlgorithm  -I$top_level/TrackletAlgorithm/Project -I$top_dir"
+set CFLAGS "-std=c++11 -I$top_level/TrackletAlgorithm  -I$top_level/TrackletAlgorithm/Project -I$top_dir $CFLAGS"
 open_project -reset $top_function
 add_files $top_path -cflags "$CFLAGS"
 build_ip $top_function

--- a/TrackletAlgorithm/MatchProcessor.h
+++ b/TrackletAlgorithm/MatchProcessor.h
@@ -14,6 +14,9 @@
 #include <fstream>
 #include <bitset>
 
+#if defined(__D1__) || defined(__D2__) || defined(__D3__) || defined(__D4__) || defined(__D5__)
+#  define __DISK__
+#endif
 
 namespace PR
 {
@@ -163,106 +166,84 @@ namespace PR
 template<int L>
 void readTable(ap_uint<1> table[]){
 
-  if (L==TF::L1) {
-    bool tmp[256]=
+#if defined(__L1__)
+  bool tmp[256]=
 #include "../emData/MP/tables/METable_L1.tab"
-    for (int i=0;i<256;++i){
+  for (int i=0;i<256;++i){
 #pragma HLS unroll
-      table[i]=tmp[i];
-    }
+    table[i]=tmp[i];
   }
-
-  if (L==TF::L2) {
-    bool tmp[256]=
+#elif defined(__L2__)
+  bool tmp[256]=
 #include "../emData/MP/tables/METable_L2.tab"
-    for (int i=0;i<256;++i){
+  for (int i=0;i<256;++i){
 #pragma HLS unroll
-      table[i]=tmp[i];
-    }
+    table[i]=tmp[i];
   }
-
-  if (L==TF::L3) {
-    bool tmp[256]=
+#elif defined(__L3__)
+  bool tmp[256]=
 #include "../emData/MP/tables/METable_L3.tab"
-    for (int i=0;i<256;++i){
+  for (int i=0;i<256;++i){
 #pragma HLS unroll
-      table[i]=tmp[i];
-    }
+    table[i]=tmp[i];
   }
-
-  if (L==TF::L4) {
-    bool tmp[512]=
+#elif defined(__L4__)
+  bool tmp[512]=
 #include "../emData/MP/tables/METable_L4.tab"
-    for (int i=0;i<512;++i){
+  for (int i=0;i<512;++i){
 #pragma HLS unroll
-      table[i]=tmp[i];
-    }
+    table[i]=tmp[i];
   }
-
-  if (L==TF::L5) {
-    bool tmp[512]=
+#elif defined(__L5__)
+  bool tmp[512]=
 #include "../emData/MP/tables/METable_L5.tab"
-    for (int i=0;i<512;++i){
+  for (int i=0;i<512;++i){
 #pragma HLS unroll
-      table[i]=tmp[i];
-    }
+    table[i]=tmp[i];
   }
-
-  if (L==TF::L6) {
-    bool tmp[512]=
+#elif defined(__L6__)
+  bool tmp[512]=
 #include "../emData/MP/tables/METable_L6.tab"
-    for (int i=0;i<512;++i){
+  for (int i=0;i<512;++i){
 #pragma HLS unroll
-      table[i]=tmp[i];
-    }
+    table[i]=tmp[i];
   }
-
-  if (L==TF::D1) {
-    bool tmp[768]=
+#elif defined(__D1__)
+  bool tmp[768]=
 #include "../emData/MP/tables/METable_D1.tab"
-    for (int i=0;i<768;++i){
+  for (int i=0;i<768;++i){
 #pragma HLS unroll
-      table[i]=tmp[i];
-    }
+    table[i]=tmp[i];
   }
-
-  if (L==TF::D2) {
-    bool tmp[768]=
+#elif defined(__D2__)
+  bool tmp[768]=
 #include "../emData/MP/tables/METable_D2.tab"
-    for (int i=0;i<768;++i){
+  for (int i=0;i<768;++i){
 #pragma HLS unroll
-      table[i]=tmp[i];
-    }
+    table[i]=tmp[i];
   }
-
-  if (L==TF::D3) {
-    bool tmp[768]=
+#elif defined(__D3__)
+  bool tmp[768]=
 #include "../emData/MP/tables/METable_D3.tab"
-    for (int i=0;i<768;++i){
+  for (int i=0;i<768;++i){
 #pragma HLS unroll
-      table[i]=tmp[i];
-    }
+    table[i]=tmp[i];
   }
-
-  if (L==TF::D4) {
-    bool tmp[768]=
+#elif defined(__D4__)
+  bool tmp[768]=
 #include "../emData/MP/tables/METable_D4.tab"
-    for (int i=0;i<768;++i){
+  for (int i=0;i<768;++i){
 #pragma HLS unroll
-      table[i]=tmp[i];
-    }
+    table[i]=tmp[i];
   }
-
-  if (L==TF::D5) {
-    bool tmp[768]=
+#elif defined(__D5__)
+  bool tmp[768]=
 #include "../emData/MP/tables/METable_D5.tab"
-    for (int i=0;i<768;++i){
+  for (int i=0;i<768;++i){
 #pragma HLS unroll
-      table[i]=tmp[i];
-    }
+    table[i]=tmp[i];
   }
-
-
+#endif
 
 }
 
@@ -305,588 +286,502 @@ namespace MC {
 // Template to get look up tables
 
 // Table for phi or z cuts
-template<TF::layerDisk L, int width, int depth>
+template<int width, int depth>
 void readRbin_LUT(ap_uint<width> table[depth]) {
-  if (L>=TF::D1){
-    ap_uint<width> tmp[depth] =
+#if defined(__DISK__)
+  ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/ProjectionDiskRadius.tab")
 #  include "../emData/MP/tables/ProjectionDiskRadius.tab"
+#else
+  {};
+#endif
+  for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
+}
+
+template<MC::lutType type, int width, int depth>
+void readTable_Cuts(ap_uint<width> table[depth]){
+
+  if (type==MC::PHICUT){ // phi cuts
+#if defined(__L1__)
+    ap_uint<width> tmp[depth] =
+#if __has_include("../emData/MP/tables/MP_L1PHIC_phicut.tab")
+#  include "../emData/MP/tables/MP_L1PHIC_phicut.tab"
 #else
     {};
 #endif
     for (int i = 0; i < depth; i++) table[i] = tmp[i];
-  }
-  else {
-      static_assert(true, "Only DISKS 1 to 5 are valid");
-  }
-}
-
-template<MC::lutType type, TF::layerDisk L, int width, int depth>
-void readTable_Cuts(ap_uint<width> table[depth]){
-  if (type==MC::PHICUT){ // phi cuts
-    if (L==TF::L1){
-      ap_uint<width> tmp[depth] =
-#if __has_include("../emData/MP/tables/MP_L1PHIC_phicut.tab")
-#  include "../emData/MP/tables/MP_L1PHIC_phicut.tab"
-#else
-      {};
-#endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::L2){
-      ap_uint<width> tmp[depth] =
+#elif defined(__L2__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_L2PHIC_phicut.tab")
 #  include "../emData/MP/tables/MP_L2PHIC_phicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::L3){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__L3__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_L3PHIC_phicut.tab")
 #  include "../emData/MP/tables/MP_L3PHIC_phicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::L4){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__L4__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_L4PHIC_phicut.tab")
 #  include "../emData/MP/tables/MP_L4PHIC_phicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::L5){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__L5__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_L5PHIC_phicut.tab")
 #  include "../emData/MP/tables/MP_L5PHIC_phicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::L6){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__L6__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_L6PHIC_phicut.tab")
 #  include "../emData/MP/tables/MP_L6PHIC_phicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only LAYERS 1 to 6 are valid");
-    }
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   } // end phi cuts
   else if(type==MC::PSPHICUT) { // PSphi cuts
-    if (L==TF::D1){
-      ap_uint<width> tmp[depth] =
+#if defined(__D1__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D1PHIC_PSphicut.tab")
 #  include "../emData/MP/tables/MP_D1PHIC_PSphicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D2){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D2__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D2PHIC_PSphicut.tab")
 #  include "../emData/MP/tables/MP_D2PHIC_PSphicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D3){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D3__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D3PHIC_PSphicut.tab")
 #  include "../emData/MP/tables/MP_D3PHIC_PSphicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D4){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D4__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D4PHIC_PSphicut.tab")
 #  include "../emData/MP/tables/MP_D4PHIC_PSphicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D5){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D5__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D5PHIC_PSphicut.tab")
 #  include "../emData/MP/tables/MP_D5PHIC_PSphicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only LAYERS 1 to 6 are valid");
-    }
- 
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   } // end PSphi
   else if(type==MC::SSPHICUT) { // 2Sphi cuts
-    if (L==TF::D1){
-      ap_uint<width> tmp[depth] =
+#if defined(__D1__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D1PHIC_2Sphicut.tab")
 #  include "../emData/MP/tables/MP_D1PHIC_2Sphicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D2){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D2__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D2PHIC_2Sphicut.tab")
 #  include "../emData/MP/tables/MP_D2PHIC_2Sphicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D3){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D3__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D3PHIC_2Sphicut.tab")
 #  include "../emData/MP/tables/MP_D3PHIC_2Sphicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D4){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D4__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D4PHIC_2Sphicut.tab")
 #  include "../emData/MP/tables/MP_D4PHIC_2Sphicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D5){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D5__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D5PHIC_2Sphicut.tab")
 #  include "../emData/MP/tables/MP_D5PHIC_2Sphicut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only LAYERS 1 to 6 are valid");
-    }
- 
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   } // end SSphi
   else if (type==MC::ZCUT) { // z cuts
-    if (L==TF::L1){
-      ap_uint<width> tmp[depth] =
+#if defined(__L1__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_L1PHIC_zcut.tab")
 #  include "../emData/MP/tables/MP_L1PHIC_zcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::L2){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__L2__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_L2PHIC_zcut.tab")
 #  include "../emData/MP/tables/MP_L2PHIC_zcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::L3){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__L3__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_L3PHIC_zcut.tab")
 #  include "../emData/MP/tables/MP_L3PHIC_zcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::L4){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__L4__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_L4PHIC_zcut.tab")
 #  include "../emData/MP/tables/MP_L4PHIC_zcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::L5){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__L5__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_L5PHIC_zcut.tab")
 #  include "../emData/MP/tables/MP_L5PHIC_zcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::L6){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__L6__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_L6PHIC_zcut.tab")
 #  include "../emData/MP/tables/MP_L6PHIC_zcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   } // end z cuts
   else if(type==MC::PSRCUT) { // PSr cuts
-    if (L==TF::D1){
-      ap_uint<width> tmp[depth] =
+#if defined(__D1__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D1PHIC_PSrcut.tab")
 #  include "../emData/MP/tables/MP_D1PHIC_PSrcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D2){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D2__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D2PHIC_PSrcut.tab")
 #  include "../emData/MP/tables/MP_D2PHIC_PSrcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D3){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D3__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D3PHIC_PSrcut.tab")
 #  include "../emData/MP/tables/MP_D3PHIC_PSrcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D4){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D4__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D4PHIC_PSrcut.tab")
 #  include "../emData/MP/tables/MP_D4PHIC_PSrcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D5){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D5__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D5PHIC_PSrcut.tab")
 #  include "../emData/MP/tables/MP_D5PHIC_PSrcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only LAYERS 1 to 6 are valid");
-    }
- 
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   } // end PSr
   else if(type==MC::SSRCUT) { // 2Sr cuts
-    if (L==TF::D1){
-      ap_uint<width> tmp[depth] =
+#if defined(__D1__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D1PHIC_2Srcut.tab")
 #  include "../emData/MP/tables/MP_D1PHIC_2Srcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D2){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D2__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D2PHIC_2Srcut.tab")
 #  include "../emData/MP/tables/MP_D2PHIC_2Srcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D3){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D3__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D3PHIC_2Srcut.tab")
 #  include "../emData/MP/tables/MP_D3PHIC_2Srcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D4){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D4__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D4PHIC_2Srcut.tab")
 #  include "../emData/MP/tables/MP_D4PHIC_2Srcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D5){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D5__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D5PHIC_2Srcut.tab")
 #  include "../emData/MP/tables/MP_D5PHIC_2Srcut.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only LAYERS 1 to 6 are valid");
-    }
- 
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   } // end 2Sr
   else if(type==MC::ALPHAINNERCUT) { // alphainner cuts (//for disks only)
-    if (L==TF::D1){
-      ap_uint<width> tmp[depth] =
+#if defined(__D1__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D1PHIC_alphainner.tab")
 #  include "../emData/MP/tables/MP_D1PHIC_alphainner.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D2){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D2__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D2PHIC_alphainner.tab")
 #  include "../emData/MP/tables/MP_D2PHIC_alphainner.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only DISKS 1 and 2 are valid for alpha inner");
-    }
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   }
   else if(type==MC::ALPHAOUTERCUT) { // alphaouter cuts (//for disks only)
-    if (L==TF::D1){
-      ap_uint<width> tmp[depth] =
+#if defined(__D1__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D1PHIC_alphaouter.tab")
 #  include "../emData/MP/tables/MP_D1PHIC_alphaouter.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D2){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D2__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D2PHIC_alphaouter.tab")
 #  include "../emData/MP/tables/MP_D2PHIC_alphaouter.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only DISKS 1 and 2 are valid for alpha outer");
-    }
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   }
 
 } // end readTable_Cuts
 
-template<MC::lutType type, TF::layerDisk L, int width, int depth>
+template<MC::lutType type, int width, int depth>
 void readTable_disk(ap_uint<width> table[depth]){
+
   if(type==MC::ALPHAINNERCUT) { // alphainner cuts (//for disks only)
-    if (L==TF::D1){
-      ap_uint<width> tmp[depth] =
+#if defined(__D1__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D1PHIC_alphainner.tab")
 #  include "../emData/MP/tables/MP_D1PHIC_alphainner.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D2){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D2__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D2PHIC_alphainner.tab")
 #  include "../emData/MP/tables/MP_D2PHIC_alphainner.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D3){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D3__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D3PHIC_alphainner.tab")
 #  include "../emData/MP/tables/MP_D3PHIC_alphainner.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only DISKS 1 and 2 are valid for alpha inner");
-    }
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   }
   else if(type==MC::ALPHAOUTERCUT) { // alphaouter cuts (//for disks only)
-    if (L==TF::D3){
-      ap_uint<width> tmp[depth] =
+#if defined(__D3__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D3PHIC_alphaouter.tab")
 #  include "../emData/MP/tables/MP_D3PHIC_alphaouter.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D4){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D4__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D4PHIC_alphaouter.tab")
 #  include "../emData/MP/tables/MP_D4PHIC_alphaouter.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D5){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D5__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D5PHIC_alphaouter.tab")
 #  include "../emData/MP/tables/MP_D5PHIC_alphaouter.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only DISKS 3 to 5 are valid for alpha outer");
-    }
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   }
+
 } // end readTable_disk()
 
-template<MC::lutType type, TF::layerDisk L, int width, int depth>
+template<MC::lutType type, int width, int depth>
 void readTable_rbend(ap_uint<width> table[depth]){
+
   if(type==MC::RBEND) { // alphainner cuts (//for disks only)
-    if (L==TF::D1){
-      ap_uint<width> tmp[depth] =
+#if defined(__D1__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_ProjectionBend_D1.tab")
 #  include "../emData/MP/tables/MP_ProjectionBend_D1.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D2){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D2__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_ProjectionBend_D2.tab")
 #  include "../emData/MP/tables/MP_ProjectionBend_D2.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D3){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D3__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_ProjectionBend_D3.tab")
 #  include "../emData/MP/tables/MP_ProjectionBend_D3.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    if (L==TF::D3){
-      ap_uint<width> tmp[depth] =
-#if __has_include("../emData/MP/tables/MP_ProjectionBend_D3.tab")
-#  include "../emData/MP/tables/MP_ProjectionBend_D3.tab"
-#else
-      {};
-#endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D4){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D4__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_ProjectionBend_D4.tab")
 #  include "../emData/MP/tables/MP_ProjectionBend_D4.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D5){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D5__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_ProjectionBend_D5.tab")
 #  include "../emData/MP/tables/MP_ProjectionBend_D5.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only DISKS for rinv bend");
-    }
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   }
+
 } // end readTable_rbend()
 
-template<MC::lutType type, TF::layerDisk L, int width, int depth>
+template<MC::lutType type, int width, int depth>
 void readTable_rDSS(ap_uint<width> table[depth]){
+
   if(type==MC::RDSSINNERCUT) { // rDSSinner cuts (//for disks only)
-    if (L==TF::D1){
-      ap_uint<width> tmp[depth] =
+#if defined(__D1__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D1PHIC_rDSSinner.tab")
 #  include "../emData/MP/tables/MP_D1PHIC_rDSSinner.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D2){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D2__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D2PHIC_rDSSinner.tab")
 #  include "../emData/MP/tables/MP_D2PHIC_rDSSinner.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D3){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D3__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D3PHIC_rDSSinner.tab")
 #  include "../emData/MP/tables/MP_D3PHIC_rDSSinner.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only DISKS 1 and 2 are valid for rDSS inner");
-    }
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   }
   else if(type==MC::RDSSOUTERCUT) { // rDSSouter cuts (//for disks only)
-    if (L==TF::D3){
-      ap_uint<width> tmp[depth] =
+#if defined(__D3__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D3PHIC_rDSSouter.tab")
 #  include "../emData/MP/tables/MP_D3PHIC_rDSSouter.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D4){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D4__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D4PHIC_rDSSouter.tab")
 #  include "../emData/MP/tables/MP_D4PHIC_rDSSouter.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else if (L==TF::D5){
-      ap_uint<width> tmp[depth] =
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#elif defined(__D5__)
+    ap_uint<width> tmp[depth] =
 #if __has_include("../emData/MP/tables/MP_D5PHIC_rDSSouter.tab")
 #  include "../emData/MP/tables/MP_D5PHIC_rDSSouter.tab"
 #else
-      {};
+    {};
 #endif
-      for (int i = 0; i < depth; i++) table[i] = tmp[i];
-    }
-    else {
-      static_assert(true, "Only DISKS 3 to 5 are valid for rDSS outer");
-    }
+    for (int i = 0; i < depth; i++) table[i] = tmp[i];
+#endif
   }
 } // end readTable_rDSS()
 //-----------------------------------------------------------------------------------------------------------
@@ -948,29 +843,29 @@ void MatchCalculator(BXType bx,
 
   // Setup look up tables for match cuts
   ap_uint<MC::LUT_matchcut_phi_width> LUT_matchcut_phi[MC::LUT_matchcut_phi_depth];
-  readTable_Cuts<MC::PHICUT,LAYER,MC::LUT_matchcut_phi_width,MC::LUT_matchcut_phi_depth>(LUT_matchcut_phi);
+  readTable_Cuts<MC::PHICUT,MC::LUT_matchcut_phi_width,MC::LUT_matchcut_phi_depth>(LUT_matchcut_phi);
   ap_uint<MC::LUT_matchcut_z_width> LUT_matchcut_z[MC::LUT_matchcut_z_depth];
-  readTable_Cuts<MC::ZCUT,LAYER,MC::LUT_matchcut_z_width,MC::LUT_matchcut_z_depth>(LUT_matchcut_z);
+  readTable_Cuts<MC::ZCUT,MC::LUT_matchcut_z_width,MC::LUT_matchcut_z_depth>(LUT_matchcut_z);
 
   ap_uint<MC::LUT_matchcut_rphi_width> LUT_matchcut_PSrphi[MC::LUT_matchcut_rphi_depth];
-  readTable_Cuts<MC::PSPHICUT,LAYER,MC::LUT_matchcut_rphi_width,MC::LUT_matchcut_rphi_depth>(LUT_matchcut_PSrphi);
+  readTable_Cuts<MC::PSPHICUT,MC::LUT_matchcut_rphi_width,MC::LUT_matchcut_rphi_depth>(LUT_matchcut_PSrphi);
 
   ap_uint<MC::LUT_matchcut_rphi_width> LUT_matchcut_2Srphi[MC::LUT_matchcut_rphi_depth];
-  readTable_Cuts<MC::SSPHICUT,LAYER,MC::LUT_matchcut_rphi_width,MC::LUT_matchcut_rphi_depth>(LUT_matchcut_2Srphi);
+  readTable_Cuts<MC::SSPHICUT,MC::LUT_matchcut_rphi_width,MC::LUT_matchcut_rphi_depth>(LUT_matchcut_2Srphi);
 
   ap_uint<MC::LUT_matchcut_r_width> LUT_matchcut_PSr[MC::LUT_matchcut_r_depth];
-  readTable_Cuts<MC::PSRCUT,LAYER,MC::LUT_matchcut_r_width,MC::LUT_matchcut_r_depth>(LUT_matchcut_PSr);
+  readTable_Cuts<MC::PSRCUT,MC::LUT_matchcut_r_width,MC::LUT_matchcut_r_depth>(LUT_matchcut_PSr);
 
   ap_uint<MC::LUT_matchcut_r_width> LUT_matchcut_2Sr[MC::LUT_matchcut_r_depth];
-  readTable_Cuts<MC::SSRCUT,LAYER,MC::LUT_matchcut_r_width,MC::LUT_matchcut_r_depth>(LUT_matchcut_2Sr);
+  readTable_Cuts<MC::SSRCUT,MC::LUT_matchcut_r_width,MC::LUT_matchcut_r_depth>(LUT_matchcut_2Sr);
 
   ap_uint<LUT_matchcut_alpha_width> LUT_matchcut_alpha[MC::LUT_matchcut_alpha_depth];
   constexpr enum MC::lutType ALPHA = (LAYER < TF::D3) ? MC::ALPHAINNERCUT : MC::ALPHAOUTERCUT;
-  readTable_disk<ALPHA,LAYER,LUT_matchcut_alpha_width,MC::LUT_matchcut_alpha_depth>(LUT_matchcut_alpha);
+  readTable_disk<ALPHA,LUT_matchcut_alpha_width,MC::LUT_matchcut_alpha_depth>(LUT_matchcut_alpha);
 
   ap_uint<MC::LUT_matchcut_rDSS_width> LUT_matchcut_rDSS[MC::LUT_matchcut_rDSS_depth];
   constexpr enum MC::lutType RDSS = (LAYER < TF::D3) ? MC::RDSSINNERCUT : MC::RDSSOUTERCUT;
-  readTable_rDSS<RDSS,LAYER,MC::LUT_matchcut_rDSS_width,MC::LUT_matchcut_rDSS_depth>(LUT_matchcut_rDSS);
+  readTable_rDSS<RDSS,MC::LUT_matchcut_rDSS_width,MC::LUT_matchcut_rDSS_depth>(LUT_matchcut_rDSS);
 
   bool goodmatch                   = false;
 
@@ -1160,8 +1055,8 @@ void MatchProcessor(BXType bx,
 #pragma HLS ARRAY_PARTITION variable=table dim=0
   readtable: for(unsigned int iMEU = 0; iMEU < kNMatchEngines; ++iMEU) {
 #pragma HLS unroll
-    readTable<LAYER>(table[iMEU]); 
-  } 
+    readTable<LAYER>(table[iMEU]);
+  }
   //FIXME moved this into main loop - jf
   // initialization:
   // check the number of entries in the input memories
@@ -1255,12 +1150,12 @@ void MatchProcessor(BXType bx,
   constexpr int nRbinBits = VMProjection<VMPTYPE>::kVMProjFineZSize + VMProjectionBase<VMPTYPE>::kVMProjZBinSize;
   ap_uint<nRbinBits> rbinLUT[256];//1<<TrackletProjection<PROJTYPE>::kTProjRZSize];
 #pragma HLS ARRAY_PARTITION variable=rbinLUT
-  readRbin_LUT<LAYER,nRbinBits,256>(rbinLUT);
+  readRbin_LUT<nRbinBits,256>(rbinLUT);
 
   const auto LUT_matchcut_rbend_width = 5;
   const auto LUT_matchcut_rbend_depth = 4096;
   ap_uint<LUT_matchcut_rbend_width> LUT_matchcut_rbend[LUT_matchcut_rbend_depth];
-  readTable_rbend<MC::RBEND,LAYER,LUT_matchcut_rbend_width,LUT_matchcut_rbend_depth>(LUT_matchcut_rbend);
+  readTable_rbend<MC::RBEND,LUT_matchcut_rbend_width,LUT_matchcut_rbend_depth>(LUT_matchcut_rbend);
   // Initialize MC delta phi cut variables
   ap_uint<MC::LUT_matchcut_z_width> best_delta_z;
   ap_uint<MC::LUT_matchcut_phi_width> best_delta_phi;

--- a/emData/generate_IR.py
+++ b/emData/generate_IR.py
@@ -86,9 +86,10 @@ def createParameters(wiresfiles='./LUTs/wires.dat', output_directory='../TopFunc
         file.write('#ifndef TopFunctions_InputRouter_parameters_h\n')
         file.write('#define TopFunctions_InputRouter_parameters_h\n')
         for dtc_name, nmemories in irs:
-            dtcs = {}
-            dtcs['LinkName'] = "DTC_" + dtc_name
-            dtcs['Noutputs'] = str(nmemories)
+            dtcs = {
+                'LinkName' : "DTC_" + dtc_name,
+                'Noutputs' : str(nmemories)
+            }
             with open(template_name, 'r') as ftemp:
                 template_string = ftemp.read()
             file.write(template_string.format(**dtcs))
@@ -105,8 +106,9 @@ def createDeclarations(wiresfiles='./LUTs/wires.dat', output_directory='../TopFu
         file.write('#include \"InputRouter.h\"\n')
         file.write('#include \"InputRouter_parameters.h\"\n')
         for dtc_name, _ in irs:
-            dtcs = {}
-            dtcs['LinkName'] = "DTC_" + dtc_name
+            dtcs = {
+                'LinkName' : "DTC_" + dtc_name
+            }
             with open(template_name, 'r') as ftemp:
                 template_string = ftemp.read()
             file.write(template_string.format(**dtcs))
@@ -120,8 +122,9 @@ def createDefinitions(wiresfiles='./LUTs/wires.dat', output_directory='../TopFun
     with open(output_directory + '/InputRouterTop.cc', 'w') as file:
         file.write('#include \"InputRouterTop.h\"\n')
         for dtc_name, _ in irs:
-            dtcs = {}
-            dtcs['LinkName'] = "DTC_" + dtc_name
+            dtcs = {
+                'LinkName' : "DTC_" + dtc_name
+            }
             with open(template_name, 'r') as ftemp:
                 template_string = ftemp.read()
             file.write(template_string.format(**dtcs))

--- a/emData/generate_MP.py
+++ b/emData/generate_MP.py
@@ -10,39 +10,38 @@ import os
 import re
 import argparse
 
-TF_index = {}
-TF_index['L1L2'] = 0
-TF_index['L2L3'] = 0
-TF_index['L3L4'] = 1
-TF_index['L5L6'] = 0
-TF_index['D1D2'] = 1
-TF_index['D3D4'] = 1
-TF_index['L1D1'] = 1
-TF_index['L2D1'] = 0
-TF_index['AAAA'] = 0
-TF_index['BBBB'] = 1
+TF_index = {
+    'L1L2' : 0,
+    'L2L3' : 0,
+    'L3L4' : 1,
+    'L5L6' : 0,
+    'D1D2' : 1,
+    'D3D4' : 1,
+    'L1D1' : 1,
+    'L2D1' : 0,
+    'AAAA' : 0,
+    'BBBB' : 1
+}
 
 
 maxTPMems = "constexpr int maxTPMemories["
 maxFMMems = "constexpr int maxFMMemories["
 
 def asRegion(region):
-    if region in ['L1', 'L2', 'L3']:
+    if region in {'L1', 'L2', 'L3'}:
         return 'BARRELPS'
-    elif region in ['L4', 'L5', 'L6']:
+    if region in {'L4', 'L5', 'L6'}:
         return 'BARREL2S'
-    elif region in ['D1', 'D2']:
+    if region in {'D1', 'D2'}:
         return 'DISKPS'
-    else:
-        return 'DISK2S'
+    return 'DISK2S'
 
 def vmStubMERegion(region):
-    if region in ['L1', 'L2', 'L3']:
+    if region in {'L1', 'L2', 'L3'}:
         return 'BARRELPS'
-    elif region in ['L4', 'L5', 'L6']:
+    if region in {'L4', 'L5', 'L6'}:
         return 'BARREL2S'
-    else:
-        return 'DISK'
+    return 'DISK'
 
 def getTProjAndVMRegions(module):
 
@@ -50,21 +49,21 @@ def getTProjAndVMRegions(module):
     vmproj_region = ""
     vmstub_region = ""
 
-    if any(psword in module for psword in ["L1","L2","L3"]):
+    if any(psword in module for psword in ("L1","L2","L3")):
         tproj_region = "BARRELPS"
-    elif any(psword in module for psword in ["L4","L5","L6"]):
+    elif any(psword in module for psword in ("L4","L5","L6")):
         tproj_region = "BARREL2S"
     else:
         tproj_region = "DISK"
 
-    if any(psword in module for psword in ["L1","L2","L3","L4","L5","L6"]):
+    if any(psword in module for psword in ("L1","L2","L3","L4","L5","L6")):
         vmproj_region = "BARREL"
     else:
         vmproj_region = "DISK"
 
-    if any(psword in module for psword in ["L1","L2","L3"]):
+    if any(psword in module for psword in ("L1","L2","L3")):
         vmstub_region = "BARRELPS"
-    elif any(psword in module for psword in ["L4","L5","L6"]):
+    elif any(psword in module for psword in ("L4","L5","L6")):
         vmstub_region = "BARREL2S"
     else:
         vmstub_region = "DISK"
@@ -72,10 +71,9 @@ def getTProjAndVMRegions(module):
     return tproj_region, vmproj_region, vmstub_region
 
 def fmRegion(region):
-    if region in ['L1', 'L2', 'L3', 'L4', 'L5', 'L6']:
+    if region in {'L1', 'L2', 'L3', 'L4', 'L5', 'L6'}:
         return 'BARREL'
-    else:
-        return 'DISK'
+    return 'DISK'
 
 parser = argparse.ArgumentParser(description="This script generates MatchCalculatorTop.h, MatchCalculatorTop.cc, and\
 MatchCalculator_parameters.h in the TopFunctions/ directory.",

--- a/emData/generate_PC.py
+++ b/emData/generate_PC.py
@@ -181,7 +181,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "ProjectionCalculator
           "PC_" + seed + iTC + ": ProjectionCalculator<\n"
           "  TF::" + seed + ",\n"
           "  TP::" + iTC[0] + ",\n"
-          "  0x%x, \n  0x%x" %(tprojMaskBarrel, tprojMaskDisk) +\
+          f"  0x{tprojMaskBarrel:x}, \n  0x{tprojMaskDisk:x}"
           " >(\n"
           "    bx,\n"
           "    bx_o,\n"

--- a/emData/generate_TB.py
+++ b/emData/generate_TB.py
@@ -197,7 +197,7 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackBuilderTop.h"),
         # definition of getMPARNPages function
         nParentheses = 0
         first = True
-        maxNPages = max([len(tpar) - len("MPAR_L1L2") for tpar in tparMems[tbName]])
+        maxNPages = max(len(tpar) - len("MPAR_L1L2") for tpar in tparMems[tbName])
         getMPARNPages = "template<> inline int\n"
         getMPARNPages += "getMPARNPages<TF::" + seed + ">(const ITCType &iTC) {\n"
         getMPARNPages += "  return "

--- a/emData/generate_TP.py
+++ b/emData/generate_TP.py
@@ -228,13 +228,13 @@ with open(os.path.join(dirname, arguments.outputDirectory, "TrackletProcessor_pa
             #regLUTSize[seed] = str(sum(1 for _ in open(arguments.LUTsDir+"/TP_{0}{1}_usereg.tab".format(seed,iTC))) - 2)
             #innerPTLUTSize[seed] = str(sum(1 for _ in open(arguments.LUTsDir+"/TP_{0}{1}_stubptinnercut.tab".format(seed,iTC))) - 2)
             #outerPTLUTSize[seed] = str(sum(1 for _ in open(arguments.LUTsDir+"/TP_{0}{1}_stubptoutercut.tab".format(seed,iTC))) - 2)
-            with open(arguments.LUTsDir+"/TP_{0}.tab".format(seed)) as f_tp:
+            with open(arguments.LUTsDir+f"/TP_{seed}.tab") as f_tp:
                 LUTSize[seed] = str(sum(1 for _ in f_tp) - 2)
-            with open(arguments.LUTsDir+"/TP_{0}{1}_usereg.tab".format(seed,iTC)) as f_usereg:
+            with open(arguments.LUTsDir+f"/TP_{seed}{iTC}_usereg.tab") as f_usereg:
                 regLUTSize[seed] = str(sum(1 for _ in f_usereg) - 2)
-            with open(arguments.LUTsDir+"/TP_{0}{1}_stubptinnercut.tab".format(seed,iTC)) as f_stubptinnercut:
+            with open(arguments.LUTsDir+f"/TP_{seed}{iTC}_stubptinnercut.tab") as f_stubptinnercut:
                 innerPTLUTSize[seed] = str(sum(1 for _ in f_stubptinnercut) - 2)
-            with open(arguments.LUTsDir+"/TP_{0}{1}_stubptoutercut.tab".format(seed,iTC)) as f_stubptoutercut:
+            with open(arguments.LUTsDir+f"/TP_{seed}{iTC}_stubptoutercut.tab") as f_stubptoutercut:
                 outerPTLUTSize[seed] = str(sum(1 for _ in f_stubptoutercut) - 2)
         # Print out parameters for this TP.
         parametersFile.write(

--- a/emData/generate_VMRCM.py
+++ b/emData/generate_VMRCM.py
@@ -326,6 +326,9 @@ def writeTopHeader(vmr, output_dir):
     # Top file name
     file_name = "VMRouterCMTop_" + vmr.split("_")[1]
 
+    # Suffix for kNbitsrzbin
+    suffix = "Layer" if layer else "Disk"
+
     with open(output_dir + "/" + file_name  + ".h", "w") as header_file:
 
         # Write preamble
@@ -362,7 +365,7 @@ def writeTopHeader(vmr, output_dir):
             "constexpr int numASInnerCopies = getNumASInnerCopies<layerdisk, phiRegion>(); // Allstub Inner memory\n"
             "constexpr int numTEOCopies = getNumTEOCopies<layerdisk, phiRegion>(); // TE Outer memories\n"
             "// Number of bits for the RZ bins \n"
-            "constexpr int kNbitsrzbinME = kNbitsrzbin%s; // For the VMSME memories\n" % ("MELayer" if layer else "MEDisk") +\
+            f"constexpr int kNbitsrzbinME = kNbitsrzbinME{suffix}; // For the VMSME memories\n" +\
             "\n\n"
         )
 
@@ -371,7 +374,7 @@ def writeTopHeader(vmr, output_dir):
             "/////////////////////////////////////////////////////\n"
             "// VMRouterCM Top Function\n"
             "\n"
-            "void %s(const BXType bx, BXType& bx_o,\n" % file_name +\
+            f"void {file_name}(const BXType bx, BXType& bx_o,\n" +\
             "  // Input memories\n"
             "  const InputStubMemory<inputType> inputStubs[numInputs],\n"
             + ("  const InputStubMemory<DISK2S> inputStubsDisk2S[numInputsDisk2S],\n" if disk else "") +\
@@ -382,7 +385,7 @@ def writeTopHeader(vmr, output_dir):
             + ("  VMStubMemory<outputType, kNbitsrzbin, kNbitsphibin, kNTEUnitsLayerDisk[layerdisk], true> memoriesTEO[numTEOCopies]\n" if has_vmste_outer[layerdisk] else "") +\
             "  );\n"
             "\n"
-            "#endif // TopFunctions_%s_h\n" % file_name
+            f"#endif // TopFunctions_{file_name}_h\n"
         )
 
 # Writes the VMRouterCMTop.cc file
@@ -404,7 +407,7 @@ def writeTopFile(vmr, num_inputs, num_inputs_disk2s, output_dir):
             "// VMRouterCM Top Function\n"
             "// Sort stubs into smaller regions in phi, i.e. Virtual Modules (VMs).\n"
             "\n"
-            "void %s(\n" % file_name +\
+            f"void {file_name}(\n" +\
             "  const BXType bx, BXType& bx_o,\n"
             "  // Input memories\n"
             "  const InputStubMemory<inputType> inputStubs[numInputs],\n"
@@ -421,9 +424,9 @@ def writeTopFile(vmr, num_inputs, num_inputs_disk2s, output_dir):
 
         # Write pragmas
         for i in range(num_inputs):
-            top_file.write("#pragma HLS resource variable=inputStubs[%s].get_mem() latency=2\n" % str(i))
+            top_file.write(f"#pragma HLS resource variable=inputStubs[{str(i)}].get_mem() latency=2\n")
         for i in range(num_inputs_disk2s):
-            top_file.write("#pragma HLS resource variable=inputStubsDisk2S[%s].get_mem() latency=2\n" % str(i))
+            top_file.write(f"#pragma HLS resource variable=inputStubsDisk2S[{str(i)}].get_mem() latency=2\n")
 
         top_file.write(
             "#pragma HLS interface register port=bx_o\n"

--- a/emData/generate_VMSMER.py
+++ b/emData/generate_VMSMER.py
@@ -59,6 +59,9 @@ def writeTopHeader(vmr, noutcopy, output_dir):
     # Top file name
     file_name = "VMStubMERouterTop_" + vmr.split("_")[1]
 
+    # Suffix for kNbitsrzbin
+    suffix = "Layer" if layer else "Disk"
+
     with open(output_dir + "/" + file_name  + ".h", "w") as header_file:
 
         # Write preamble
@@ -89,7 +92,7 @@ def writeTopHeader(vmr, noutcopy, output_dir):
             "constexpr regionType inType = (kDISK ==0) ? getInputType<layerdisk>() : DISKPS;\n"
             "constexpr regionType outType = (kDISK ==0) ? getInputType<layerdisk>() : DISK;\n"
             "// Number of bits for the RZ bins used but VMSMER\n"
-            "constexpr int kNbitsrzbinME = kNbitsrzbin%s; // For the VMSME memories\n" % ("MELayer" if layer else "MEDisk") +\
+            f"constexpr int kNbitsrzbinME = kNbitsrzbinME{suffix}; // For the VMSME memories\n" +\
             "\n\n"
         )
 
@@ -98,7 +101,7 @@ def writeTopHeader(vmr, noutcopy, output_dir):
             "/////////////////////////////////////////////////////\n"
             "// VMStubMERouter Top Function \n"
             "\n"
-            "void %s(const BXType bx, BXType& bx_o,\n" % file_name +\
+            f"void {file_name}(const BXType bx, BXType& bx_o,\n" +\
             "  // Input memories\n"
             "  AllStub<inType>& allStub,\n"
             "  // Output memories\n"
@@ -110,7 +113,7 @@ def writeTopHeader(vmr, noutcopy, output_dir):
             "  bool valid\n"
             "  );\n"
             "\n"
-            "#endif // TopFunctions_%s_h\n" % file_name
+            f"#endif // TopFunctions_{file_name}_h\n"
         )
 
 # Writes the VMRouterCMTop.cc file
@@ -127,7 +130,7 @@ def writeTopFile(vmr, output_dir):
             "// VMStubMERouter Top Function\n"
             "// Sort AllStubs into smaller regions in phi, i.e. Virtual Modules (VMs). By writing VMStubME memories.\n"
             "\n"
-            "void %s(\n" % file_name +\
+            f"void {file_name}(\n" +\
             "  const BXType bx, BXType& bx_o,\n"
             "  // Input memories\n"
             "  AllStub<inType>& allStub,\n"

--- a/project/script_MP.tcl
+++ b/project/script_MP.tcl
@@ -50,16 +50,6 @@ set modules_to_test {
 # test bench; otherwise, the C/RTL cosimulation will fail
 set module_to_export MP_D1PHIC
 
-# create new project (deleting any existing one of same name)
-open_project -reset match_processor
-
-# source files
-set CFLAGS {-std=c++11 -I../TrackletAlgorithm -I../TrackletAlgorithm/TestBench -I../TopFunctions/CombinedConfig_FPGA2}
-add_files ../TopFunctions/CombinedConfig_FPGA2/MatchProcessorTop.cc -cflags "$CFLAGS"
-add_files -tb ../TestBenches/MatchProcessor_test.cpp -cflags "$CFLAGS"
-
-# data files
-add_files -tb ../emData/MP/
 
 foreach i $modules_to_test {
   set layerDisk [string range $i 3 4]
@@ -70,6 +60,17 @@ foreach i $modules_to_test {
   puts [join [list "layerDisk = " $layerDisk] ""]
   puts [join [list "iMP = " $iMP] ""]
   puts [join [list "top function = " $top_func] ""]
+
+  # create new project (deleting any existing one of same name)
+  open_project -reset [join [list "match_processor_" $layerDisk "PHI" $iMP $extra] ""]
+
+  # source files
+  set CFLAGS [join [list "-std=c++11 -I../TrackletAlgorithm -I../TrackletAlgorithm/TestBench -I../TopFunctions/CombinedConfig_FPGA2 -D__" $layerDisk "__"] ""]
+  add_files ../TopFunctions/CombinedConfig_FPGA2/MatchProcessorTop.cc -cflags "$CFLAGS"
+  add_files -tb ../TestBenches/MatchProcessor_test.cpp -cflags "$CFLAGS"
+
+  # data files
+  add_files -tb ../emData/MP/
 
    # set macros for this module in CCFLAG environment variable
   set ::env(CCFLAG) [join [list $::env(CCFLAG_CMSSW) " -D \"MODULE_=" $i "_\" -D \"TOP_FUNC_=" $top_func "\""] ""]

--- a/project/script_PC.tcl
+++ b/project/script_PC.tcl
@@ -37,7 +37,6 @@ add_files ../TopFunctions/CombinedConfig_FPGA2/ProjectionCalculatorTop.cc -cflag
 add_files -tb ../TestBenches/ProjectionCalculator_test.cpp -cflags "$CFLAGS"
 
 # data files
-add_files -tb ../emData/PC/tables/
 add_files -tb ../emData/PC/
 
 foreach i $modules_to_test {


### PR DESCRIPTION
This PR updates our CI to use default runners (for non-Vivado jobs) and CI4FPGA (for Vivado jobs), instead of the runner at CU Boulder that we currently use.

A couple ancillary updates are also included:
- .pylintrc has been updated, and new pylint issues have been fixed.
- The addition of an empty directory in project/script_PC.tcl has been removed. This is needed because the empty directory is not included in artifacts used in the CI.
- The inclusion of lookup tables in the MP is now based on preprocessor directives. This allows the C-simulation and C-synthesis to run significantly faster, as well as use less memory.